### PR TITLE
feat: add tab navigation to Workouts page for Body Weight

### DIFF
--- a/client/src/components/BodyWeightTracker.jsx
+++ b/client/src/components/BodyWeightTracker.jsx
@@ -4,7 +4,6 @@ import { format } from 'date-fns';
 import clientApi from '../api/clientApi.js';
 import useAuth from '../hooks/useAuth.js';
 import ConfirmModal from './ConfirmModal.jsx';
-import CollapseButton from './CollapseButton.jsx';
 import styles from '../styles/BodyWeightTracker.module.scss';
 
 function BodyWeightTracker() {
@@ -14,7 +13,6 @@ function BodyWeightTracker() {
   const [date, setDate] = useState(() => format(new Date(), 'yyyy-MM-dd'));
   const [submitting, setSubmitting] = useState(false);
   const [deleteId, setDeleteId] = useState(null);
-  const [collapsed, setCollapsed] = useState(false);
   const { withAuth } = useAuth();
 
   useEffect(() => {
@@ -67,12 +65,7 @@ function BodyWeightTracker() {
 
   return (
     <section className={styles.container}>
-      <div className={`${styles.headingRow} ${collapsed ? styles.headingRowCollapsed : ''}`}>
-        <h2 className={styles.heading}>Body Weight</h2>
-        <CollapseButton isOpen={!collapsed} onClick={() => setCollapsed(c => !c)} />
-      </div>
-
-      {!collapsed && <><form className={styles.form} onSubmit={handleSubmit}>
+      <form className={styles.form} onSubmit={handleSubmit}>
         <input
           className={styles.input}
           type="number"
@@ -161,7 +154,6 @@ function BodyWeightTracker() {
           ))}
         </ul>
       )}
-      </>}
 
       {deleteId !== null && (
         <ConfirmModal

--- a/client/src/pages/Workouts.jsx
+++ b/client/src/pages/Workouts.jsx
@@ -7,8 +7,14 @@ import Header from '../components/Header.jsx';
 import clientApi from '../api/clientApi.js';
 import useAuth from '../hooks/useAuth.js';
 
+const TABS = {
+  WORKOUTS: 'workouts',
+  BODY_WEIGHT: 'body-weight',
+};
+
 function Workouts() {
   const [sections, setSections] = useState([]);
+  const [activeTab, setActiveTab] = useState(TABS.WORKOUTS);
   const { withAuth } = useAuth();
 
   useEffect(() => {
@@ -24,17 +30,37 @@ function Workouts() {
     <>
       <Header />
       <main className={styles.container}>
-        <BodyWeightTracker />
-        <div>
-          {sections.map((s) => (
-            <Section
-              key={s.id}
-              section={s}
-              setSections={setSections}
-            />
-          ))}
-        </div>
-        <AddSection setSections={setSections} />
+        <nav className={styles.tabs}>
+          <button
+            className={`${styles.tab} ${activeTab === TABS.WORKOUTS ? styles.tabActive : ''}`}
+            onClick={() => setActiveTab(TABS.WORKOUTS)}
+          >
+            Workouts
+          </button>
+          <button
+            className={`${styles.tab} ${activeTab === TABS.BODY_WEIGHT ? styles.tabActive : ''}`}
+            onClick={() => setActiveTab(TABS.BODY_WEIGHT)}
+          >
+            Body Weight
+          </button>
+        </nav>
+
+        {activeTab === TABS.WORKOUTS && (
+          <div>
+            {sections.map((s) => (
+              <Section
+                key={s.id}
+                section={s}
+                setSections={setSections}
+              />
+            ))}
+            <AddSection setSections={setSections} />
+          </div>
+        )}
+
+        {activeTab === TABS.BODY_WEIGHT && (
+          <BodyWeightTracker />
+        )}
       </main>
     </>
   );

--- a/client/src/styles/BodyWeightTracker.module.scss
+++ b/client/src/styles/BodyWeightTracker.module.scss
@@ -4,56 +4,10 @@
   background-color: $surface;
   border-radius: $border-radius;
   padding: 24px 32px;
-  margin-bottom: 2rem;
 
   @media (max-width: $mobile-width) {
     padding: 20px 16px;
   }
-}
-
-.headingRow {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 20px;
-}
-
-.headingRowCollapsed {
-  margin-bottom: 0;
-}
-
-.heading {
-  margin: 0;
-  color: $text;
-  font-family: $sarabun;
-  font-size: 26px;
-  font-weight: 500;
-  letter-spacing: $sarabun-spacing;
-}
-
-.collapseBtn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  padding: 4px;
-  border-radius: 8px;
-
-  &:hover {
-    background-color: $primary-translucent;
-  }
-}
-
-.chevronOpen {
-  transform: rotate(0deg);
-  transition: transform 0.2s ease;
-}
-
-.chevronClosed {
-  transform: rotate(90deg);
-  transition: transform 0.2s ease;
 }
 
 .form {

--- a/client/src/styles/Workouts.module.scss
+++ b/client/src/styles/Workouts.module.scss
@@ -8,6 +8,43 @@
   }
 }
 
+.tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 1.5rem;
+  border-bottom: 2px solid $surface;
+  padding-bottom: 0;
+}
+
+.tab {
+  background: transparent;
+  border: none;
+  border-bottom: 3px solid transparent;
+  margin-bottom: -2px;
+  padding: 10px 20px;
+  cursor: pointer;
+  color: rgba($text, 0.55);
+  font-family: $sarabun;
+  font-size: 18px;
+  font-weight: 500;
+  letter-spacing: $sarabun-spacing;
+  transition: color 0.15s ease, border-color 0.15s ease;
+
+  &:hover {
+    color: $text;
+  }
+
+  @media (max-width: $mobile-width) {
+    font-size: 16px;
+    padding: 8px 14px;
+  }
+}
+
+.tabActive {
+  color: $primary;
+  border-bottom-color: $primary;
+}
+
 .sectionWrapper {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
Moves the Body Weight Tracker out of the main Workouts list and into its own dedicated tab. The Workouts page now has two tabs — **Workouts** (default) and **Body Weight** — rendered beneath the header before the page content.

## Changes
- `Workouts.jsx`: Added `activeTab` state and a `<nav>` tab bar with two buttons. Sections list + AddSection now render only on the Workouts tab; BodyWeightTracker renders only on the Body Weight tab.
- `Workouts.module.scss`: Added `.tabs`, `.tab`, and `.tabActive` styles — underline-style tabs using `$primary` for the active indicator, matching the existing design system (SCSS variables, Sarabun font, `$text` color, `$border-radius`).
- `BodyWeightTracker.jsx`: Removed `collapsed` state, `CollapseButton` import, and the heading row — no longer needed since the tracker has its own tab.
- `BodyWeightTracker.module.scss`: Removed unused `.headingRow`, `.headingRowCollapsed`, `.heading`, `.collapseBtn`, `.chevronOpen`, `.chevronClosed` styles. Also removed `margin-bottom: 2rem` from `.container` (no longer needed as a stacked element).

## Assumptions
- No assumption needed about which tab should be default — "Workouts" is the natural default since it's the primary content.
- The collapse/expand behavior of BodyWeightTracker is intentionally removed; the tab itself serves as the show/hide mechanism. If a collapsed state is ever desired within the tab, it can be re-added.

## Testing
- Verified JSX structure parses cleanly (no stray fragments or mismatched tags).
- Tab switching logic is simple controlled state — Workouts tab renders sections list, Body Weight tab renders BodyWeightTracker.
- No new dependencies added.