### PR TITLE
feat: account menu dropdown + API key management modal

### DIFF
--- a/client/src/components/AccountMenu.jsx
+++ b/client/src/components/AccountMenu.jsx
@@ -1,0 +1,64 @@
+import { useEffect, useRef, useState } from 'react';
+import { logout } from '../api/authApi.js';
+import { useUser } from '../context/UserProvider.jsx';
+import { Profile } from './Icons.jsx';
+import ApiKeyModal from './ApiKeyModal.jsx';
+import styles from '../styles/Header.module.scss';
+
+function AccountMenu() {
+  const { setUser } = useUser();
+  const [open, setOpen] = useState(false);
+  const [showApiKeys, setShowApiKeys] = useState(false);
+  const menuRef = useRef(null);
+
+  useEffect(() => {
+    function handleClickOutside(e) {
+      if (menuRef.current && !menuRef.current.contains(e.target)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  async function handleLogout() {
+    setOpen(false);
+    await logout();
+    setUser(null);
+  }
+
+  function handleApiKeys() {
+    setOpen(false);
+    setShowApiKeys(true);
+  }
+
+  return (
+    <>
+      <div className={styles.accountMenu} ref={menuRef}>
+        <button
+          className={styles.accountBtn}
+          onClick={() => setOpen(o => !o)}
+          aria-label="Account menu"
+          aria-expanded={open}
+        >
+          <Profile className={styles.profileIcon} />
+        </button>
+
+        {open && (
+          <div className={styles.dropdown}>
+            <button className={styles.dropdownItem} onClick={handleApiKeys}>
+              API Keys
+            </button>
+            <button className={`${styles.dropdownItem} ${styles.dropdownItemDanger}`} onClick={handleLogout}>
+              Logout
+            </button>
+          </div>
+        )}
+      </div>
+
+      {showApiKeys && <ApiKeyModal onClose={() => setShowApiKeys(false)} />}
+    </>
+  );
+}
+
+export default AccountMenu;

--- a/client/src/components/ApiKeyModal.jsx
+++ b/client/src/components/ApiKeyModal.jsx
@@ -1,0 +1,107 @@
+import { useEffect, useState } from 'react';
+import { format } from 'date-fns';
+import clientApi from '../api/clientApi.js';
+import useAuth from '../hooks/useAuth.js';
+import styles from '../styles/ApiKeyModal.module.scss';
+
+function ApiKeyModal({ onClose }) {
+  const [keys, setKeys] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [label, setLabel] = useState('');
+  const [generating, setGenerating] = useState(false);
+  const [newKey, setNewKey] = useState(null);
+  const [copied, setCopied] = useState(false);
+  const { withAuth } = useAuth();
+
+  useEffect(() => {
+    fetchKeys();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function fetchKeys() {
+    const res = await withAuth(() => clientApi.get('/api/v1/keys'));
+    if (res?.data?.data) setKeys(res.data.data);
+    setLoading(false);
+  }
+
+  async function handleGenerate(e) {
+    e.preventDefault();
+    if (!label.trim()) return;
+    setGenerating(true);
+    const res = await withAuth(() => clientApi.post('/api/v1/keys', { label: label.trim() }));
+    if (res?.data?.data) {
+      setNewKey(res.data.data.key);
+      setKeys(prev => [{ id: res.data.data.id, label: label.trim(), created_at: new Date().toISOString(), last_used_at: null }, ...prev]);
+      setLabel('');
+    }
+    setGenerating(false);
+  }
+
+  async function handleDelete(id) {
+    await withAuth(() => clientApi.delete(`/api/v1/keys/${id}`));
+    setKeys(prev => prev.filter(k => k.id !== id));
+  }
+
+  async function handleCopy() {
+    await navigator.clipboard.writeText(newKey);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <div className={styles.overlay} onClick={onClose}>
+      <div className={styles.modal} onClick={e => e.stopPropagation()}>
+        <div className={styles.header}>
+          <h2 className={styles.title}>API Keys</h2>
+          <button className={styles.closeBtn} onClick={onClose} aria-label="Close">✕</button>
+        </div>
+
+        {newKey && (
+          <div className={styles.newKeyBox}>
+            <p className={styles.newKeyWarning}>⚠ Copy this key now — it won't be shown again.</p>
+            <div className={styles.newKeyRow}>
+              <code className={styles.newKeyValue}>{newKey}</code>
+              <button className={styles.copyBtn} onClick={handleCopy}>
+                {copied ? 'Copied!' : 'Copy'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        <form className={styles.form} onSubmit={handleGenerate}>
+          <input
+            className={styles.input}
+            type="text"
+            placeholder="Key label (e.g. my-script)"
+            value={label}
+            onChange={e => setLabel(e.target.value)}
+            required
+          />
+          <button className={styles.generateBtn} type="submit" disabled={generating || !label.trim()}>
+            {generating ? 'Generating…' : 'Generate'}
+          </button>
+        </form>
+
+        <div className={styles.keyList}>
+          {loading ? (
+            <p className={styles.empty}>Loading…</p>
+          ) : keys.length === 0 ? (
+            <p className={styles.empty}>No API keys yet.</p>
+          ) : (
+            keys.map(key => (
+              <div key={key.id} className={styles.keyItem}>
+                <div className={styles.keyInfo}>
+                  <span className={styles.keyLabel}>{key.label || <em>unlabeled</em>}</span>
+                  <span className={styles.keyMeta}>Created {format(new Date(key.created_at), 'MMM d, yyyy')}</span>
+                </div>
+                <button className={styles.deleteBtn} onClick={() => handleDelete(key.id)} aria-label="Delete key">✕</button>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ApiKeyModal;

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -1,7 +1,7 @@
 import styles from "../styles/Header.module.scss";
 import { Link } from "react-router-dom";
 import { useUser } from "../context/UserProvider";
-import Logout from "./Logout";
+import AccountMenu from "./AccountMenu";
 
 function Header() {
   const { user } = useUser();
@@ -19,7 +19,7 @@ function Header() {
               <Link to="/sign-in" className={styles.solidButton}>Sign In</Link>
             </>
           )
-          : <Logout />
+          : <AccountMenu />
         }
       </div>
     </header>

--- a/client/src/styles/ApiKeyModal.module.scss
+++ b/client/src/styles/ApiKeyModal.module.scss
@@ -1,0 +1,228 @@
+@import "variables";
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  background-color: $surface;
+  border-radius: $border-radius;
+  padding: 32px 40px;
+  width: 90%;
+  max-width: 520px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.title {
+  margin: 0;
+  color: $text;
+  font-family: $sarabun;
+  font-size: 24px;
+  font-weight: 500;
+  letter-spacing: $sarabun-spacing;
+}
+
+.closeBtn {
+  background: transparent;
+  border: none;
+  color: $text;
+  font-size: 18px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 8px;
+  opacity: 0.6;
+  line-height: 1;
+
+  &:hover {
+    opacity: 1;
+    background-color: $primary-translucent;
+  }
+}
+
+// --- New key reveal box ---
+
+.newKeyBox {
+  background-color: rgba($primary, 0.08);
+  border: 1px solid rgba($primary, 0.3);
+  border-radius: 10px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.newKeyWarning {
+  margin: 0;
+  color: $primary;
+  font-family: $sarabun;
+  font-size: 14px;
+  letter-spacing: $sarabun-spacing;
+}
+
+.newKeyRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.newKeyValue {
+  flex: 1;
+  font-family: 'Courier New', monospace;
+  font-size: 13px;
+  color: $text;
+  background-color: rgba(0, 0, 0, 0.3);
+  border-radius: 6px;
+  padding: 6px 10px;
+  word-break: break-all;
+  overflow-wrap: anywhere;
+}
+
+.copyBtn {
+  flex-shrink: 0;
+  background-color: $primary;
+  color: $background;
+  border: none;
+  border-radius: 8px;
+  padding: 6px 14px;
+  font-family: $sarabun;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  letter-spacing: $sarabun-spacing;
+
+  &:hover {
+    background-color: $primary-dark;
+  }
+}
+
+// --- Generate form ---
+
+.form {
+  display: flex;
+  gap: 10px;
+}
+
+.input {
+  flex: 1;
+  background-color: transparent;
+  color: $text;
+  border: none;
+  border-bottom: 3px solid $primary;
+  padding: 4px 4px;
+  font-family: $sarabun;
+  font-size: 16px;
+  letter-spacing: $sarabun-spacing;
+
+  &:focus {
+    outline: none;
+  }
+
+  &::placeholder {
+    color: rgba($text, 0.4);
+  }
+}
+
+.generateBtn {
+  flex-shrink: 0;
+  background-color: $primary;
+  color: $background;
+  border: none;
+  border-radius: $border-radius;
+  padding: 6px 20px;
+  font-family: $sarabun;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: $sarabun-spacing;
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    background-color: $primary-dark;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+// --- Key list ---
+
+.keyList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.empty {
+  margin: 0;
+  color: $text;
+  font-family: $sarabun;
+  font-size: 15px;
+  opacity: 0.5;
+  letter-spacing: $sarabun-spacing;
+}
+
+.keyItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background-color: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba($surface-border, 0.4);
+}
+
+.keyInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.keyLabel {
+  color: $text;
+  font-family: $sarabun;
+  font-size: 15px;
+  font-weight: 500;
+  letter-spacing: $sarabun-spacing;
+}
+
+.keyMeta {
+  color: rgba($text, 0.5);
+  font-family: $sarabun;
+  font-size: 12px;
+  letter-spacing: $sarabun-spacing;
+}
+
+.deleteBtn {
+  background: transparent;
+  border: none;
+  color: $text;
+  opacity: 0.4;
+  font-size: 14px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 6px;
+  line-height: 1;
+
+  &:hover {
+    opacity: 1;
+    background-color: rgba($error, 0.15);
+    color: $error;
+  }
+}

--- a/client/src/styles/Header.module.scss
+++ b/client/src/styles/Header.module.scss
@@ -65,3 +65,75 @@
     }
   }
 }
+
+// --- Account menu dropdown ---
+
+.accountMenu {
+  position: relative;
+}
+
+.accountBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  background: transparent;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  color: $primary;
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    background-color: rgba($primary, 0.1);
+  }
+}
+
+.profileIcon {
+  width: 24px;
+  height: 24px;
+  color: $primary;
+}
+
+.dropdown {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  background-color: $surface;
+  border: 1px solid $surface-border;
+  border-radius: 10px;
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 140px;
+  z-index: 100;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+.dropdownItem {
+  background: transparent;
+  border: none;
+  color: $text;
+  font-family: $sarabun;
+  font-size: 15px;
+  letter-spacing: $sarabun-spacing;
+  padding: 8px 14px;
+  border-radius: 7px;
+  cursor: pointer;
+  text-align: left;
+  transition: background-color 0.15s ease;
+
+  &:hover {
+    background-color: rgba($primary, 0.12);
+    color: $primary;
+  }
+}
+
+.dropdownItemDanger {
+  &:hover {
+    background-color: rgba($error, 0.12);
+    color: $error;
+  }
+}


### PR DESCRIPTION
## Changes

### Profile dropdown (replaces Logout button)
- Profile icon in the header opens a dropdown with two options: **API Keys** and **Logout**
- Dropdown closes on outside click
- Logout hover → red tint; API Keys hover → green tint

### API Key modal
- Lists all your keys (label + created date + delete button)
- Generate form: type a label → hit Generate → get the raw key displayed once with a Copy button and a warning
- Delete individual keys
- Scrollable if you have many keys

Closes off the loop from the `/api/v1` backend we shipped earlier.