### PR TITLE
Expose habit tallies through the public API

### DIFF
--- a/routes/apiV1.ts
+++ b/routes/apiV1.ts
@@ -462,4 +462,138 @@ router.get('/summary', async (req, res): Promise<any> => {
     res.status(200).json({ data, message: "Summary retrieved successfully" });
 });
 
+// ---------------------------------------------------------------------------
+// Habits (tallies)
+// ---------------------------------------------------------------------------
+
+// GET distinct habit names for the user (discover what habits exist)
+router.get('/habits', async (req, res): Promise<any> => {
+    const { uuid } = res.locals.user;
+
+    let rows: RowDataPacket[];
+    try {
+        [rows] = await pool.query<RowDataPacket[]>(`
+            SELECT DISTINCT habit_name
+            FROM habit_tallies
+            WHERE user_uuid = UUID_TO_BIN(?)
+            ORDER BY habit_name ASC
+        `, [uuid]);
+    } catch (error) {
+        return handleSqlError(error, res);
+    }
+
+    const data = rows.map(r => r.habit_name);
+    res.status(200).json({ data, message: "Successfully retrieved habits" });
+});
+
+// GET all tally rows for a habit (sorted descending by date)
+router.get('/habits/:habitName', async (req, res): Promise<any> => {
+    const { uuid } = res.locals.user;
+    const habitName = req.params.habitName?.trim();
+    if (!habitName) {
+        return res.status(400).json({ message: "habitName must be a non-empty string" });
+    }
+
+    let data: RowDataPacket[];
+    try {
+        [data] = await pool.query<RowDataPacket[]>(`
+            SELECT id, habit_name, date, count, range_start, range_end
+            FROM habit_tallies
+            WHERE user_uuid = UUID_TO_BIN(?) AND habit_name = ?
+            ORDER BY date DESC
+        `, [uuid, habitName]);
+    } catch (error) {
+        return handleSqlError(error, res);
+    }
+
+    res.status(200).json({
+        data,
+        message: `Successfully retrieved habit tallies for ${habitName}`
+    });
+});
+
+// POST a tally — upserts: creates with count=1 or increments count and pushes range_end
+router.post('/habits/:habitName/tally', async (req, res): Promise<any> => {
+    const { uuid } = res.locals.user;
+    const habitName = req.params.habitName?.trim();
+    if (!habitName) {
+        return res.status(400).json({ message: "habitName must be a non-empty string" });
+    }
+
+    // Optionally accept the device's local time so we store the correct local date/time
+    const { localTime, localDate } = req.body as { localTime?: string; localDate?: string };
+
+    // Validate localTime is HH:mm
+    const timeValue = localTime && /^\d{2}:\d{2}$/.test(localTime) ? localTime : null;
+    // Validate localDate is YYYY-MM-DD
+    const dateValue = localDate && /^\d{4}-\d{2}-\d{2}$/.test(localDate) ? localDate : null;
+
+    // Fallback: use current UTC time/date if client values missing (e.g. empty body)
+    const now = new Date();
+    const fallbackDate = now.toISOString().slice(0, 10);
+    const fallbackTime = now.toTimeString().slice(0, 5);
+
+    const todayDate = dateValue ?? fallbackDate;
+    const currentTime = timeValue ?? fallbackTime;
+
+    let existingRows: RowDataPacket[];
+    try {
+        [existingRows] = await pool.query<RowDataPacket[]>(`
+            SELECT id, count, range_start, range_end
+            FROM habit_tallies
+            WHERE user_uuid = UUID_TO_BIN(?) AND habit_name = ? AND date = ?
+        `, [uuid, habitName, todayDate]);
+    } catch (error) {
+        return handleSqlError(error, res);
+    }
+
+    if (existingRows.length === 0) {
+        // No row for the date — insert with count=1 and range_start=range_end=currentTime
+        let result: ResultSetHeader;
+        try {
+            [result] = await pool.query<ResultSetHeader>(`
+                INSERT INTO habit_tallies (user_uuid, habit_name, date, count, range_start, range_end)
+                VALUES (UUID_TO_BIN(?), ?, ?, 1, ?, ?)
+            `, [uuid, habitName, todayDate, currentTime, currentTime]);
+        } catch (error) {
+            return handleSqlError(error, res);
+        }
+
+        return res.status(201).json({
+            data: {
+                id: result.insertId,
+                date: todayDate,
+                count: 1,
+                range_start: currentTime,
+                range_end: currentTime
+            },
+            message: `Tally added for ${habitName} on ${todayDate}`
+        });
+    } else {
+        // Row exists — increment count and push range_end forward
+        const existing = existingRows[0];
+        const newCount = existing.count + 1;
+        try {
+            await pool.query<ResultSetHeader>(`
+                UPDATE habit_tallies
+                SET count = ?, range_end = ?
+                WHERE id = ?
+            `, [newCount, currentTime, existing.id]);
+        } catch (error) {
+            return handleSqlError(error, res);
+        }
+
+        return res.status(200).json({
+            data: {
+                id: existing.id,
+                date: todayDate,
+                count: newCount,
+                range_start: existing.range_start,
+                range_end: currentTime
+            },
+            message: `Tally incremented for ${habitName} on ${todayDate}`
+        });
+    }
+});
+
 export default router;


### PR DESCRIPTION
## Summary

Adds habit tally endpoints to the public API (`/api/v1/`, API-key auth) so habits can be tallied from an iPhone Shortcut. Previously tallies only existed on the internal JWT-protected `/api/habits` route, which a Shortcut cannot use.

All three endpoints sit below the `router.use(authenticateApiKey)` line, so they require API-key auth (`X-API-Key` header or `?apiKey=` query param) and resolve the user via `res.locals.user.uuid`.

### Endpoints added

- **`POST /habits/:habitName/tally`** — primary endpoint for the Shortcut. Mirrors the upsert logic from the internal `routes/habits.ts`:
  - No row for the date → INSERT with `count=1`, `range_start=range_end=currentTime`
  - Row exists → increment `count`, push `range_end` to `currentTime`
  - Accepts optional `localDate` (`YYYY-MM-DD`) and `localTime` (`HH:mm`) in the JSON body; falls back to server UTC date/time when absent, so an empty / `{}` body works.
- **`GET /habits`** — returns the distinct habit names for the user (discovery).
- **`GET /habits/:habitName`** — returns all tally rows for a habit, sorted by `date DESC` (`id, habit_name, date, count, range_start, range_end`).

Follows existing `apiV1.ts` conventions: `handleSqlError`, `{ data, message }` response shape. `habit_name` is free-form (habits are created implicitly by tallying), so it is only trimmed and checked for non-emptiness rather than validated against a list.

## iPhone Shortcut setup

Configure a single **Get Contents of URL** action:
- **URL:** `https://peak-pr-tracker-61a81e590177.herokuapp.com/api/v1/habits/<habitName>/tally` (replace `<habitName>`, e.g. `nail-biting`)
- **Method:** `POST`
- **Headers:** `X-API-Key: <your-key>`
- **Request Body:** JSON, empty or `{}` (or optionally `{ "localDate": "2026-06-21", "localTime": "14:30" }` to record the device's local date/time instead of server UTC)

Each run adds/increments today's tally.

## Notes / assumptions

- No DB migration needed — `habit_tallies` already exists.
- README has no `/api/v1` documentation section, so there was nothing to update there.
- No tests added (no backend test framework in the repo).
- `npm run build` (tsc) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)