### PR TITLE
seed dev user and fix habit tally +/- centering

### DIFF
--- a/client/src/components/HabitTracker.jsx
+++ b/client/src/components/HabitTracker.jsx
@@ -120,14 +120,14 @@ function HabitRow({ row, isToday, onIncrement, onDecrement, onRangeChange }) {
             aria-label="Decrement tally"
             disabled={row.count === 0}
           >
-            −
+            <span className={styles.adjustBtnIcon}>−</span>
           </button>
           <button
             className={styles.adjustBtn}
             onClick={() => onIncrement(row.date)}
             aria-label="Increment tally"
           >
-            +
+            <span className={styles.adjustBtnIcon}>+</span>
           </button>
         </div>
       </div>

--- a/client/src/styles/HabitTracker.module.scss
+++ b/client/src/styles/HabitTracker.module.scss
@@ -128,7 +128,6 @@
   font-family: $sarabun;
   font-size: 22px;
   font-weight: 400;
-  line-height: 1;
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
   padding: 0;
@@ -150,6 +149,11 @@
     height: 40px;
     font-size: 24px;
   }
+}
+
+.adjustBtnIcon {
+  display: block;
+  line-height: 1;
 }
 
 // ── Tally marks ────────────────────────────────────────────────────────────────

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,12 @@ services:
       - "3306:3306"
     volumes:
       - db_data:/var/lib/mysql
-      - ./migrations:/docker-entrypoint-initdb.d
+      - ./migrations/001_initial_schema.sql:/docker-entrypoint-initdb.d/001_initial_schema.sql
+      - ./migrations/002_body_weight.sql:/docker-entrypoint-initdb.d/002_body_weight.sql
+      - ./migrations/003_api_keys.sql:/docker-entrypoint-initdb.d/003_api_keys.sql
+      - ./migrations/004_variation_history_reps.sql:/docker-entrypoint-initdb.d/004_variation_history_reps.sql
+      - ./migrations/005_habit_tallies.sql:/docker-entrypoint-initdb.d/005_habit_tallies.sql
+      - ./seeds/dev_user.sql:/docker-entrypoint-initdb.d/zzz_dev_user.sql
 
 volumes:
   db_data:

--- a/seeds/dev_user.sql
+++ b/seeds/dev_user.sql
@@ -1,0 +1,3 @@
+-- Dev user seed: dev@dev.com / dev (bcrypt cost 10)
+INSERT IGNORE INTO users (user_uuid, email, `password`)
+VALUES (UUID_TO_BIN(UUID()), 'dev@dev.com', '$2b$10$qwCxH0klBbY/lgiAqNhQ6uk7tdG7SkdczY12gQL2.TXkwU2iHqR.S');


### PR DESCRIPTION
## Summary
- Adds a dev user seed (`dev@dev.com` / `dev`) for local Docker MySQL
- Fixes plus/minus button icon misalignment in habit tracker tally rows

## Changes
- `seeds/dev_user.sql` — INSERT IGNORE for dev user with bcrypt-hashed password
- `docker-compose.yml` — mounts seed file as `zzz_dev_user.sql` (runs after migrations)
- `HabitTracker.module.scss` — centers icons inside inc/dec buttons
- `client/src/components/HabitTracker.jsx` — any related JSX adjustments

## Testing
- Dev credentials available at `dev@dev.com` / `dev` after `docker-compose down -v && docker-compose up -d`
- +/- button centering visually confirmed