### PR TITLE
Fix off-center delete-x on variations

### DIFF
--- a/client/src/styles/Variation.module.scss
+++ b/client/src/styles/Variation.module.scss
@@ -65,6 +65,7 @@
   width: 40px;
   height: 40px;
   align-items: center;
+  justify-content: center;
   background-color: transparent;
   border: none;
   border-radius: 100px;


### PR DESCRIPTION
The ✕ on a variation's delete button sat left-of-center inside its circular hover background.

`.delete` (Variation.module.scss) had `align-items: center` but was missing `justify-content: center` — so the icon centered vertically but not horizontally (the sibling `.graphBtn` has both). Added `justify-content: center`.

Verified with Playwright (before/after screenshots of the hovered button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)