### PR TITLE
Fix API key card 'Created' subtext contrast

### DIFF
--- a/client/src/styles/ApiKeyModal.module.scss
+++ b/client/src/styles/ApiKeyModal.module.scss
@@ -203,7 +203,7 @@
 }
 
 .keyMeta {
-  color: rgba($text, 0.5);
+  color: rgba($text, 0.7);
   font-family: $sarabun;
   font-size: 12px;
   letter-spacing: $sarabun-spacing;


### PR DESCRIPTION
## Problem
In the API Keys modal, each key card showed the label (e.g. "Shortcuts") and a "Created <date>" subtext. The ticket reported both as nearly invisible against the dark card.

## Investigation
- Component: \`client/src/components/ApiKeyModal.jsx\`; styles: \`client/src/styles/ApiKeyModal.module.scss\`.
- The title (\`.keyLabel\`) was already \`color: \$text\` (#EBEDE9) — full light text, readable. No change needed there.
- The "Created ..." subtext (\`.keyMeta\`) was \`rgba(\$text, 0.5)\`. Rendered against the very dark key card (\`rgba(255,255,255,0.04)\` over \`\$surface\`/\`\$background\`), 50% opacity light text at 12px was too dim — effectively the invisible-on-dark issue the ticket describes. Verified by rendering the actual compiled module CSS in a browser and screenshotting.

## Fix
Bumped \`.keyMeta\` opacity from \`rgba(\$text, 0.5)\` to \`rgba(\$text, 0.7)\` for clear legibility while keeping it visually muted vs. the full-strength title. Uses the existing \`\$text\` light variable (no hardcoded #fff), consistent with the muted-subtext convention elsewhere (Workouts/HabitTracker use 0.55).

## Assumptions
- The title was deemed already correct (full \`\$text\`); left unchanged. The delete "x" icon was already light grey per the ticket; left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)