### PR TITLE
fix: docker-compose init from migrations/ dir, add .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Local development environment variables (used when JAWSDB_URL is not set)
+# Copy this file to .env and fill in values for local dev with docker-compose.
+# Do NOT commit .env — it is in .gitignore.
+
+DB_HOST=127.0.0.1
+DB_USERNAME=dev
+DB_PASSWORD=dev
+DB_NAME=workout_log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - "3306:3306"
     volumes:
       - db_data:/var/lib/mysql
-      - ./sqlScripts.sql:/docker-entrypoint-initdb.d/init.sql
+      - ./migrations:/docker-entrypoint-initdb.d
 
 volumes:
   db_data:


### PR DESCRIPTION
## Summary
- Fixes local Docker MySQL init to use all numbered migration files instead of the stale `sqlScripts.sql`, so fresh containers get `habit_tallies` and all other newer tables
- Adds `.env.example` documenting the local dev env vars for connecting to the Docker MySQL container

## Changes
- **docker-compose.yml**: replaced `./sqlScripts.sql:/docker-entrypoint-initdb.d/init.sql` volume mount with `./migrations:/docker-entrypoint-initdb.d` — MySQL's entrypoint runs all `.sql` files in the mounted directory in alphabetical order, so all 5 migrations (001–005) run on first container startup
- **`.env.example`**: new file documenting `DB_HOST`, `DB_USERNAME`, `DB_PASSWORD`, `DB_NAME` values for local dev; matches the credentials in `docker-compose.yml`

## Assumptions
- `sqlScripts.sql` intentionally left in the repo as historical reference (not deleted), per the ticket notes
- `.env` was already in `.gitignore` (line 16: `/.env`) — no change needed

## Testing
- Verified the migrations directory contains 001–005 SQL files that cover all tables (initial schema, body_weight, api_keys, variation_history reps, habit_tallies)
- To test: `docker-compose down -v && docker-compose up -d` on a clean slate — all tables should be present after init