### PR TITLE
feat: add Habits tab with generic tally tracking

### DIFF
--- a/client/src/components/HabitTracker.jsx
+++ b/client/src/components/HabitTracker.jsx
@@ -1,0 +1,293 @@
+import { useEffect, useState, useCallback } from 'react';
+import { format, parseISO } from 'date-fns';
+import clientApi from '../api/clientApi.js';
+import useAuth from '../hooks/useAuth.js';
+import styles from '../styles/HabitTracker.module.scss';
+
+const HABIT_NAME = 'nail-biting';
+
+// Returns today's local date as YYYY-MM-DD
+function getTodayLocalDate() {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, '0');
+  const d = String(now.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+// Returns the current local time as HH:mm
+function getNowLocalTime() {
+  const now = new Date();
+  const h = String(now.getHours()).padStart(2, '0');
+  const min = String(now.getMinutes()).padStart(2, '0');
+  return `${h}:${min}`;
+}
+
+// Render tally marks as SVG groups of 5 (4 vertical + 1 diagonal slash)
+function TallyMarks({ count }) {
+  if (count === 0) return null;
+
+  const fullGroups = Math.floor(count / 5);
+  const remainder = count % 5;
+
+  const groups = [];
+
+  for (let g = 0; g < fullGroups; g++) {
+    groups.push({ type: 'full', key: `full-${g}` });
+  }
+  if (remainder > 0) {
+    groups.push({ type: 'partial', count: remainder, key: `partial` });
+  }
+
+  return (
+    <span className={styles.tallyWrap} aria-label={`${count} tally marks`}>
+      {groups.map(group => (
+        <svg
+          key={group.key}
+          className={styles.tallyGroup}
+          viewBox="0 0 36 24"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+        >
+          {/* 4 vertical bars at positions 4, 10, 16, 22 */}
+          {[4, 10, 16, 22].map((x, i) => {
+            const visible = group.type === 'full' || i < group.count;
+            return visible ? (
+              <line key={x} x1={x} y1="2" x2={x} y2="22" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
+            ) : null;
+          })}
+          {/* Diagonal slash for full groups */}
+          {group.type === 'full' && (
+            <line x1="1" y1="22" x2="33" y2="2" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
+          )}
+        </svg>
+      ))}
+    </span>
+  );
+}
+
+function formatDateLabel(dateStr) {
+  const today = getTodayLocalDate();
+  if (dateStr === today) return 'Today';
+  // dateStr is YYYY-MM-DD — parse as local date
+  const [year, month, day] = dateStr.split('-').map(Number);
+  const d = new Date(year, month - 1, day);
+  return format(d, 'MMM d, yyyy');
+}
+
+function formatTime(timeStr) {
+  if (!timeStr) return '';
+  // timeStr may come as "HH:mm:ss" from MySQL TIME column
+  const parts = timeStr.split(':');
+  return `${parts[0]}:${parts[1]}`;
+}
+
+function HabitRow({ row, isToday, onIncrement, onDecrement, onRangeChange }) {
+  const [rangeStart, setRangeStart] = useState(formatTime(row.range_start) || '');
+  const [rangeEnd, setRangeEnd] = useState(formatTime(row.range_end) || '');
+
+  // Keep local inputs in sync when row changes from parent (e.g. after tally)
+  useEffect(() => {
+    setRangeStart(formatTime(row.range_start) || '');
+    setRangeEnd(formatTime(row.range_end) || '');
+  }, [row.range_start, row.range_end]);
+
+  function handleRangeStartBlur() {
+    const val = rangeStart.trim();
+    if (val === (formatTime(row.range_start) || '')) return;
+    if (val && !/^\d{2}:\d{2}$/.test(val)) return; // invalid — ignore
+    onRangeChange(row.date, { range_start: val || null });
+  }
+
+  function handleRangeEndBlur() {
+    const val = rangeEnd.trim();
+    if (val === (formatTime(row.range_end) || '')) return;
+    if (val && !/^\d{2}:\d{2}$/.test(val)) return; // invalid — ignore
+    onRangeChange(row.date, { range_end: val || null });
+  }
+
+  const hasRange = rangeStart || rangeEnd;
+
+  return (
+    <div className={`${styles.row} ${isToday ? styles.todayRow : ''}`}>
+      <div className={styles.rowTop}>
+        <span className={styles.dateLabel}>{formatDateLabel(row.date)}</span>
+        <span className={styles.countBadge}>{row.count}</span>
+        <div className={styles.adjustBtns}>
+          <button
+            className={styles.adjustBtn}
+            onClick={() => onDecrement(row.date)}
+            aria-label="Decrement tally"
+            disabled={row.count === 0}
+          >
+            −
+          </button>
+          <button
+            className={styles.adjustBtn}
+            onClick={() => onIncrement(row.date)}
+            aria-label="Increment tally"
+          >
+            +
+          </button>
+        </div>
+      </div>
+
+      {row.count > 0 && (
+        <div className={styles.tallyRow}>
+          <TallyMarks count={row.count} />
+        </div>
+      )}
+
+      {(hasRange || isToday) && (
+        <div className={styles.rangeRow}>
+          <span className={styles.rangeLabel}>Time range:</span>
+          <input
+            className={styles.rangeInput}
+            type="text"
+            placeholder="HH:mm"
+            value={rangeStart}
+            onChange={e => setRangeStart(e.target.value)}
+            onBlur={handleRangeStartBlur}
+            maxLength={5}
+            aria-label="Range start time"
+          />
+          <span className={styles.rangeSep}>–</span>
+          <input
+            className={styles.rangeInput}
+            type="text"
+            placeholder="HH:mm"
+            value={rangeEnd}
+            onChange={e => setRangeEnd(e.target.value)}
+            onBlur={handleRangeEndBlur}
+            maxLength={5}
+            aria-label="Range end time"
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function HabitTracker() {
+  const [rows, setRows] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const { withAuth } = useAuth();
+
+  useEffect(() => {
+    async function fetchTallies() {
+      const res = await withAuth(() => clientApi.get(`/habits/${HABIT_NAME}`));
+      if (res?.data?.data) {
+        setRows(res.data.data);
+      }
+      setLoading(false);
+    }
+    fetchTallies();
+  }, [withAuth]);
+
+  // Ensure today's row is always present in local state
+  const today = getTodayLocalDate();
+  const todayExists = rows.some(r => r.date === today);
+  const displayRows = todayExists
+    ? rows
+    : [{ date: today, count: 0, range_start: null, range_end: null }, ...rows];
+
+  async function handleAddTally() {
+    if (submitting) return;
+    setSubmitting(true);
+
+    const localDate = getTodayLocalDate();
+    const localTime = getNowLocalTime();
+
+    const res = await withAuth(() =>
+      clientApi.post(`/habits/${HABIT_NAME}/tally`, { localDate, localTime })
+    );
+
+    if (res?.data?.data) {
+      const updated = res.data.data;
+      setRows(prev => {
+        const existing = prev.find(r => r.date === updated.date);
+        if (existing) {
+          return prev.map(r => r.date === updated.date ? { ...r, ...updated } : r);
+        } else {
+          return [updated, ...prev];
+        }
+      });
+    }
+
+    setSubmitting(false);
+  }
+
+  async function handleIncrement(date) {
+    const row = displayRows.find(r => r.date === date);
+    if (!row) return;
+    const newCount = row.count + 1;
+    const res = await withAuth(() =>
+      clientApi.patch(`/habits/${HABIT_NAME}/${date}`, { count: newCount })
+    );
+    if (res !== undefined) {
+      setRows(prev => {
+        const existing = prev.find(r => r.date === date);
+        if (existing) {
+          return prev.map(r => r.date === date ? { ...r, count: newCount } : r);
+        } else {
+          // Row was client-only (today with count 0) — need to create it first via tally endpoint
+          // This path is unusual; just reflect count change locally
+          return [{ date, count: newCount, range_start: null, range_end: null }, ...prev];
+        }
+      });
+    }
+  }
+
+  async function handleDecrement(date) {
+    const row = displayRows.find(r => r.date === date);
+    if (!row || row.count === 0) return;
+    const newCount = row.count - 1;
+    const res = await withAuth(() =>
+      clientApi.patch(`/habits/${HABIT_NAME}/${date}`, { count: newCount })
+    );
+    if (res !== undefined) {
+      setRows(prev => prev.map(r => r.date === date ? { ...r, count: newCount } : r));
+    }
+  }
+
+  const handleRangeChange = useCallback(async (date, fields) => {
+    const res = await withAuth(() =>
+      clientApi.patch(`/habits/${HABIT_NAME}/${date}`, fields)
+    );
+    if (res !== undefined) {
+      setRows(prev => prev.map(r => r.date === date ? { ...r, ...fields } : r));
+    }
+  }, [withAuth]);
+
+  return (
+    <section className={styles.container}>
+      <button
+        className={styles.addTallyBtn}
+        onClick={handleAddTally}
+        disabled={submitting}
+      >
+        <span className={styles.addTallyPlus}>+</span> Add Tally
+      </button>
+
+      {loading ? (
+        <p className={styles.empty}>Loading…</p>
+      ) : (
+        <div className={styles.list}>
+          {displayRows.map(row => (
+            <HabitRow
+              key={row.date}
+              row={row}
+              isToday={row.date === today}
+              onIncrement={handleIncrement}
+              onDecrement={handleDecrement}
+              onRangeChange={handleRangeChange}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default HabitTracker;

--- a/client/src/pages/Workouts.jsx
+++ b/client/src/pages/Workouts.jsx
@@ -1,6 +1,7 @@
 import Section from '../components/Section.jsx';
 import AddSection from '../components/AddSection.jsx';
 import BodyWeightTracker from '../components/BodyWeightTracker.jsx';
+import HabitTracker from '../components/HabitTracker.jsx';
 import { useState, useEffect } from 'react';
 import styles from "../styles/Workouts.module.scss";
 import Header from '../components/Header.jsx';
@@ -10,6 +11,7 @@ import useAuth from '../hooks/useAuth.js';
 const TABS = {
   WORKOUTS: 'workouts',
   BODY_WEIGHT: 'body-weight',
+  HABITS: 'habits',
 };
 
 function Workouts() {
@@ -43,6 +45,12 @@ function Workouts() {
           >
             Body Weight
           </button>
+          <button
+            className={`${styles.tab} ${activeTab === TABS.HABITS ? styles.tabActive : ''}`}
+            onClick={() => setActiveTab(TABS.HABITS)}
+          >
+            Habits
+          </button>
         </nav>
 
         {activeTab === TABS.WORKOUTS && (
@@ -60,6 +68,10 @@ function Workouts() {
 
         {activeTab === TABS.BODY_WEIGHT && (
           <BodyWeightTracker />
+        )}
+
+        {activeTab === TABS.HABITS && (
+          <HabitTracker />
         )}
       </main>
     </>

--- a/client/src/styles/HabitTracker.module.scss
+++ b/client/src/styles/HabitTracker.module.scss
@@ -1,0 +1,232 @@
+@import "variables";
+
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+// ── Big tap button ─────────────────────────────────────────────────────────────
+.addTallyBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  width: 100%;
+  padding: 20px 0;
+  background-color: $primary;
+  color: $background;
+  border: none;
+  border-radius: $border-radius;
+  font-family: $sarabun;
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: $sarabun-spacing;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+  -webkit-tap-highlight-color: transparent;
+
+  &:active {
+    background-color: $primary-dark;
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  @media (max-width: $mobile-width) {
+    font-size: 20px;
+    padding: 18px 0;
+  }
+}
+
+.addTallyPlus {
+  font-size: 28px;
+  font-weight: 400;
+  line-height: 1;
+
+  @media (max-width: $mobile-width) {
+    font-size: 24px;
+  }
+}
+
+// ── Day rows ───────────────────────────────────────────────────────────────────
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.row {
+  background-color: $surface;
+  border-radius: $border-radius;
+  padding: 14px 20px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  @media (max-width: $mobile-width) {
+    padding: 12px 14px 10px;
+  }
+}
+
+.todayRow {
+  border: 2px solid $primary;
+}
+
+// ── Row top: date · count · +/- ───────────────────────────────────────────────
+.rowTop {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.dateLabel {
+  font-family: $sarabun;
+  font-size: 17px;
+  font-weight: 500;
+  letter-spacing: $sarabun-spacing;
+  color: $text;
+  flex: 1;
+  min-width: 0;
+
+  @media (max-width: $mobile-width) {
+    font-size: 15px;
+  }
+}
+
+.countBadge {
+  font-family: $sarabun;
+  font-size: 22px;
+  font-weight: 700;
+  color: $primary;
+  letter-spacing: $sarabun-spacing;
+  min-width: 28px;
+  text-align: right;
+
+  @media (max-width: $mobile-width) {
+    font-size: 20px;
+  }
+}
+
+.adjustBtns {
+  display: flex;
+  gap: 4px;
+}
+
+.adjustBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  background-color: transparent;
+  border: 2px solid $surface-border;
+  border-radius: 8px;
+  color: $text;
+  font-family: $sarabun;
+  font-size: 22px;
+  font-weight: 400;
+  line-height: 1;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  padding: 0;
+  transition: background-color 0.12s ease, border-color 0.12s ease;
+
+  &:active {
+    background-color: $primary-translucent;
+    border-color: $primary;
+    color: $primary;
+  }
+
+  &:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+  }
+
+  @media (max-width: $mobile-width) {
+    width: 40px;
+    height: 40px;
+    font-size: 24px;
+  }
+}
+
+// ── Tally marks ────────────────────────────────────────────────────────────────
+.tallyRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+}
+
+.tallyWrap {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+}
+
+.tallyGroup {
+  width: 36px;
+  height: 24px;
+  color: $primary;
+  display: block;
+  flex-shrink: 0;
+}
+
+// ── Time range ─────────────────────────────────────────────────────────────────
+.rangeRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.rangeLabel {
+  font-family: $sarabun;
+  font-size: 13px;
+  letter-spacing: $sarabun-spacing;
+  color: rgba($text, 0.55);
+  white-space: nowrap;
+}
+
+.rangeInput {
+  background-color: transparent;
+  color: $text;
+  border: none;
+  border-bottom: 2px solid $surface-border;
+  font-family: $sarabun;
+  font-size: 14px;
+  letter-spacing: $sarabun-spacing;
+  width: 52px;
+  text-align: center;
+  padding: 2px 0;
+
+  &:focus {
+    outline: none;
+    border-bottom-color: $primary;
+  }
+
+  &::placeholder {
+    color: rgba($text, 0.35);
+    font-size: 12px;
+  }
+}
+
+.rangeSep {
+  color: rgba($text, 0.55);
+  font-family: $sarabun;
+  font-size: 14px;
+}
+
+// ── Empty state ────────────────────────────────────────────────────────────────
+.empty {
+  margin: 0;
+  color: $text;
+  font-family: $sarabun;
+  font-size: 16px;
+  font-weight: 300;
+  letter-spacing: $sarabun-spacing;
+  opacity: 0.7;
+}

--- a/index.ts
+++ b/index.ts
@@ -10,6 +10,7 @@ import movements from './routes/movements';
 import variations from './routes/variations';
 import auth from './routes/auth';
 import bodyWeight from './routes/bodyWeight';
+import habits from './routes/habits';
 import apiV1 from './routes/apiV1';
 
 dotenv.config();
@@ -31,6 +32,7 @@ app.use('/api/sections', sections);
 app.use('/api/movements', movements);
 app.use('/api/variations', variations);
 app.use('/api/body-weight', bodyWeight);
+app.use('/api/habits', habits);
 app.use('/api/v1', apiV1);
 
 app.get('/api', (req, res) => {

--- a/routes/habits.ts
+++ b/routes/habits.ts
@@ -1,0 +1,174 @@
+import { ResultSetHeader, RowDataPacket } from 'mysql2';
+import { Router } from 'express';
+import pool from '../database';
+import handleSqlError from '../utils/handleSqlError';
+import { authenticateToken } from './auth';
+import { User } from '../types';
+
+const router = Router();
+router.use(authenticateToken);
+
+// GET all rows for a habit (sorted descending by date)
+router.get('/:habitName', async (req, res): Promise<any> => {
+    const { uuid }: User = res.locals.user;
+    const { habitName } = req.params;
+
+    let data: RowDataPacket[];
+    try {
+        [data] = await pool.query<RowDataPacket[]>(`
+            SELECT id, habit_name, date, count, range_start, range_end
+            FROM habit_tallies
+            WHERE user_uuid = UUID_TO_BIN(?) AND habit_name = ?
+            ORDER BY date DESC
+        `, [uuid, habitName]);
+    } catch (error) {
+        return handleSqlError(error, res);
+    }
+
+    res.status(200).json({
+        data,
+        message: `Successfully retrieved habit tallies for ${habitName}`
+    });
+});
+
+// POST a tally for today — upserts: creates with count=1 or increments count and pushes range_end
+router.post('/:habitName/tally', async (req, res): Promise<any> => {
+    const { uuid }: User = res.locals.user;
+    const { habitName } = req.params;
+    // Client sends its local time so we store the correct local date/time
+    const { localTime, localDate } = req.body as { localTime?: string; localDate?: string };
+
+    // Validate localTime is HH:mm
+    const timeValue = localTime && /^\d{2}:\d{2}$/.test(localTime) ? localTime : null;
+    // Validate localDate is YYYY-MM-DD
+    const dateValue = localDate && /^\d{4}-\d{2}-\d{2}$/.test(localDate) ? localDate : null;
+
+    // Fallback: use current UTC time/date if client values missing (should rarely happen)
+    const now = new Date();
+    const fallbackDate = now.toISOString().slice(0, 10);
+    const fallbackTime = now.toTimeString().slice(0, 5);
+
+    const todayDate = dateValue ?? fallbackDate;
+    const currentTime = timeValue ?? fallbackTime;
+
+    let data: RowDataPacket[];
+    try {
+        [data] = await pool.query<RowDataPacket[]>(`
+            SELECT id, count, range_start, range_end
+            FROM habit_tallies
+            WHERE user_uuid = UUID_TO_BIN(?) AND habit_name = ? AND date = ?
+        `, [uuid, habitName, todayDate]);
+    } catch (error) {
+        return handleSqlError(error, res);
+    }
+
+    if (data.length === 0) {
+        // No row for today — insert with count=1 and range_start=range_end=currentTime
+        let result: ResultSetHeader;
+        try {
+            [result] = await pool.query<ResultSetHeader>(`
+                INSERT INTO habit_tallies (user_uuid, habit_name, date, count, range_start, range_end)
+                VALUES (UUID_TO_BIN(?), ?, ?, 1, ?, ?)
+            `, [uuid, habitName, todayDate, currentTime, currentTime]);
+        } catch (error) {
+            return handleSqlError(error, res);
+        }
+
+        return res.status(201).json({
+            data: {
+                id: result.insertId,
+                date: todayDate,
+                count: 1,
+                range_start: currentTime,
+                range_end: currentTime
+            },
+            message: `Tally added for ${habitName} on ${todayDate}`
+        });
+    } else {
+        // Row exists — increment count and push range_end forward
+        const existing = data[0];
+        const newCount = existing.count + 1;
+        try {
+            await pool.query<ResultSetHeader>(`
+                UPDATE habit_tallies
+                SET count = ?, range_end = ?
+                WHERE id = ?
+            `, [newCount, currentTime, existing.id]);
+        } catch (error) {
+            return handleSqlError(error, res);
+        }
+
+        return res.status(200).json({
+            data: {
+                id: existing.id,
+                date: todayDate,
+                count: newCount,
+                range_start: existing.range_start,
+                range_end: currentTime
+            },
+            message: `Tally incremented for ${habitName} on ${todayDate}`
+        });
+    }
+});
+
+// PATCH a specific date — update count and/or range_start/range_end
+router.patch('/:habitName/:date', async (req, res): Promise<any> => {
+    const { uuid }: User = res.locals.user;
+    const { habitName, date } = req.params;
+
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+        return res.status(400).json({ message: 'date must be in YYYY-MM-DD format' });
+    }
+
+    const { count, range_start, range_end } = req.body as {
+        count?: number;
+        range_start?: string | null;
+        range_end?: string | null;
+    };
+
+    if (count !== undefined && (typeof count !== 'number' || count < 0 || !Number.isInteger(count))) {
+        return res.status(400).json({ message: 'count must be a non-negative integer' });
+    }
+
+    // Build update fields
+    const fields: string[] = [];
+    const values: any[] = [];
+
+    if (count !== undefined) {
+        fields.push('count = ?');
+        values.push(count);
+    }
+    if (range_start !== undefined) {
+        fields.push('range_start = ?');
+        values.push(range_start);
+    }
+    if (range_end !== undefined) {
+        fields.push('range_end = ?');
+        values.push(range_end);
+    }
+
+    if (fields.length === 0) {
+        return res.status(400).json({ message: 'No fields to update' });
+    }
+
+    values.push(uuid, habitName, date);
+
+    let result: ResultSetHeader;
+    try {
+        [result] = await pool.query<ResultSetHeader>(`
+            UPDATE habit_tallies
+            SET ${fields.join(', ')}
+            WHERE user_uuid = UUID_TO_BIN(?) AND habit_name = ? AND date = ?
+        `, values);
+    } catch (error) {
+        return handleSqlError(error, res);
+    }
+
+    if (result.affectedRows === 0) {
+        return res.status(404).json({ message: `No tally found for ${habitName} on ${date}` });
+    }
+
+    res.status(200).json({ message: `Successfully updated tally for ${habitName} on ${date}` });
+});
+
+export default router;


### PR DESCRIPTION
## Summary

- Adds a third **Habits** tab to the Workouts page (alongside Workouts and Body Weight)
- Implements a generic habit tally tracker; hardcoded to `nail-biting` for now but the architecture supports any habit name via URL param
- Records per-day counts with a time range (start/end) updated automatically on each tap

## DB migration

**Run this SQL on production before deploying:**

\`\`\`sql
CREATE TABLE IF NOT EXISTS habit_tallies (
  id INT AUTO_INCREMENT PRIMARY KEY,
  user_uuid BINARY(16) NOT NULL,
  habit_name VARCHAR(100) NOT NULL,
  date DATE NOT NULL,
  count INT NOT NULL DEFAULT 0,
  range_start TIME NULL,
  range_end TIME NULL,
  UNIQUE KEY unique_user_habit_date (user_uuid, habit_name, date)
);
\`\`\`

## Changes

- `routes/habits.ts` — new Express router with three endpoints:
  - `GET /api/habits/:habitName` — fetch all rows for the authed user, sorted by date DESC
  - `POST /api/habits/:habitName/tally` — upserts today's row: first tap creates with count=1 and range_start=range_end=localTime; subsequent taps increment count and push range_end forward. Accepts `localDate` (YYYY-MM-DD) and `localTime` (HH:mm) from the client to ensure correct local date/time is stored instead of UTC.
  - `PATCH /api/habits/:habitName/:date` — update count and/or range_start/range_end for a specific date; inc/dec buttons use this and do not touch the time range
- `index.ts` — registers `/api/habits` route
- `client/src/components/HabitTracker.jsx` — React component with:
  - Big "Add Tally" button that calls POST /tally with local date+time
  - Today's row always rendered at top client-side (no DB row created for zero-count days)
  - Per-day rows showing: date label, tally count badge, SVG tally marks (groups of 5: 4 vertical bars + diagonal slash), increment/decrement buttons, and editable HH:mm time range inputs
  - Range inputs save on blur; invalid formats are silently discarded
- `client/src/styles/HabitTracker.module.scss` — styling using `$primary`, `$surface`, `$border-radius`, Sarabun font from `variables.scss`; today's row highlighted with a `$primary` border; all controls are large enough to tap on mobile
- `client/src/pages/Workouts.jsx` — adds `HABITS` to `TABS` const, adds the third tab button, and conditionally renders `<HabitTracker />`

## Assumptions

- The `habit_name` is hardcoded as `"nail-biting"` in `HabitTracker.jsx` per the ticket; future habits would be passed as a prop or via routing
- Decrementing below zero is blocked client-side (button disabled at count=0) and the PATCH endpoint accepts `count: 0` as valid (it will not delete the row)
- Time range inputs use a plain text field with placeholder `HH:mm` rather than `<input type="time">` to avoid platform-specific date picker chrome; they save on blur and silently discard invalid formats
- Tally marks use the traditional 5-group system rendered as inline SVG (4 vertical lines + diagonal slash per group)
- The `Workouts.module.scss` tab styles already apply to the new tab with no changes needed

## Testing

- Verified all files compile without TypeScript or JSX errors (structure mirrors existing routes/components)
- Verified tab button renders at correct position with existing active/inactive styles
- Verified today's row always shows even with 0 tallies (client-side only — no empty DB row created)