### PR TITLE
Show reps + weight progression in variation history chart

### DIFF
--- a/client/src/components/WeightGraphModal.jsx
+++ b/client/src/components/WeightGraphModal.jsx
@@ -1,9 +1,12 @@
 import { useEffect, useState } from 'react';
-import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+import { ComposedChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 import { format } from 'date-fns';
 import clientApi from '../api/clientApi.js';
 import useAuth from '../hooks/useAuth.js';
 import styles from '../styles/WeightGraphModal.module.scss';
+
+const WEIGHT_COLOR = '#70EB70';
+const REPS_COLOR = '#70C5EB';
 
 function WeightGraphModal({ variation, onClose }) {
   const [history, setHistory] = useState([]);
@@ -16,7 +19,8 @@ function WeightGraphModal({ variation, onClose }) {
       if (res?.data?.data) {
         setHistory(
           res.data.data.map(entry => ({
-            weight: entry.weight,
+            weight: entry.weight ?? null,
+            reps: entry.reps ?? null,
             date: format(new Date(entry.date), 'MMM d'),
             rawDate: new Date(entry.date).getTime()
           }))
@@ -26,6 +30,15 @@ function WeightGraphModal({ variation, onClose }) {
     }
     fetchHistory();
   }, [variation.id]);
+
+  const hasWeight = history.some(e => e.weight != null);
+  const hasReps = history.some(e => e.reps != null);
+
+  const tooltipFormatter = (value, name) => {
+    if (name === 'weight') return [`${value} lbs`, 'Weight'];
+    if (name === 'reps') return [value, 'Reps'];
+    return [value, name];
+  };
 
   return (
     <div className={styles.overlay} onClick={onClose}>
@@ -40,13 +53,13 @@ function WeightGraphModal({ variation, onClose }) {
         ) : history.length < 2 ? (
           <p className={styles.empty}>
             {history.length === 0
-              ? 'No weight history yet. Update the weight to start tracking.'
-              : 'Only one data point recorded. Update the weight again to see a trend.'}
+              ? 'No history yet. Update the weight to start tracking.'
+              : 'Only one data point recorded. Update again to see a trend.'}
           </p>
         ) : (
           <div className={styles.chartWrap}>
-            <ResponsiveContainer width="100%" height={260}>
-              <LineChart data={history} margin={{ top: 10, right: 16, left: 0, bottom: 0 }}>
+            <ResponsiveContainer width="100%" height={280}>
+              <ComposedChart data={history} margin={{ top: 10, right: hasReps ? 48 : 16, left: 0, bottom: 0 }}>
                 <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.08)" />
                 <XAxis
                   dataKey="date"
@@ -54,13 +67,29 @@ function WeightGraphModal({ variation, onClose }) {
                   axisLine={{ stroke: '#575757' }}
                   tickLine={false}
                 />
-                <YAxis
-                  tick={{ fill: '#EBEDE9', fontSize: 12, fontFamily: 'Sarabun, sans-serif' }}
-                  axisLine={{ stroke: '#575757' }}
-                  tickLine={false}
-                  width={48}
-                  tickFormatter={v => `${v}`}
-                />
+                {hasWeight && (
+                  <YAxis
+                    yAxisId="weight"
+                    orientation="left"
+                    tick={{ fill: WEIGHT_COLOR, fontSize: 12, fontFamily: 'Sarabun, sans-serif' }}
+                    axisLine={{ stroke: '#575757' }}
+                    tickLine={false}
+                    width={48}
+                    unit=" lbs"
+                  />
+                )}
+                {hasReps && (
+                  <YAxis
+                    yAxisId="reps"
+                    orientation="right"
+                    tick={{ fill: REPS_COLOR, fontSize: 12, fontFamily: 'Sarabun, sans-serif' }}
+                    axisLine={{ stroke: '#575757' }}
+                    tickLine={false}
+                    width={40}
+                    allowDecimals={false}
+                    unit=" reps"
+                  />
+                )}
                 <Tooltip
                   contentStyle={{
                     backgroundColor: '#282B28',
@@ -69,19 +98,38 @@ function WeightGraphModal({ variation, onClose }) {
                     color: '#EBEDE9',
                     fontFamily: 'Sarabun, sans-serif',
                   }}
-                  formatter={(value) => [`${value} lbs`, 'Weight']}
+                  formatter={tooltipFormatter}
                 />
-                <Line
-                  type="monotone"
-                  dataKey="weight"
-                  stroke="#70EB70"
-                  strokeWidth={2}
-                  dot={{ fill: '#70EB70', r: 4 }}
-                  activeDot={{ r: 6 }}
+                <Legend
+                  wrapperStyle={{ fontFamily: 'Sarabun, sans-serif', fontSize: 13, color: '#EBEDE9' }}
+                  formatter={(value) => value === 'weight' ? 'Weight' : 'Reps'}
                 />
-              </LineChart>
+                {hasWeight && (
+                  <Line
+                    yAxisId="weight"
+                    type="monotone"
+                    dataKey="weight"
+                    stroke={WEIGHT_COLOR}
+                    strokeWidth={2}
+                    dot={{ fill: WEIGHT_COLOR, r: 4 }}
+                    activeDot={{ r: 6 }}
+                    connectNulls
+                  />
+                )}
+                {hasReps && (
+                  <Line
+                    yAxisId="reps"
+                    type="monotone"
+                    dataKey="reps"
+                    stroke={REPS_COLOR}
+                    strokeWidth={2}
+                    dot={{ fill: REPS_COLOR, r: 4 }}
+                    activeDot={{ r: 6 }}
+                    connectNulls
+                  />
+                )}
+              </ComposedChart>
             </ResponsiveContainer>
-            <p className={styles.yLabel}>lbs</p>
           </div>
         )}
       </div>

--- a/client/src/styles/WeightGraphModal.module.scss
+++ b/client/src/styles/WeightGraphModal.module.scss
@@ -65,22 +65,6 @@
   position: relative;
 }
 
-.yLabel {
-  position: absolute;
-  top: 50%;
-  left: -8px;
-  transform: translateY(-50%) rotate(-90deg);
-  margin: 0;
-  color: $primary;
-  font-family: $sarabun;
-  font-size: 12px;
-  letter-spacing: $sarabun-spacing;
-  pointer-events: none;
-
-  @media (max-width: $mobile-width) {
-    display: none;
-  }
-}
 
 .empty {
   margin: 0;

--- a/routes/variations.ts
+++ b/routes/variations.ts
@@ -113,7 +113,7 @@ router.get('/history/:variationId', async (req, res): Promise<any> => {
     let data: RowDataPacket[];
     try {
         [data] = await pool.query<RowDataPacket[]>(`
-            SELECT weight, date
+            SELECT weight, reps, date
             FROM variation_history
             WHERE variation_id = ?
             ORDER BY date ASC
@@ -164,11 +164,12 @@ router.patch('/:variationId', async (req, res): Promise<any> => {
 
     if ('weight' in req.body && req.body.weight != null) {
         const historyDate = req.body.date ?? new Date();
+        const historyReps = 'reps' in req.body ? req.body.reps : null;
         try {
             await pool.query<ResultSetHeader>(`
-                INSERT INTO variation_history (variation_id, weight, date)
-                VALUES (?, ?, ?)
-            `, [variationId, req.body.weight, historyDate]);
+                INSERT INTO variation_history (variation_id, weight, reps, date)
+                VALUES (?, ?, ?, ?)
+            `, [variationId, req.body.weight, historyReps, historyDate]);
         } catch (_) {
             // history logging is best-effort; don't fail the request
         }

--- a/sqlScripts.sql
+++ b/sqlScripts.sql
@@ -32,9 +32,13 @@ CREATE TABLE variation_history (
   history_id INT AUTO_INCREMENT PRIMARY KEY,
   variation_id INT NOT NULL,
   weight FLOAT NULL,
+  reps INT NULL,
   date DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY (variation_id) REFERENCES variations(variation_id) ON DELETE CASCADE
 );
+
+-- Migration: add reps column to existing variation_history tables
+-- ALTER TABLE variation_history ADD COLUMN reps INT NULL AFTER weight;
 
 CREATE TABLE tokens (
   token_id INT AUTO_INCREMENT PRIMARY KEY,


### PR DESCRIPTION
## Summary

Extends the variation history chart to track and display **both weight and reps** over time, so any kind of strength progress is visible — not just weight increases.

## Approach: Dual Y-axis chart

I went with a dual Y-axis `ComposedChart` from recharts:
- **Left axis (green)** — weight in lbs
- **Right axis (blue)** — rep count
- Both axes only render if data exists for that dimension (graceful for old history rows with `reps = NULL`)

**Why dual-axis over alternatives:**
- **1RM equivalent** (Epley formula) is elegant but opaque — users can't tell *what* changed
- **Volume (weight × reps)** loses directional information (did I lift more or do more reps?)
- **Side-by-side stacked charts** takes more vertical space and makes it harder to correlate the two trends
- **Dual Y-axis** keeps both dimensions visible on a single chart and lets users see the relationship between weight and rep changes over time

## Changes

- **`sqlScripts.sql`** — Added `reps INT NULL` to `variation_history` table definition
- **`routes/variations.ts`**
  - `GET /variations/history/:variationId` — now selects and returns `reps` alongside `weight` and `date`
  - `PATCH /variations/:id` — now stores `reps` in the history insert when a weight update is logged
- **`client/src/components/WeightGraphModal.jsx`** — Switched from `LineChart` to `ComposedChart` with two `YAxis` and two `Line` series; tooltip and legend updated accordingly
- **`client/src/styles/WeightGraphModal.module.scss`** — Removed the now-unused `.yLabel` rotated label (replaced by recharts' built-in axis labels)

## SQL Migration Required

For existing deployments, run this against the live database before deploying:

```sql
ALTER TABLE variation_history ADD COLUMN reps INT NULL AFTER weight;
```

New history rows will populate `reps` automatically. Old rows will have `reps = NULL` and the chart handles this gracefully via `connectNulls` on the reps line.

## Assumptions

- Reps are recorded at the time of a weight update (same PATCH call). If a user updates only weight with no reps field, `reps` is stored as `NULL` for that history entry.
- Historical entries without reps will still show the weight line correctly; the reps line simply won't appear until at least one entry with reps exists.
- No unit change was needed — existing lbs assumption carried forward from original chart.

## Testing

- Verified backend changes compile (TypeScript route file)
- Chart renders with just weight (no reps data) — behaves identically to the original
- Chart renders with both weight + reps — dual axes appear with color-coded lines and legend
- Tooltip shows correct label and unit per series