### PR TITLE
Fix prod login 404: default API base to same-origin /api

### DIFF
--- a/client/src/api/authApi.js
+++ b/client/src/api/authApi.js
@@ -1,5 +1,6 @@
 import axios from "axios";
-const URL = import.meta.env.VITE_API_URL
+// Same-origin `/api` by default in production; VITE_API_URL overrides for local dev.
+const URL = import.meta.env.VITE_API_URL || '/api'
 
 const authApi = axios.create({
   withCredentials: true,

--- a/client/src/api/clientApi.js
+++ b/client/src/api/clientApi.js
@@ -1,6 +1,8 @@
 import axios from "axios";
 import { jwtDecode } from "jwt-decode";
-const URL = import.meta.env.VITE_API_URL;
+// In production the client is served same-origin as the API, so default to the
+// relative `/api` base; local dev overrides this via VITE_API_URL in .env.local.
+const URL = import.meta.env.VITE_API_URL || '/api';
 axios.defaults.withCredentials = true;
 
 const clientApi = axios.create({


### PR DESCRIPTION
## Bug
Login on prod returned a 404 (surfaced in the UI as a server error). The app was calling `POST /auth/login` instead of `/api/auth/login`.

## Cause
`clientApi.js`/`authApi.js` set the axios `baseURL` from `import.meta.env.VITE_API_URL`. The Vite migration renamed the env var, but the Heroku config still only has the old CRA `REACT_APP_API_URL` (which Vite doesn't expose). So the prod build inlined an **undefined** base URL → the `/api` prefix was dropped.

## Fix
Default the base to the same-origin relative `/api` when `VITE_API_URL` is unset. Prod is served same-origin as the API, so `/api` is always correct and host-agnostic; local dev still overrides via `client/.env.local`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)