### PR TITLE
fix: bookmarkable tab URLs and SameSite lax cookie

### DIFF
--- a/client/src/pages/Workouts.jsx
+++ b/client/src/pages/Workouts.jsx
@@ -3,6 +3,7 @@ import AddSection from '../components/AddSection.jsx';
 import BodyWeightTracker from '../components/BodyWeightTracker.jsx';
 import HabitTracker from '../components/HabitTracker.jsx';
 import { useState, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import styles from "../styles/Workouts.module.scss";
 import Header from '../components/Header.jsx';
 import clientApi from '../api/clientApi.js';
@@ -14,17 +15,27 @@ const TABS = {
   HABITS: 'habits',
 };
 
+const VALID_TABS = new Set(Object.values(TABS));
+
 function Workouts() {
   const [sections, setSections] = useState([]);
-  const [activeTab, setActiveTab] = useState(TABS.WORKOUTS);
   const { withAuth, user } = useAuth();
+  const [searchParams, setSearchParams] = useSearchParams();
 
-  // Reset to Workouts tab if user logs out while on an auth-only tab
+  // Derive active tab from URL; fall back to WORKOUTS for unknown values
+  const tabParam = searchParams.get('tab');
+  const activeTab = VALID_TABS.has(tabParam) ? tabParam : TABS.WORKOUTS;
+
+  // If a non-logged-in user lands on an auth-only tab, redirect to Workouts
   useEffect(() => {
     if (!user && activeTab !== TABS.WORKOUTS) {
-      setActiveTab(TABS.WORKOUTS);
+      setSearchParams({ tab: TABS.WORKOUTS }, { replace: true });
     }
-  }, [user, activeTab]);
+  }, [user, activeTab, setSearchParams]);
+
+  const switchTab = (tab) => {
+    setSearchParams({ tab }, { replace: false });
+  };
 
   useEffect(() => {
     const fetchSections = async () => {
@@ -42,7 +53,7 @@ function Workouts() {
         <nav className={styles.tabs}>
           <button
             className={`${styles.tab} ${activeTab === TABS.WORKOUTS ? styles.tabActive : ''}`}
-            onClick={() => setActiveTab(TABS.WORKOUTS)}
+            onClick={() => switchTab(TABS.WORKOUTS)}
           >
             Workouts
           </button>
@@ -50,13 +61,13 @@ function Workouts() {
             <>
               <button
                 className={`${styles.tab} ${activeTab === TABS.BODY_WEIGHT ? styles.tabActive : ''}`}
-                onClick={() => setActiveTab(TABS.BODY_WEIGHT)}
+                onClick={() => switchTab(TABS.BODY_WEIGHT)}
               >
                 Body Weight
               </button>
               <button
                 className={`${styles.tab} ${activeTab === TABS.HABITS ? styles.tabActive : ''}`}
-                onClick={() => setActiveTab(TABS.HABITS)}
+                onClick={() => switchTab(TABS.HABITS)}
               >
                 Habits
               </button>
@@ -64,25 +75,28 @@ function Workouts() {
           )}
         </nav>
 
-        {activeTab === TABS.WORKOUTS && (
-          <div>
-            {sections.map((s) => (
-              <Section
-                key={s.id}
-                section={s}
-                setSections={setSections}
-              />
-            ))}
-            <AddSection setSections={setSections} />
+        {/* All panels stay mounted to preserve in-memory state; hidden via CSS */}
+        <div style={{ display: activeTab === TABS.WORKOUTS ? undefined : 'none' }}>
+          {sections.map((s) => (
+            <Section
+              key={s.id}
+              section={s}
+              setSections={setSections}
+            />
+          ))}
+          <AddSection setSections={setSections} />
+        </div>
+
+        {user && (
+          <div style={{ display: activeTab === TABS.BODY_WEIGHT ? undefined : 'none' }}>
+            <BodyWeightTracker />
           </div>
         )}
 
-        {activeTab === TABS.BODY_WEIGHT && (
-          <BodyWeightTracker />
-        )}
-
-        {activeTab === TABS.HABITS && (
-          <HabitTracker />
+        {user && (
+          <div style={{ display: activeTab === TABS.HABITS ? undefined : 'none' }}>
+            <HabitTracker />
+          </div>
         )}
       </main>
     </>

--- a/routes/auth.ts
+++ b/routes/auth.ts
@@ -109,7 +109,7 @@ router.post('/login', async (req, res): Promise<any> => {
   res.cookie("refreshToken", refreshToken, {
     httpOnly: true,
     secure: process.env.NODE_ENV === 'production',
-    sameSite: "strict",
+    sameSite: "lax",
     path: "/",
     maxAge: 7 * 24 * 60 * 60 * 1000 // 7 days
   })
@@ -165,7 +165,7 @@ router.post('/signup', async (req, res): Promise<any> => {
   res.cookie("refreshToken", refreshToken, {
     httpOnly: true,
     secure: process.env.NODE_ENV === 'production',
-    sameSite: "strict",
+    sameSite: "lax",
     path: "/",
     maxAge: 7 * 24 * 60 * 60 * 1000 // 7 days
   })


### PR DESCRIPTION
## Summary

- **Bookmarkable tabs**: Active tab is now reflected in the URL as `?tab=workouts|body-weight|habits` using React Router's `useSearchParams`. Clicking a tab does a client-side navigation (no page reload, no state loss). All three tab panels are always mounted in the DOM and shown/hidden with `display: none` — this preserves in-memory state (e.g. unsaved edits, fetched data) when switching between tabs. Unknown or missing `tab` param falls back to `workouts`.

- **SameSite lax cookie**: Changed `sameSite: "strict"` → `sameSite: "lax"` on the `refreshToken` cookie in both the login and signup handlers (`routes/auth.ts`). `Strict` blocked the cookie on top-level navigations from bookmarks and iOS home-screen shortcuts, causing users to appear logged out every fresh open. `Lax` allows the cookie through on those navigations while still blocking it on cross-site sub-resource requests (CSRF protection preserved).

## Assumptions

- `replace: false` is used for tab switches so the browser back button works as expected (navigating between tabs). The logout redirect uses `replace: true` so pressing back doesn't loop back to an auth-only tab.
- Auth-only panels (`BodyWeightTracker`, `HabitTracker`) are only rendered (and thus mounted) when `user` is truthy, matching the prior conditional rendering behaviour.

## Test plan

- [ ] Visit `/?tab=body-weight` directly — lands on Body Weight tab (if logged in)
- [ ] Click each tab — URL updates, no page reload, sections data still visible when returning to Workouts tab
- [ ] Copy URL with `?tab=habits`, open in new tab — correct tab is active
- [ ] Log out while on Body Weight tab — redirected to Workouts tab
- [ ] Add app to iOS home screen, open from home screen — user stays logged in

🤖 Generated with [Claude Code](https://claude.com/claude-code)