### PR TITLE
fix: move variation date below name to fix rightGroup overflow

### DIFF
--- a/client/src/components/variation/ThinVariation.jsx
+++ b/client/src/components/variation/ThinVariation.jsx
@@ -1,28 +1,28 @@
 import Editable from "../Editable";
 import styles from "../../styles/Variation.module.scss";
 import mobileStyles from "../../styles/ThinVariation.module.scss";
-import { Dumbbell, Number, Delete, Calender, Chart } from "../Icons";
+import { Dumbbell, Number, Delete, Chart } from "../Icons";
 import DateInput from "../DateInput";
 
 function ThinVariation({ variation, details, handleLabelEdit, handleDetailEdit, handleRemove, showRemove, removeAllowed, onGraphOpen }) {
   return (
     <div className={mobileStyles.variation}>
       <section>
-        {/* variation label */}
-        <div className={`${styles.part} ${styles.variationName} ${mobileStyles.variationName}`}>
-          <Editable value={variation.label} onSubmit={handleLabelEdit} />
-        </div>
-
-        {/* date + graph + remove grouped for consistent right-alignment */}
-        <div className={mobileStyles.rightGroup}>
-          <div className={styles.part}>
-            <Calender className={styles.icon} />
+        {/* variation label + date subtext */}
+        <div className={`${styles.nameCell} ${mobileStyles.variationName}`}>
+          <div className={`${styles.part} ${styles.variationName}`}>
+            <Editable value={variation.label} onSubmit={handleLabelEdit} />
+          </div>
+          <div className={styles.dateSubtext}>
             <DateInput
               date={details.date}
               onSubmit={change => handleDetailEdit("date", change)}
             />
           </div>
+        </div>
 
+        {/* graph + remove grouped for consistent right-alignment */}
+        <div className={mobileStyles.rightGroup}>
           <button className={styles.graphBtn} onClick={onGraphOpen}>
             <Chart className={styles.icon} />
           </button>

--- a/client/src/components/variation/WideVariation.jsx
+++ b/client/src/components/variation/WideVariation.jsx
@@ -1,6 +1,6 @@
 import Editable from "../Editable";
 import styles from "../../styles/Variation.module.scss";
-import { Dumbbell, Number, Delete, Calender, Chart } from "../Icons";
+import { Dumbbell, Number, Delete, Chart } from "../Icons";
 import DateInput from "../DateInput";
 
 function WideVariation({ variation, details, handleLabelEdit, handleDetailEdit, handleRemove, showRemove, setShowRemove, removeAllowed, onGraphOpen }) {
@@ -11,9 +11,17 @@ function WideVariation({ variation, details, handleLabelEdit, handleDetailEdit, 
 
   return (
     <>
-      {/* variation label */}
-      <div className={`${styles.part} ${styles.variationName}`} {...hoverProps}>
-        <Editable value={variation.label} onSubmit={handleLabelEdit} />
+      {/* variation label + date subtext */}
+      <div className={styles.nameCell} {...hoverProps}>
+        <div className={`${styles.part} ${styles.variationName}`}>
+          <Editable value={variation.label} onSubmit={handleLabelEdit} />
+        </div>
+        <div className={styles.dateSubtext}>
+          <DateInput
+            date={details.date}
+            onSubmit={change => handleDetailEdit("date", change)}
+          />
+        </div>
       </div>
 
       {/* weight */}
@@ -41,16 +49,8 @@ function WideVariation({ variation, details, handleLabelEdit, handleDetailEdit, 
       {/* whitespace */}
       <div {...hoverProps}></div>
 
-      {/* date + graph + remove grouped for right-alignment */}
+      {/* graph + remove grouped for right-alignment */}
       <div className={styles.rightGroup} {...hoverProps}>
-        <div className={styles.part}>
-          <Calender className={styles.icon} />
-          <DateInput
-            date={details.date}
-            onSubmit={change => handleDetailEdit("date", change)}
-          />
-        </div>
-
         <button className={styles.graphBtn} onClick={onGraphOpen}>
           <Chart className={styles.icon} />
         </button>

--- a/client/src/styles/Variation.module.scss
+++ b/client/src/styles/Variation.module.scss
@@ -42,9 +42,22 @@
   }
 }
 
+.nameCell {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
 .variationName {
   font-style: italic;
   padding-right: 40px;
+}
+
+.dateSubtext {
+  font-size: 14px;
+  opacity: 0.55;
+  padding-left: 2px;
+  margin-top: -2px;
 }
 
 .delete {


### PR DESCRIPTION
## Summary
- Removes the date from `rightGroup` in both `WideVariation.jsx` and `ThinVariation.jsx`
- Displays the date as small muted subtext (14px, 55% opacity) directly below the variation name inside the name cell
- `rightGroup` now contains only: graph button + delete button (or `.noRemove` placeholder)

## Changes
- `WideVariation.jsx`: wrapped name cell in `.nameCell` flex column, moved `DateInput` below name as `.dateSubtext`; removed `Calender` icon import (no longer needed in this component)
- `ThinVariation.jsx`: same pattern — `.nameCell` wraps name + date subtext; `mobileStyles.variationName` (`margin-right: auto`) applied to the `.nameCell` wrapper so rightGroup still aligns right
- `Variation.module.scss`: added `.nameCell` (flex column, align items start) and `.dateSubtext` (font-size 14px, opacity 0.55) classes

## Assumptions
- The date remains fully editable (tapping it still opens the `DateInput` edit mode) — only its visual position and size changed
- The `.noRemove` spacer placeholder in rightGroup is kept so the graph button stays consistently positioned when remove is not allowed
- `padding-right: 40px` on `.variationName` is left as-is (provides horizontal breathing room between name and the next column in the wide grid)

## Testing
- Wide layout (>885px): grid still renders 5 columns; name cell is taller but other cells center their content via flex; rightGroup is now just 2 buttons wide
- Thin/mobile layout (≤885px): first section row has name+date stacked on the left, graph+delete on the right; second section row unchanged (weight + reps)