### PR TITLE
Fix API Keys modal black text + tab URL reverting on refresh

### DIFF
--- a/client/src/components/ApiKeyModal.jsx
+++ b/client/src/components/ApiKeyModal.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { format } from 'date-fns';
 import clientApi from '../api/clientApi.js';
 import useAuth from '../hooks/useAuth.js';
@@ -48,7 +49,7 @@ function ApiKeyModal({ onClose }) {
     setTimeout(() => setCopied(false), 2000);
   }
 
-  return (
+  return createPortal(
     <div className={styles.overlay} onClick={onClose}>
       <div className={styles.modal} onClick={e => e.stopPropagation()}>
         <div className={styles.header}>
@@ -100,7 +101,8 @@ function ApiKeyModal({ onClose }) {
           )}
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }
 

--- a/client/src/context/UserProvider.jsx
+++ b/client/src/context/UserProvider.jsx
@@ -7,7 +7,8 @@ export function useUser() {
 }
 
 function UserProvider({ children }) {
-  const [user, setUser] = useState(null);
+  // `undefined` = auth not yet resolved (loading); `null` = definitively logged out; `{}` = logged in
+  const [user, setUser] = useState(undefined);
   useEffect(() => {
     const fetchUser = async () => {
       setUser(await isLoggedIn() ? {} : null);

--- a/client/src/pages/Workouts.jsx
+++ b/client/src/pages/Workouts.jsx
@@ -26,9 +26,11 @@ function Workouts() {
   const tabParam = searchParams.get('tab');
   const activeTab = VALID_TABS.has(tabParam) ? tabParam : TABS.WORKOUTS;
 
-  // If a non-logged-in user lands on an auth-only tab, redirect to Workouts
+  // If a non-logged-in user lands on an auth-only tab, redirect to Workouts.
+  // Only act once auth has RESOLVED to logged-out (user === null); while
+  // user === undefined (still loading) we leave the URL untouched.
   useEffect(() => {
-    if (!user && activeTab !== TABS.WORKOUTS) {
+    if (user === null && activeTab !== TABS.WORKOUTS) {
       setSearchParams({ tab: TABS.WORKOUTS }, { replace: true });
     }
   }, [user, activeTab, setSearchParams]);


### PR DESCRIPTION
Fixes two confirmed bugs.

## Bug 1 — API Keys modal labels rendered black (unreadable)
**Cause:** `ApiKeyModal` is rendered inside `AccountMenu`, which lives in the header's `.authLinks` container. The rule `.header > .authLinks { span, a, a:visited { color: inherit } }` (specificity 0,2,1) beat the modal's own `.keyLabel`/`.keyMeta` color rules, so every modal `<span>` inherited black from `body`.

**Fix:** Render `ApiKeyModal` through `ReactDOM.createPortal(..., document.body)` so it escapes the header subtree and the Header color rule no longer matches. (PR #48 bumped opacity and did nothing because that was not the cause — that change is left as-is; with the override gone, `.keyMeta`'s `rgba($text,0.7)` gives the intended muted-but-readable date subtext.)

Checked existing modals first: neither `ConfirmModal` nor `WeightGraphModal` uses a portal, but they aren't rendered inside `.authLinks`, so portaling `ApiKeyModal` is the targeted, lowest-risk fix.

## Bug 2 — `?tab=habits` / `?tab=body-weight` revert to `?tab=workouts` on refresh
**Cause:** `UserProvider` initialized `user = null`, so `null` meant both "still loading" and "logged out". On refresh the `Workouts.jsx` effect saw `!user` true during the async `isLoggedIn()` load and rewrote the URL to workouts before auth resolved.

**Fix:**
- `UserProvider`: initialize `user = undefined` (loading); resolve to `{}` (logged in) or `null` (logged out).
- `Workouts.jsx`: redirect only when `user === null` (confirmed logged out); leave the URL alone while `undefined` (loading).

Other `user` consumers are unaffected: `{user && ...}` guards and Header's `user == null` (loose) ternary treat `undefined` the same as the old `null` initial state for rendering.

## Verification (Playwright on local dev, ports 3002/4002)
- Bug 1: generated a key; computed `color` of the key-label span is `rgb(235, 237, 233)` (light) and the meta span is `rgba(235, 237, 233, 0.7)` — not black. Confirmed the modal overlay's parent element is `BODY` (portal working).
- Bug 2: navigated directly to `/?tab=habits` and `/?tab=body-weight`; URL stays on each tab after auth resolves and the correct panel/tab is active.

## Assumptions
- `ApiKeyModal` only opens when logged in, so `withAuth` (which guards on `!user`) behaves identically with the new `undefined` initial state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)