### PR TITLE
add $primary-border muted green for borders

### DIFF
--- a/client/src/styles/ApiKeyModal.module.scss
+++ b/client/src/styles/ApiKeyModal.module.scss
@@ -59,7 +59,7 @@
 
 .newKeyBox {
   background-color: rgba($primary, 0.08);
-  border: 1px solid rgba($primary, 0.3);
+  border: 1px solid rgba($primary-border, 0.5);
   border-radius: 10px;
   padding: 16px;
   display: flex;
@@ -123,7 +123,7 @@
   background-color: transparent;
   color: $text;
   border: none;
-  border-bottom: 3px solid $primary;
+  border-bottom: 3px solid $primary-border;
   padding: 4px 4px;
   font-family: $sarabun;
   font-size: 16px;

--- a/client/src/styles/Authentication.module.scss
+++ b/client/src/styles/Authentication.module.scss
@@ -46,7 +46,7 @@
                     border: solid 1px $surface-border;
 
                     &:focus {
-                        outline: solid 1px $primary
+                        outline: solid 1px $primary-border
                     }
                 }
 

--- a/client/src/styles/BodyWeightTracker.module.scss
+++ b/client/src/styles/BodyWeightTracker.module.scss
@@ -21,7 +21,7 @@
   background-color: transparent;
   color: $text;
   border: none;
-  border-bottom: solid 3px $primary;
+  border-bottom: solid 3px $primary-border;
   padding: 4px 4px;
   font-family: $sarabun;
   font-size: 16px;

--- a/client/src/styles/DateInput.module.scss
+++ b/client/src/styles/DateInput.module.scss
@@ -11,7 +11,7 @@
         }
 
         &:focus {
-            border-bottom: solid 3px $primary !important;
+            border-bottom: solid 3px $primary-border !important;
         }
     }
 

--- a/client/src/styles/HabitTracker.module.scss
+++ b/client/src/styles/HabitTracker.module.scss
@@ -72,7 +72,7 @@
 }
 
 .todayRow {
-  border: 2px solid $primary;
+  border: 2px solid $primary-border;
 }
 
 // ── Row top: date · count · +/- ───────────────────────────────────────────────
@@ -136,7 +136,7 @@
 
   &:active {
     background-color: $primary-translucent;
-    border-color: $primary;
+    border-color: $primary-border;
     color: $primary;
   }
 
@@ -205,7 +205,7 @@
 
   &:focus {
     outline: none;
-    border-bottom-color: $primary;
+    border-bottom-color: $primary-border;
   }
 
   &::placeholder {

--- a/client/src/styles/Header.module.scss
+++ b/client/src/styles/Header.module.scss
@@ -8,7 +8,7 @@
   width: 100%;
   height: 8vh;
   padding: 2rem 2.5rem;
-  border-bottom: 5px solid $primary;
+  border-bottom: 5px solid $primary-border;
 
   > a {
     text-decoration: none;

--- a/client/src/styles/Movement.module.scss
+++ b/client/src/styles/Movement.module.scss
@@ -65,7 +65,7 @@
   background-color: transparent;
   color: $text;
   border: none;
-  border-bottom: solid 3px $primary;
+  border-bottom: solid 3px $primary-border;
   letter-spacing: $sarabun-spacing;
   font: {
     family: "Sarabun", sans-serif;

--- a/client/src/styles/Variation.module.scss
+++ b/client/src/styles/Variation.module.scss
@@ -19,7 +19,7 @@
     background-color: transparent;
     color: $text;
     border: none;
-    border-bottom: solid 3px $primary;
+    border-bottom: solid 3px $primary-border;
 
     &:focus {
       outline: none;

--- a/client/src/styles/Workouts.module.scss
+++ b/client/src/styles/Workouts.module.scss
@@ -42,7 +42,7 @@
 
 .tabActive {
   color: $primary;
-  border-bottom-color: $primary;
+  border-bottom-color: $primary-border;
 }
 
 .sectionWrapper {
@@ -98,7 +98,7 @@
     background-color: transparent;
     color: $text;
     border: none;
-    border-bottom: solid 3px $primary;
+    border-bottom: solid 3px $primary-border;
     letter-spacing: $sarabun-spacing;
 
     &:focus {

--- a/client/src/styles/variables.scss
+++ b/client/src/styles/variables.scss
@@ -2,6 +2,7 @@ $background: #151515;
 $primary: #70EB70;
 $primary-translucent: rgba($primary, 0.2);
 $primary-dark: #62CF62;
+$primary-border: #4CAF4C;
 $button-hover: rgba($primary, 0.8);
 $surface: #282B28;
 $surface-border: #575757;


### PR DESCRIPTION
## Summary
Adds a new CSS variable `$primary-border` (#4CAF4C — muted green) to `variables.scss` and switches every border/outline that previously used `$primary` (#70EB70, the bright lime green) to use the new variable instead. Non-border usages of `$primary` (backgrounds, text colors, icon colors, hover fill, translucent overlays) are unchanged.

## Changes
- `variables.scss`: new `$primary-border: #4CAF4C` between `$primary-dark` and `$button-hover`
- `Header.module.scss`: header bottom border
- `HabitTracker.module.scss`: today-row border, adjustBtn active border-color, rangeInput focus border-bottom-color
- `BodyWeightTracker.module.scss`: weight input border-bottom
- `DateInput.module.scss`: date input focus border-bottom
- `Movement.module.scss`: section label input border-bottom
- `ApiKeyModal.module.scss`: new-key reveal box border (adjusted opacity from 0.3→0.5 to compensate for the darker base color), API key name input border-bottom
- `Workouts.module.scss`: active tab underline border, section label input border-bottom
- `Variation.module.scss`: variation field input border-bottom
- `Authentication.module.scss`: login/register input focus outline

## Assumptions
- "light primary green used as a border" refers to the single `$primary` variable (#70EB70) — there was no separate "light" variant; `$primary` is the brightest green in the palette
- The `rgba($primary, 0.3)` translucent border on the API key reveal box is counted as a border usage and converted to `rgba($primary-border, 0.5)` (opacity bumped slightly to preserve visual weight since #4CAF4C is darker than #70EB70)
- The `outline` on the authentication input focus state is treated as a border usage (same visual intent)

## Testing
- Verified all border/outline usages of `$primary` across all SCSS modules are now `$primary-border`
- Verified non-border usages (backgrounds, colors, fills) remain as `$primary`