### PR TITLE
Nutrition Phase 1: manual calorie tracker (4th tab)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,10 @@ DB_USERNAME=dev
 DB_PASSWORD=dev
 DB_NAME=workout_log
 
+# Nutrition feature API keys
+USDA_FDC_API_KEY=
+OPENAI_API_KEY=
+
 # Frontend env vars (Vite) — place these in client/.env.local for local dev
 # In production (Heroku), set them via: heroku config:set VITE_API_URL=... --app peak-pr-tracker
 VITE_API_URL=

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,6 +11,8 @@
         "@radix-ui/react-dialog": "^1.1.17",
         "@tanstack/react-query": "^5.101.0",
         "@vitejs/plugin-react": "^4.3.4",
+        "@zxing/browser": "^0.2.0",
+        "@zxing/library": "^0.22.0",
         "axios": "^1.7.9",
         "date-fns": "^4.1.0",
         "http-proxy-middleware": "^3.0.3",
@@ -2007,6 +2009,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@zxing/browser": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@zxing/browser/-/browser-0.2.0.tgz",
+      "integrity": "sha512-+ORhrLva0vm6ck74NDCmvYNW3XLoAG81Mu90qfcssN1PBKJjQadxZGeMCcIk+BdJbD/zEAjjHDXOwEK1QCmRtw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@zxing/text-encoding": "^0.9.0"
+      },
+      "peerDependencies": {
+        "@zxing/library": "^0.22.0"
+      }
+    },
+    "node_modules/@zxing/library": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.22.0.tgz",
+      "integrity": "sha512-BmInervZV7NwaZWX1LW64sZ4Lh4wxXYFZwGmj98ArPOkRXCtO9b8Gog0Xyh82dsYYGOeRxX+aAhLSq+hQ2XLZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ts-custom-error": "^3.3.1"
+      },
+      "engines": {
+        "node": ">= 24.0.0"
+      },
+      "optionalDependencies": {
+        "@zxing/text-encoding": "~0.9.0"
+      }
+    },
+    "node_modules/@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "license": "(Unlicense OR Apache-2.0)",
+      "optional": true
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3464,6 +3500,15 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-custom-error": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
+      "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {

--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,8 @@
     "@radix-ui/react-dialog": "^1.1.17",
     "@tanstack/react-query": "^5.101.0",
     "@vitejs/plugin-react": "^4.3.4",
+    "@zxing/browser": "^0.2.0",
+    "@zxing/library": "^0.22.0",
     "axios": "^1.7.9",
     "date-fns": "^4.1.0",
     "http-proxy-middleware": "^3.0.3",

--- a/client/src/features/nutrition/BarcodeScanner.module.scss
+++ b/client/src/features/nutrition/BarcodeScanner.module.scss
@@ -1,0 +1,78 @@
+@import "../../styles/variables";
+
+// Full-screen overlay rendered on top of everything (z-index above modals).
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  background-color: rgba(0, 0, 0, 0.92);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  width: 100%;
+  max-width: 400px;
+  padding: 24px 16px;
+}
+
+.viewfinder {
+  position: relative;
+  width: 100%;
+  max-width: 320px;
+  aspect-ratio: 1 / 1;
+}
+
+.video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 12px;
+  display: block; // iOS Safari: must be block inside a flex/positioned parent
+}
+
+.reticle {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+// SVG is a flex child of .reticle — use display: block to avoid iOS Safari quirk
+.reticleSvg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.hint {
+  margin: 0;
+  color: rgba($text, 0.75);
+  font-family: $sarabun;
+  font-size: 15px;
+  letter-spacing: $sarabun-spacing;
+  text-align: center;
+}
+
+.closeBtn {
+  min-height: 48px; // Minimum tap target for mobile
+  min-width: 120px;
+  padding: 10px 28px;
+  background-color: transparent;
+  color: $text;
+  border: 2px solid $surface-border;
+  border-radius: $border-radius;
+  font-family: $sarabun;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: $sarabun-spacing;
+  cursor: pointer;
+
+  &:active {
+    background-color: rgba($text, 0.1);
+  }
+}

--- a/client/src/features/nutrition/BarcodeScanner.tsx
+++ b/client/src/features/nutrition/BarcodeScanner.tsx
@@ -1,0 +1,122 @@
+// NOTE: BarcodeScanner requires a secure context (HTTPS or localhost).
+// getUserMedia will be denied on plain HTTP pages in production.
+
+import { useEffect, useRef } from 'react';
+import { BrowserMultiFormatReader } from '@zxing/browser';
+import styles from './BarcodeScanner.module.scss';
+
+interface BarcodeScannerProps {
+  onDetected: (code: string) => void;
+  onClose: () => void;
+}
+
+export default function BarcodeScanner({ onDetected, onClose }: BarcodeScannerProps) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  // Keep refs so the cleanup closure can stop everything even after unmount.
+  const readerRef = useRef<BrowserMultiFormatReader | null>(null);
+  const controlsRef = useRef<{ stop: () => void } | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const detectedRef = useRef(false);
+
+  useEffect(() => {
+    const reader = new BrowserMultiFormatReader();
+    readerRef.current = reader;
+
+    let cancelled = false;
+
+    async function start() {
+      try {
+        // Request environment-facing (rear) camera explicitly.
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode: 'environment' },
+        });
+
+        if (cancelled) {
+          stream.getTracks().forEach(t => t.stop());
+          return;
+        }
+
+        streamRef.current = stream;
+
+        if (!videoRef.current) return;
+        videoRef.current.srcObject = stream;
+
+        const controls = await reader.decodeFromVideoDevice(
+          undefined,
+          videoRef.current,
+          (result, _err, ctrl) => {
+            if (result && !detectedRef.current) {
+              detectedRef.current = true;
+              // Stop scanning; let the parent handle the detected code.
+              ctrl.stop();
+              stream.getTracks().forEach(t => t.stop());
+              onDetected(result.getText());
+            }
+          },
+        );
+
+        if (cancelled) {
+          controls.stop();
+          stream.getTracks().forEach(t => t.stop());
+          return;
+        }
+
+        controlsRef.current = controls;
+      } catch (err) {
+        // Camera permission denied or not available — just close.
+        console.error('[BarcodeScanner] camera error:', err);
+        if (!cancelled) onClose();
+      }
+    }
+
+    start();
+
+    return () => {
+      cancelled = true;
+      controlsRef.current?.stop();
+      streamRef.current?.getTracks().forEach(t => t.stop());
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <div className={styles.overlay}>
+      <div className={styles.panel}>
+        <div className={styles.viewfinder}>
+          {/* playsInline is essential for iOS Safari; muted prevents autoplay policy block */}
+          <video
+            ref={videoRef}
+            className={styles.video}
+            playsInline
+            muted
+            autoPlay
+          />
+          {/* Framing reticle */}
+          <div className={styles.reticle}>
+            <svg
+              viewBox="0 0 200 200"
+              className={styles.reticleSvg}
+              aria-hidden="true"
+            >
+              {/* Four corner brackets */}
+              <polyline points="0,40 0,0 40,0" fill="none" stroke="#70EB70" strokeWidth="4" strokeLinecap="round" />
+              <polyline points="160,0 200,0 200,40" fill="none" stroke="#70EB70" strokeWidth="4" strokeLinecap="round" />
+              <polyline points="200,160 200,200 160,200" fill="none" stroke="#70EB70" strokeWidth="4" strokeLinecap="round" />
+              <polyline points="40,200 0,200 0,160" fill="none" stroke="#70EB70" strokeWidth="4" strokeLinecap="round" />
+            </svg>
+          </div>
+        </div>
+
+        <p className={styles.hint}>Point camera at a barcode</p>
+
+        <button
+          type="button"
+          className={styles.closeBtn}
+          onClick={onClose}
+          aria-label="Close barcode scanner"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/features/nutrition/EntryEditor.module.scss
+++ b/client/src/features/nutrition/EntryEditor.module.scss
@@ -1,0 +1,406 @@
+@import "../../styles/variables";
+
+// Modal content override — tall enough to scroll on small screens.
+.modalContent {
+  max-width: 560px !important;
+  max-height: 92dvh;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+// Editor layout
+.editor {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 24px 20px 20px;
+
+  @media (max-width: $mobile-width) {
+    padding: 16px 14px 16px;
+    gap: 16px;
+  }
+}
+
+// Header
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.title {
+  margin: 0;
+  font-family: $sarabun;
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: $sarabun-spacing;
+  color: $text;
+}
+
+// Meal selector — segmented button group
+.mealSelector {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.mealBtn {
+  flex: 1 1 auto;
+  min-height: 44px; // mobile tap target
+  padding: 8px 12px;
+  background-color: transparent;
+  color: rgba($text, 0.65);
+  border: 2px solid $surface-border;
+  border-radius: 10px;
+  font-family: $sarabun;
+  font-size: 15px;
+  letter-spacing: $sarabun-spacing;
+  cursor: pointer;
+  transition: border-color 0.1s, color 0.1s, background-color 0.1s;
+
+  &:active {
+    background-color: $primary-translucent;
+  }
+}
+
+.mealBtnActive {
+  border-color: $primary-border;
+  color: $primary;
+  font-weight: 600;
+}
+
+// Field
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.fieldLabel {
+  font-family: $sarabun;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: $sarabun-spacing;
+  color: rgba($text, 0.6);
+  text-transform: uppercase;
+}
+
+// Shared input style
+.input {
+  background-color: transparent;
+  color: $text;
+  border: none;
+  border-bottom: 2px solid $primary-border;
+  padding: 6px 4px;
+  font-family: $sarabun;
+  font-size: 16px;
+  letter-spacing: $sarabun-spacing;
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 44px; // mobile tap target
+
+  &::placeholder {
+    color: rgba($text, 0.4);
+  }
+
+  &:focus {
+    outline: none;
+    border-bottom-color: $primary;
+  }
+}
+
+.inputSmall {
+  @extend .input;
+  font-size: 14px;
+  min-height: 36px;
+  width: 70px;
+  text-align: right;
+  padding: 4px 2px;
+
+  &[readonly] {
+    color: rgba($text, 0.55);
+    border-bottom-style: dashed;
+  }
+}
+
+// Ingredients section
+.ingredientsSection {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ingredientsLabel {
+  font-family: $sarabun;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: $sarabun-spacing;
+  color: rgba($text, 0.6);
+  text-transform: uppercase;
+}
+
+.ingredientsList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+// Single ingredient row
+.row {
+  background-color: rgba($background, 0.5);
+  border: 1px solid rgba($surface-border, 0.5);
+  border-radius: 10px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+// Row: name + barcode button in one line
+.rowNameWrap {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+  position: relative;
+}
+
+.rowNameInputWrap {
+  flex: 1;
+  position: relative;
+}
+
+.barcodeBtn {
+  flex-shrink: 0;
+  min-width: 44px;
+  min-height: 44px; // mobile tap target
+  padding: 8px;
+  background-color: transparent;
+  border: 2px solid $surface-border;
+  border-radius: 8px;
+  color: rgba($text, 0.7);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:active {
+    color: $primary;
+    border-color: $primary-border;
+  }
+}
+
+// SVG icon: display:block is required — avoids iOS Safari flex-child misrender
+.barcodeIcon {
+  display: block;
+  width: 20px;
+  height: 20px;
+}
+
+// Row: nutrient fields in a flex row
+.rowNutrients {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 14px;
+  align-items: flex-end;
+}
+
+.nutrientLabel {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-family: $sarabun;
+  font-size: 11px;
+  letter-spacing: $sarabun-spacing;
+  color: rgba($text, 0.55);
+}
+
+.removeRowBtn {
+  margin-left: auto;
+  align-self: flex-end;
+  min-width: 36px;
+  min-height: 36px;
+  background: transparent;
+  border: none;
+  color: rgba($text, 0.45);
+  font-size: 13px;
+  cursor: pointer;
+  border-radius: 6px;
+  padding: 4px 8px;
+
+  &:active {
+    color: $error;
+    background-color: rgba($error, 0.12);
+  }
+}
+
+.rowHint {
+  margin: 0;
+  font-family: $sarabun;
+  font-size: 11px;
+  color: rgba($text, 0.4);
+  letter-spacing: $sarabun-spacing;
+}
+
+// Search dropdown
+.dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  z-index: 200;
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+  background-color: $surface;
+  border: 1px solid $surface-border;
+  border-radius: 10px;
+  max-height: 240px;
+  overflow-y: auto;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+}
+
+.dropdownItem {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px 14px;
+  cursor: pointer;
+
+  &:active {
+    background-color: rgba($primary, 0.12);
+  }
+}
+
+.dropdownName {
+  font-family: $sarabun;
+  font-size: 15px;
+  color: $text;
+  letter-spacing: $sarabun-spacing;
+}
+
+.dropdownMeta {
+  font-family: $sarabun;
+  font-size: 12px;
+  color: rgba($text, 0.5);
+  letter-spacing: $sarabun-spacing;
+}
+
+.dropdownHint {
+  padding: 10px 14px;
+  font-family: $sarabun;
+  font-size: 14px;
+  color: rgba($text, 0.5);
+  letter-spacing: $sarabun-spacing;
+}
+
+// Add ingredient button
+.addRowBtn {
+  align-self: flex-start;
+  min-height: 44px;
+  padding: 8px 16px;
+  background-color: transparent;
+  color: $primary;
+  border: 2px dashed $primary-border;
+  border-radius: 10px;
+  font-family: $sarabun;
+  font-size: 15px;
+  letter-spacing: $sarabun-spacing;
+  cursor: pointer;
+
+  &:active {
+    background-color: $primary-translucent;
+  }
+}
+
+// Live totals
+.totals {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  padding: 12px 14px;
+  background-color: rgba($primary, 0.07);
+  border: 1px solid rgba($primary-border, 0.4);
+  border-radius: 10px;
+  align-items: center;
+}
+
+.totalsLabel {
+  font-family: $sarabun;
+  font-size: 13px;
+  font-weight: 700;
+  color: $primary;
+  letter-spacing: $sarabun-spacing;
+  text-transform: uppercase;
+  margin-right: 4px;
+}
+
+.totalsStat {
+  font-family: $sarabun;
+  font-size: 14px;
+  color: rgba($text, 0.85);
+  letter-spacing: $sarabun-spacing;
+
+  strong {
+    color: $text;
+    font-weight: 600;
+  }
+}
+
+// Error message
+.errorMsg {
+  margin: 0;
+  font-family: $sarabun;
+  font-size: 14px;
+  color: $error;
+  letter-spacing: $sarabun-spacing;
+}
+
+// Footer
+.footer {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  padding-top: 4px;
+}
+
+// Shared button base
+%btn-base {
+  min-height: 48px; // mobile tap target
+  padding: 10px 24px;
+  border-radius: $border-radius;
+  font-family: $sarabun;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: $sarabun-spacing;
+  cursor: pointer;
+  border: none;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.saveBtn {
+  @extend %btn-base;
+  background-color: $primary;
+  color: $background;
+
+  &:not(:disabled):active {
+    background-color: $primary-dark;
+  }
+}
+
+.cancelBtn {
+  @extend %btn-base;
+  background-color: transparent;
+  color: rgba($text, 0.75);
+  border: 2px solid $surface-border;
+}
+
+.denyBtn {
+  @extend %btn-base;
+  background-color: transparent;
+  color: $error;
+  border: 2px solid rgba($error, 0.5);
+}

--- a/client/src/features/nutrition/EntryEditor.tsx
+++ b/client/src/features/nutrition/EntryEditor.tsx
@@ -1,0 +1,718 @@
+/**
+ * EntryEditor — Phase 1
+ * Handles 'manual-add' and 'manual-edit' modes.
+ * 'proposal' mode renders the same form but onConfirm/onDeny are wired in Phase 2.
+ */
+import {
+  useState,
+  useCallback,
+  useEffect,
+  useRef,
+} from 'react';
+import Modal from '../../components/Modal.jsx';
+import BarcodeScanner from './BarcodeScanner';
+import { useCreateEntry, useUpdateEntry, searchFoods, lookupBarcode } from './api';
+import type {
+  EntryEditorProps,
+  Meal,
+  IngredientInput,
+  EntryInput,
+  FoodSearchResult,
+  Per100g,
+} from './types';
+import { MEALS } from './types';
+import styles from './EntryEditor.module.scss';
+
+// ---------------------------------------------------------------------------
+// Internal row shape — extends IngredientInput with UI-only per100g snapshot
+// so we can recompute macros live when grams changes.
+// ---------------------------------------------------------------------------
+interface EditorRow extends IngredientInput {
+  /** Internal row id for React keys/removal. */
+  rowKey: number;
+  /** Non-null when row was filled from a search/barcode result (enables live recompute). */
+  per100g: Per100g | null;
+}
+
+let _rowKeyCounter = 0;
+function nextKey(): number {
+  return ++_rowKeyCounter;
+}
+
+function emptyRow(): EditorRow {
+  return {
+    rowKey: nextKey(),
+    name: '',
+    grams: 100,
+    source: 'manual',
+    source_ref: null,
+    calories: 0,
+    protein_g: 0,
+    carbs_g: 0,
+    fat_g: 0,
+    per100g: null,
+  };
+}
+
+/** Recompute a row's macros from its per100g snapshot and current grams. */
+function recomputeMacros(per100g: Per100g, grams: number): Pick<EditorRow, 'calories' | 'protein_g' | 'carbs_g' | 'fat_g'> {
+  const factor = grams / 100;
+  return {
+    calories: round2(per100g.calories * factor),
+    protein_g: round2(per100g.protein_g * factor),
+    carbs_g: round2(per100g.carbs_g * factor),
+    fat_g: round2(per100g.fat_g * factor),
+  };
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/** Convert a FoodSearchResult into an editor row. */
+function rowFromFood(food: FoodSearchResult, defaultGrams?: number): EditorRow {
+  const grams = defaultGrams ?? food.serving_grams ?? 100;
+  return {
+    rowKey: nextKey(),
+    name: food.name,
+    grams,
+    source: food.source,
+    source_ref: food.source_ref,
+    per100g: food.per100g,
+    ...recomputeMacros(food.per100g, grams),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Debounce hook
+// ---------------------------------------------------------------------------
+function useDebounce<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(t);
+  }, [value, delay]);
+  return debounced;
+}
+
+// ---------------------------------------------------------------------------
+// Search dropdown for a single ingredient row
+// ---------------------------------------------------------------------------
+interface SearchDropdownProps {
+  query: string;
+  onSelect: (food: FoodSearchResult) => void;
+}
+
+function SearchDropdown({ query, onSelect }: SearchDropdownProps) {
+  const [results, setResults] = useState<FoodSearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const debouncedQuery = useDebounce(query, 300);
+
+  useEffect(() => {
+    if (debouncedQuery.trim().length < 2) {
+      setResults([]);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    searchFoods(debouncedQuery)
+      .then(res => { if (!cancelled) setResults(res); })
+      .catch(() => { if (!cancelled) setResults([]); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [debouncedQuery]);
+
+  if (!query.trim() || (results.length === 0 && !loading)) return null;
+
+  return (
+    <ul className={styles.dropdown} role="listbox">
+      {loading && (
+        <li className={styles.dropdownHint}>Searching…</li>
+      )}
+      {!loading && results.length === 0 && (
+        <li className={styles.dropdownHint}>No results</li>
+      )}
+      {results.map(food => (
+        <li
+          key={`${food.source}:${food.source_ref}`}
+          className={styles.dropdownItem}
+          role="option"
+          aria-selected={false}
+          onPointerDown={e => {
+            // Use pointerDown so we fire before the name input's onBlur hides
+            // any ancestor focus-based dropdown (we're not using onBlur here,
+            // but this is good defensive practice).
+            e.preventDefault();
+            onSelect(food);
+          }}
+        >
+          <span className={styles.dropdownName}>{food.name}</span>
+          <span className={styles.dropdownMeta}>
+            {food.per100g.calories} kcal/100g · {food.source.toUpperCase()}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Single ingredient row
+// ---------------------------------------------------------------------------
+interface IngredientRowProps {
+  row: EditorRow;
+  onChange: (updated: EditorRow) => void;
+  onRemove: () => void;
+  onOpenBarcode: () => void;
+}
+
+function IngredientRowEditor({ row, onChange, onRemove, onOpenBarcode }: IngredientRowProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [showSearch, setShowSearch] = useState(false);
+
+  function handleNameChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const name = e.target.value;
+    setSearchQuery(name);
+    setShowSearch(true);
+    // Keep typing into the name — clear per100g so it becomes manual mode.
+    onChange({
+      ...row,
+      name,
+      source: 'manual',
+      source_ref: null,
+      per100g: null,
+    });
+  }
+
+  function handleSelectFood(food: FoodSearchResult) {
+    setShowSearch(false);
+    setSearchQuery('');
+    onChange(rowFromFood(food, row.grams));
+  }
+
+  function handleGramsChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const grams = parseFloat(e.target.value) || 0;
+    if (row.per100g) {
+      // Recompute macros live from the per100g snapshot.
+      onChange({ ...row, grams, ...recomputeMacros(row.per100g, grams) });
+    } else {
+      onChange({ ...row, grams });
+    }
+  }
+
+  function handleMacroChange(field: 'calories' | 'protein_g' | 'carbs_g' | 'fat_g', value: string) {
+    onChange({ ...row, [field]: parseFloat(value) || 0 });
+  }
+
+  const macrosReadOnly = row.per100g !== null;
+
+  return (
+    <div className={styles.row}>
+      <div className={styles.rowNameWrap}>
+        <div className={styles.rowNameInputWrap}>
+          <input
+            className={styles.input}
+            type="text"
+            placeholder="Ingredient name"
+            value={row.name}
+            onChange={handleNameChange}
+            onFocus={() => setShowSearch(true)}
+            onBlur={() => {
+              // Small delay so pointerDown on a dropdown item fires first.
+              setTimeout(() => setShowSearch(false), 150);
+            }}
+            aria-label="Ingredient name"
+          />
+          {showSearch && (
+            <SearchDropdown query={searchQuery} onSelect={handleSelectFood} />
+          )}
+        </div>
+        <button
+          type="button"
+          className={styles.barcodeBtn}
+          onClick={onOpenBarcode}
+          aria-label="Scan barcode"
+          title="Scan barcode"
+        >
+          {/* Barcode icon — display:block per iOS SVG rule */}
+          <svg
+            className={styles.barcodeIcon}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <rect x="2" y="4" width="3" height="16" rx="0.5" fill="currentColor" stroke="none" />
+            <rect x="7" y="4" width="1.5" height="16" rx="0.5" fill="currentColor" stroke="none" />
+            <rect x="10.5" y="4" width="2.5" height="16" rx="0.5" fill="currentColor" stroke="none" />
+            <rect x="15" y="4" width="1.5" height="16" rx="0.5" fill="currentColor" stroke="none" />
+            <rect x="18.5" y="4" width="3.5" height="16" rx="0.5" fill="currentColor" stroke="none" />
+          </svg>
+        </button>
+      </div>
+
+      <div className={styles.rowNutrients}>
+        <label className={styles.nutrientLabel}>
+          <span>Grams</span>
+          <input
+            className={styles.inputSmall}
+            type="number"
+            min="0"
+            step="1"
+            value={row.grams === 0 ? '' : row.grams}
+            onChange={handleGramsChange}
+            aria-label="Grams"
+          />
+        </label>
+
+        <label className={styles.nutrientLabel}>
+          <span>kcal</span>
+          <input
+            className={styles.inputSmall}
+            type="number"
+            min="0"
+            step="0.1"
+            value={row.calories === 0 ? '' : row.calories}
+            onChange={e => handleMacroChange('calories', e.target.value)}
+            readOnly={macrosReadOnly}
+            aria-label="Calories"
+          />
+        </label>
+
+        <label className={styles.nutrientLabel}>
+          <span>Prot</span>
+          <input
+            className={styles.inputSmall}
+            type="number"
+            min="0"
+            step="0.1"
+            value={row.protein_g === 0 ? '' : row.protein_g}
+            onChange={e => handleMacroChange('protein_g', e.target.value)}
+            readOnly={macrosReadOnly}
+            aria-label="Protein g"
+          />
+        </label>
+
+        <label className={styles.nutrientLabel}>
+          <span>Carbs</span>
+          <input
+            className={styles.inputSmall}
+            type="number"
+            min="0"
+            step="0.1"
+            value={row.carbs_g === 0 ? '' : row.carbs_g}
+            onChange={e => handleMacroChange('carbs_g', e.target.value)}
+            readOnly={macrosReadOnly}
+            aria-label="Carbs g"
+          />
+        </label>
+
+        <label className={styles.nutrientLabel}>
+          <span>Fat</span>
+          <input
+            className={styles.inputSmall}
+            type="number"
+            min="0"
+            step="0.1"
+            value={row.fat_g === 0 ? '' : row.fat_g}
+            onChange={e => handleMacroChange('fat_g', e.target.value)}
+            readOnly={macrosReadOnly}
+            aria-label="Fat g"
+          />
+        </label>
+
+        <button
+          type="button"
+          className={styles.removeRowBtn}
+          onClick={onRemove}
+          aria-label="Remove ingredient"
+        >
+          ✕
+        </button>
+      </div>
+
+      {macrosReadOnly && (
+        <p className={styles.rowHint}>
+          Macros computed from per-100g values · edit grams to recalculate
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Totals bar
+// ---------------------------------------------------------------------------
+interface TotalsProps {
+  rows: EditorRow[];
+}
+
+function Totals({ rows }: TotalsProps) {
+  const totals = rows.reduce(
+    (acc, r) => ({
+      calories: acc.calories + r.calories,
+      protein_g: acc.protein_g + r.protein_g,
+      carbs_g: acc.carbs_g + r.carbs_g,
+      fat_g: acc.fat_g + r.fat_g,
+    }),
+    { calories: 0, protein_g: 0, carbs_g: 0, fat_g: 0 },
+  );
+
+  return (
+    <div className={styles.totals}>
+      <span className={styles.totalsLabel}>Total</span>
+      <span className={styles.totalsStat}>
+        <strong>{Math.round(totals.calories)}</strong> kcal
+      </span>
+      <span className={styles.totalsStat}>
+        <strong>{round2(totals.protein_g)}</strong>g prot
+      </span>
+      <span className={styles.totalsStat}>
+        <strong>{round2(totals.carbs_g)}</strong>g carbs
+      </span>
+      <span className={styles.totalsStat}>
+        <strong>{round2(totals.fat_g)}</strong>g fat
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+export default function EntryEditor({ open, mode, onClose, onConfirm, onDeny }: EntryEditorProps) {
+  const isEdit = mode.kind === 'manual-edit';
+  const date = mode.date;
+
+  // ----- Meal selector -----
+  const [meal, setMeal] = useState<Meal>(() => {
+    if (mode.kind === 'manual-edit') return mode.entry.meal;
+    if (mode.kind === 'manual-add') return mode.defaultMeal ?? 'breakfast';
+    // proposal
+    return mode.proposal.meal;
+  });
+
+  // ----- Entry name -----
+  const [entryName, setEntryName] = useState<string>(() => {
+    if (mode.kind === 'manual-edit') return mode.entry.name;
+    if (mode.kind === 'proposal') return mode.proposal.name;
+    return '';
+  });
+
+  // ----- Ingredient rows -----
+  const [rows, setRows] = useState<EditorRow[]>(() => {
+    if (mode.kind === 'manual-edit') {
+      return mode.entry.ingredients.map(ing => ({
+        ...ing,
+        rowKey: nextKey(),
+        per100g: null, // existing edit rows — macros already stored, not per100g
+      }));
+    }
+    if (mode.kind === 'proposal') {
+      // TODO Phase 2: wire proposal ingredients here
+      return mode.proposal.ingredients.map(ing => ({
+        ...ing,
+        rowKey: nextKey(),
+        per100g: null,
+      }));
+    }
+    return [emptyRow()];
+  });
+
+  // ----- Barcode scanner state -----
+  const [scanningRowKey, setScanningRowKey] = useState<number | null>(null);
+  const [barcodeError, setBarcodeError] = useState<string | null>(null);
+  const scanningRowKeyRef = useRef<number | null>(null);
+  scanningRowKeyRef.current = scanningRowKey;
+
+  // ----- Error display -----
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  // ----- Mutations -----
+  const createMutation = useCreateEntry(date);
+  const updateMutation = useUpdateEntry(date);
+
+  const isPending = createMutation.isPending || updateMutation.isPending;
+
+  // Reset form when the mode prop changes (e.g. open different entry).
+  const modeKind = mode.kind;
+  useEffect(() => {
+    if (!open) return;
+    if (mode.kind === 'manual-edit') {
+      setMeal(mode.entry.meal);
+      setEntryName(mode.entry.name);
+      setRows(
+        mode.entry.ingredients.map(ing => ({
+          ...ing,
+          rowKey: nextKey(),
+          per100g: null,
+        })),
+      );
+    } else if (mode.kind === 'manual-add') {
+      setMeal(mode.defaultMeal ?? 'breakfast');
+      setEntryName('');
+      setRows([emptyRow()]);
+    }
+    // proposal: TODO Phase 2 — keep form as-is for now
+    setSaveError(null);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, modeKind]);
+
+  // ----- Row helpers -----
+  const updateRow = useCallback((key: number, updated: EditorRow) => {
+    setRows(prev => prev.map(r => (r.rowKey === key ? updated : r)));
+  }, []);
+
+  const removeRow = useCallback((key: number) => {
+    setRows(prev => prev.filter(r => r.rowKey !== key));
+  }, []);
+
+  const addRow = useCallback(() => {
+    setRows(prev => [...prev, emptyRow()]);
+  }, []);
+
+  // ----- Barcode callbacks -----
+  const handleOpenBarcode = useCallback((rowKey: number) => {
+    setBarcodeError(null);
+    setScanningRowKey(rowKey);
+  }, []);
+
+  const handleBarcodeDetected = useCallback(async (code: string) => {
+    setScanningRowKey(null);
+    const targetKey = scanningRowKeyRef.current;
+    if (targetKey === null) return;
+    try {
+      const food = await lookupBarcode(code);
+      if (!food) {
+        setBarcodeError(`Barcode ${code} not found in database.`);
+        return;
+      }
+      const newRow = rowFromFood(food);
+      setRows(prev => prev.map(r => (r.rowKey === targetKey ? { ...newRow, rowKey: targetKey } : r)));
+    } catch {
+      setBarcodeError('Failed to look up barcode. Try again.');
+    }
+  }, []);
+
+  const handleBarcodeClose = useCallback(() => {
+    setScanningRowKey(null);
+  }, []);
+
+  // ----- Save -----
+  const canSave =
+    entryName.trim().length > 0 &&
+    rows.length > 0 &&
+    !isPending;
+
+  async function handleSave() {
+    if (!canSave) return;
+    setSaveError(null);
+
+    const ingredients: IngredientInput[] = rows.map(r => ({
+      name: r.name,
+      grams: r.grams,
+      source: r.source,
+      source_ref: r.source_ref ?? null,
+      calories: r.calories,
+      protein_g: r.protein_g,
+      carbs_g: r.carbs_g,
+      fat_g: r.fat_g,
+    }));
+
+    const input: EntryInput = {
+      localDate: date,
+      meal,
+      name: entryName.trim(),
+      source: 'manual',
+      ingredients,
+    };
+
+    try {
+      if (mode.kind === 'manual-edit') {
+        await updateMutation.mutateAsync({ id: mode.entry.id, input });
+      } else {
+        await createMutation.mutateAsync(input);
+      }
+      onClose();
+    } catch (err: unknown) {
+      const msg =
+        err instanceof Error ? err.message : 'Failed to save. Please try again.';
+      setSaveError(msg);
+    }
+  }
+
+  // ----- Proposal mode footer (Phase 2 wiring) -----
+  function handleConfirm() {
+    // TODO Phase 2: build EntryInput from current form state and call onConfirm
+    if (onConfirm) {
+      const ingredients: IngredientInput[] = rows.map(r => ({
+        name: r.name,
+        grams: r.grams,
+        source: r.source,
+        source_ref: r.source_ref ?? null,
+        calories: r.calories,
+        protein_g: r.protein_g,
+        carbs_g: r.carbs_g,
+        fat_g: r.fat_g,
+      }));
+      onConfirm({
+        localDate: date,
+        meal,
+        name: entryName.trim(),
+        source: 'manual',
+        ingredients,
+      });
+    }
+  }
+
+  function handleDeny() {
+    // TODO Phase 2: wire onDeny
+    if (onDeny) onDeny();
+  }
+
+  const isProposal = mode.kind === 'proposal';
+
+  const titleMap: Record<typeof modeKind, string> = {
+    'manual-add': 'Add Food Entry',
+    'manual-edit': 'Edit Food Entry',
+    'proposal': 'Review Entry',
+  };
+
+  return (
+    <>
+      <Modal
+        open={open}
+        onOpenChange={(isOpen: boolean) => { if (!isOpen) onClose(); }}
+        title={titleMap[modeKind]}
+        showTitle={false}
+        contentClassName={styles.modalContent}
+      >
+        <div className={styles.editor}>
+          {/* Header */}
+          <div className={styles.header}>
+            <h2 className={styles.title}>{titleMap[modeKind]}</h2>
+          </div>
+
+          {/* Meal selector */}
+          <div className={styles.mealSelector} role="group" aria-label="Meal">
+            {MEALS.map(m => (
+              <button
+                key={m}
+                type="button"
+                className={`${styles.mealBtn} ${meal === m ? styles.mealBtnActive : ''}`}
+                onClick={() => setMeal(m)}
+              >
+                {m.charAt(0).toUpperCase() + m.slice(1)}
+              </button>
+            ))}
+          </div>
+
+          {/* Entry name */}
+          <div className={styles.field}>
+            <label className={styles.fieldLabel} htmlFor="entry-name">
+              Entry name
+            </label>
+            <input
+              id="entry-name"
+              className={styles.input}
+              type="text"
+              placeholder="e.g. Chicken salad"
+              value={entryName}
+              onChange={e => setEntryName(e.target.value)}
+            />
+          </div>
+
+          {/* Ingredient rows */}
+          <div className={styles.ingredientsSection}>
+            <span className={styles.ingredientsLabel}>Ingredients</span>
+            <div className={styles.ingredientsList}>
+              {rows.map(row => (
+                <IngredientRowEditor
+                  key={row.rowKey}
+                  row={row}
+                  onChange={updated => updateRow(row.rowKey, updated)}
+                  onRemove={() => removeRow(row.rowKey)}
+                  onOpenBarcode={() => handleOpenBarcode(row.rowKey)}
+                />
+              ))}
+            </div>
+            <button
+              type="button"
+              className={styles.addRowBtn}
+              onClick={addRow}
+            >
+              + Add ingredient
+            </button>
+          </div>
+
+          {/* Barcode lookup error */}
+          {barcodeError && (
+            <p className={styles.errorMsg}>{barcodeError}</p>
+          )}
+
+          {/* Live totals */}
+          <Totals rows={rows} />
+
+          {/* Save error */}
+          {saveError && (
+            <p className={styles.errorMsg}>{saveError}</p>
+          )}
+
+          {/* Footer */}
+          <div className={styles.footer}>
+            {isProposal ? (
+              <>
+                {/* TODO Phase 2: these buttons call onConfirm/onDeny */}
+                <button
+                  type="button"
+                  className={styles.denyBtn}
+                  onClick={handleDeny}
+                >
+                  Deny
+                </button>
+                <button
+                  type="button"
+                  className={styles.saveBtn}
+                  onClick={handleConfirm}
+                  disabled={!canSave}
+                >
+                  Confirm
+                </button>
+              </>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  className={styles.cancelBtn}
+                  onClick={onClose}
+                  disabled={isPending}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className={styles.saveBtn}
+                  onClick={handleSave}
+                  disabled={!canSave}
+                >
+                  {isPending ? 'Saving…' : isEdit ? 'Save changes' : 'Save'}
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+      </Modal>
+
+      {/* Barcode scanner renders outside the modal (above it) */}
+      {scanningRowKey !== null && (
+        <BarcodeScanner
+          onDetected={handleBarcodeDetected}
+          onClose={handleBarcodeClose}
+        />
+      )}
+    </>
+  );
+}

--- a/client/src/features/nutrition/NutritionGoalsModal.module.scss
+++ b/client/src/features/nutrition/NutritionGoalsModal.module.scss
@@ -1,0 +1,133 @@
+@import "../../styles/variables";
+
+.modalContent {
+  max-width: 420px !important;
+}
+
+.modal {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 24px 20px 20px;
+
+  @media (max-width: $mobile-width) {
+    padding: 18px 16px 16px;
+    gap: 16px;
+  }
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.title {
+  margin: 0;
+  font-family: $sarabun;
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: $sarabun-spacing;
+  color: $text;
+}
+
+.hint {
+  margin: 0;
+  font-family: $sarabun;
+  font-size: 13px;
+  color: rgba($text, 0.45);
+  letter-spacing: $sarabun-spacing;
+}
+
+.fields {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.label {
+  font-family: $sarabun;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: $sarabun-spacing;
+  color: rgba($text, 0.6);
+  text-transform: uppercase;
+}
+
+.input {
+  background-color: transparent;
+  color: $text;
+  border: none;
+  border-bottom: 2px solid $primary-border;
+  padding: 8px 4px;
+  font-family: $sarabun;
+  font-size: 16px;
+  letter-spacing: $sarabun-spacing;
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 44px;
+
+  &::placeholder {
+    color: rgba($text, 0.3);
+  }
+
+  &:focus {
+    outline: none;
+    border-bottom-color: $primary;
+  }
+}
+
+.errorMsg {
+  margin: 0;
+  font-family: $sarabun;
+  font-size: 14px;
+  color: $error;
+  letter-spacing: $sarabun-spacing;
+}
+
+.footer {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  padding-top: 4px;
+}
+
+%btn-base {
+  min-height: 48px;
+  padding: 10px 24px;
+  border-radius: $border-radius;
+  font-family: $sarabun;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: $sarabun-spacing;
+  cursor: pointer;
+  border: none;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.saveBtn {
+  @extend %btn-base;
+  background-color: $primary;
+  color: $background;
+
+  &:not(:disabled):active {
+    background-color: $primary-dark;
+  }
+}
+
+.cancelBtn {
+  @extend %btn-base;
+  background-color: transparent;
+  color: rgba($text, 0.75);
+  border: 2px solid $surface-border;
+}

--- a/client/src/features/nutrition/NutritionGoalsModal.tsx
+++ b/client/src/features/nutrition/NutritionGoalsModal.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useState } from 'react';
+import Modal from '../../components/Modal.jsx';
+import { useGoals, usePutGoals } from './api';
+import type { Goals } from './types';
+import styles from './NutritionGoalsModal.module.scss';
+
+interface NutritionGoalsModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+// Parse a string input to a number or null.
+// Empty string / whitespace → null (clears the goal).
+// Valid numeric string → the number.
+// Invalid string → null (treat as clear).
+function parseGoalValue(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const n = Number(trimmed);
+  if (!isFinite(n) || n < 0) return null;
+  return n;
+}
+
+export default function NutritionGoalsModal({ open, onClose }: NutritionGoalsModalProps) {
+  const goalsQuery = useGoals();
+  const putGoals = usePutGoals();
+
+  // Local string state so the user can type freely without coercion
+  const [calories, setCalories] = useState('');
+  const [protein, setProtein] = useState('');
+  const [carbs, setCarbs] = useState('');
+  const [fat, setFat] = useState('');
+
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  // Pre-fill form when goals load or modal re-opens
+  useEffect(() => {
+    if (!open) return;
+    const g: Goals = goalsQuery.data ?? {};
+    setCalories(g.calories != null ? String(g.calories) : '');
+    setProtein(g.protein_g != null ? String(g.protein_g) : '');
+    setCarbs(g.carbs_g != null ? String(g.carbs_g) : '');
+    setFat(g.fat_g != null ? String(g.fat_g) : '');
+    setSaveError(null);
+  }, [open, goalsQuery.data]);
+
+  async function handleSave() {
+    setSaveError(null);
+    const goals: Goals = {
+      calories: parseGoalValue(calories),
+      protein_g: parseGoalValue(protein),
+      carbs_g: parseGoalValue(carbs),
+      fat_g: parseGoalValue(fat),
+    };
+    try {
+      await putGoals.mutateAsync(goals);
+      onClose();
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Failed to save goals.';
+      setSaveError(msg);
+    }
+  }
+
+  const isPending = putGoals.isPending;
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={(isOpen: boolean) => { if (!isOpen) onClose(); }}
+      title="Nutrition Goals"
+      showTitle={false}
+      contentClassName={styles.modalContent}
+    >
+      <div className={styles.modal}>
+        <div className={styles.header}>
+          <h2 className={styles.title}>Nutrition Goals</h2>
+        </div>
+
+        <p className={styles.hint}>
+          Leave a field empty to remove that goal.
+        </p>
+
+        <div className={styles.fields}>
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="goal-calories">
+              Calories (kcal)
+            </label>
+            <input
+              id="goal-calories"
+              className={styles.input}
+              type="number"
+              inputMode="numeric"
+              min="0"
+              step="1"
+              placeholder="e.g. 2000"
+              value={calories}
+              onChange={e => setCalories(e.target.value)}
+            />
+          </div>
+
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="goal-protein">
+              Protein (g)
+            </label>
+            <input
+              id="goal-protein"
+              className={styles.input}
+              type="number"
+              inputMode="decimal"
+              min="0"
+              step="1"
+              placeholder="e.g. 150"
+              value={protein}
+              onChange={e => setProtein(e.target.value)}
+            />
+          </div>
+
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="goal-carbs">
+              Carbs (g)
+            </label>
+            <input
+              id="goal-carbs"
+              className={styles.input}
+              type="number"
+              inputMode="decimal"
+              min="0"
+              step="1"
+              placeholder="e.g. 250"
+              value={carbs}
+              onChange={e => setCarbs(e.target.value)}
+            />
+          </div>
+
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="goal-fat">
+              Fat (g)
+            </label>
+            <input
+              id="goal-fat"
+              className={styles.input}
+              type="number"
+              inputMode="decimal"
+              min="0"
+              step="1"
+              placeholder="e.g. 70"
+              value={fat}
+              onChange={e => setFat(e.target.value)}
+            />
+          </div>
+        </div>
+
+        {saveError && (
+          <p className={styles.errorMsg}>{saveError}</p>
+        )}
+
+        <div className={styles.footer}>
+          <button
+            className={styles.cancelBtn}
+            type="button"
+            onClick={onClose}
+            disabled={isPending}
+          >
+            Cancel
+          </button>
+          <button
+            className={styles.saveBtn}
+            type="button"
+            onClick={handleSave}
+            disabled={isPending}
+          >
+            {isPending ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/client/src/features/nutrition/NutritionTracker.module.scss
+++ b/client/src/features/nutrition/NutritionTracker.module.scss
@@ -1,0 +1,379 @@
+@import "../../styles/variables";
+
+// ---- Container ----
+.container {
+  padding: 16px 14px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 680px;
+  margin: 0 auto;
+}
+
+// ---- Date nav ----
+.dateNav {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.arrowBtn {
+  min-width: 44px;
+  min-height: 44px;
+  background: transparent;
+  border: 2px solid rgba($surface-border, 0.7);
+  border-radius: 10px;
+  color: $text;
+  font-size: 18px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+
+  &:active {
+    background-color: rgba($primary, 0.12);
+    border-color: $primary-border;
+  }
+}
+
+.arrowIcon {
+  display: block;
+  width: 18px;
+  height: 18px;
+}
+
+.dateInput {
+  flex: 1;
+  min-height: 44px;
+  background: transparent;
+  color: $text;
+  border: 2px solid rgba($surface-border, 0.7);
+  border-radius: 10px;
+  padding: 8px 12px;
+  font-family: $sarabun;
+  font-size: 16px;
+  letter-spacing: $sarabun-spacing;
+  text-align: center;
+  cursor: pointer;
+
+  &:focus {
+    outline: none;
+    border-color: $primary-border;
+  }
+
+  // Webkit date picker icon color
+  &::-webkit-calendar-picker-indicator {
+    filter: invert(1) opacity(0.4);
+    cursor: pointer;
+  }
+}
+
+// ---- Actions row ----
+.actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.addBtn {
+  flex: 1 1 auto;
+  min-height: 48px;
+  padding: 10px 18px;
+  background-color: $primary;
+  color: $background;
+  border: none;
+  border-radius: $border-radius;
+  font-family: $sarabun;
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: $sarabun-spacing;
+  cursor: pointer;
+
+  &:active {
+    background-color: $primary-dark;
+  }
+}
+
+.aiBtn {
+  flex: 0 1 auto;
+  min-height: 48px;
+  padding: 10px 18px;
+  background-color: transparent;
+  color: rgba($text, 0.4);
+  border: 2px dashed rgba($surface-border, 0.5);
+  border-radius: $border-radius;
+  font-family: $sarabun;
+  font-size: 15px;
+  letter-spacing: $sarabun-spacing;
+  cursor: not-allowed;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.aiBadge {
+  font-size: 11px;
+  background-color: rgba($primary, 0.12);
+  color: rgba($primary, 0.6);
+  border-radius: 6px;
+  padding: 2px 6px;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+}
+
+.settingsBtn {
+  min-width: 48px;
+  min-height: 48px;
+  background: transparent;
+  border: 2px solid rgba($surface-border, 0.7);
+  border-radius: $border-radius;
+  color: rgba($text, 0.75);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:active {
+    background-color: rgba($primary, 0.12);
+    border-color: $primary-border;
+    color: $primary;
+  }
+}
+
+.settingsIcon {
+  display: block;
+  width: 20px;
+  height: 20px;
+}
+
+// ---- Totals card ----
+.totalsCard {
+  background-color: $surface;
+  border-radius: $border-radius;
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.caloriesRow {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.caloriesBig {
+  font-family: $sarabun;
+  font-size: 36px;
+  font-weight: 700;
+  color: $text;
+  letter-spacing: -0.5px;
+  line-height: 1;
+}
+
+.caloriesUnit {
+  font-family: $sarabun;
+  font-size: 15px;
+  color: rgba($text, 0.5);
+  letter-spacing: $sarabun-spacing;
+}
+
+.caloriesGoal {
+  font-family: $sarabun;
+  font-size: 15px;
+  color: rgba($text, 0.5);
+  letter-spacing: $sarabun-spacing;
+}
+
+// ---- Progress bar (shared) ----
+.progressTrack {
+  width: 100%;
+  height: 8px;
+  background-color: rgba($text, 0.1);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.progressFill {
+  height: 100%;
+  border-radius: 4px;
+  background-color: $primary;
+  transition: width 0.3s ease;
+  max-width: 100%;
+}
+
+.progressFillOver {
+  background-color: $error;
+}
+
+// ---- Macros row ----
+.macrosRow {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.macroItem {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.macroHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.macroName {
+  font-family: $sarabun;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: $sarabun-spacing;
+  color: rgba($text, 0.65);
+  text-transform: uppercase;
+}
+
+.macroValue {
+  font-family: $sarabun;
+  font-size: 13px;
+  color: rgba($text, 0.85);
+  letter-spacing: $sarabun-spacing;
+}
+
+// ---- Meal group ----
+.mealGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.mealHeader {
+  font-family: $sarabun;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 1.5px;
+  color: rgba($text, 0.45);
+  text-transform: uppercase;
+  padding: 0 2px;
+}
+
+// ---- Entry row ----
+.entryRow {
+  background-color: $surface;
+  border-radius: 12px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.entryTop {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.entryName {
+  flex: 1;
+  font-family: $sarabun;
+  font-size: 16px;
+  font-weight: 600;
+  color: $text;
+  letter-spacing: $sarabun-spacing;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.entryCalories {
+  font-family: $sarabun;
+  font-size: 15px;
+  font-weight: 700;
+  color: $primary;
+  letter-spacing: $sarabun-spacing;
+  flex-shrink: 0;
+}
+
+.entryBtns {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.editBtn,
+.deleteBtn {
+  min-width: 36px;
+  min-height: 36px;
+  background: transparent;
+  border: 1px solid rgba($surface-border, 0.6);
+  border-radius: 8px;
+  color: rgba($text, 0.5);
+  font-size: 13px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 8px;
+  font-family: $sarabun;
+  letter-spacing: $sarabun-spacing;
+
+  &:active {
+    color: $primary;
+    border-color: $primary-border;
+    background-color: rgba($primary, 0.08);
+  }
+}
+
+.deleteBtn {
+  &:active {
+    color: $error;
+    border-color: rgba($error, 0.5);
+    background-color: rgba($error, 0.08);
+  }
+}
+
+.macroChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.chip {
+  font-family: $sarabun;
+  font-size: 12px;
+  letter-spacing: $sarabun-spacing;
+  color: rgba($text, 0.55);
+  background-color: rgba($text, 0.07);
+  border-radius: 6px;
+  padding: 3px 8px;
+}
+
+// ---- Empty / loading states ----
+.emptyDay {
+  text-align: center;
+  font-family: $sarabun;
+  font-size: 15px;
+  color: rgba($text, 0.4);
+  letter-spacing: $sarabun-spacing;
+  padding: 32px 0 8px;
+}
+
+.errorMsg {
+  font-family: $sarabun;
+  font-size: 14px;
+  color: $error;
+  letter-spacing: $sarabun-spacing;
+  padding: 8px 0;
+}
+
+.loadingMsg {
+  font-family: $sarabun;
+  font-size: 14px;
+  color: rgba($text, 0.5);
+  letter-spacing: $sarabun-spacing;
+  padding: 8px 0;
+}

--- a/client/src/features/nutrition/NutritionTracker.tsx
+++ b/client/src/features/nutrition/NutritionTracker.tsx
@@ -1,0 +1,356 @@
+import { useState } from 'react';
+import { useDay, useGoals, useDeleteEntry } from './api';
+import EntryEditor from './EntryEditor';
+import NutritionGoalsModal from './NutritionGoalsModal';
+import ConfirmModal from '../../components/ConfirmModal.jsx';
+import type { EntryEditorMode, EntryRow } from './types';
+import { MEALS } from './types';
+import styles from './NutritionTracker.module.scss';
+
+// ---- Helpers ----
+
+function getTodayLocalDate(): string {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, '0');
+  const d = String(now.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function shiftDate(dateStr: string, days: number): string {
+  const [y, mo, d] = dateStr.split('-').map(Number);
+  const dt = new Date(y, mo - 1, d + days);
+  const ny = dt.getFullYear();
+  const nm = String(dt.getMonth() + 1).padStart(2, '0');
+  const nd = String(dt.getDate()).padStart(2, '0');
+  return `${ny}-${nm}-${nd}`;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+// ---- Progress bar ----
+
+interface ProgressBarProps {
+  value: number;
+  goal: number;
+  color?: string;
+}
+
+function ProgressBar({ value, goal }: ProgressBarProps) {
+  const pct = goal > 0 ? clamp((value / goal) * 100, 0, 100) : 0;
+  const over = goal > 0 && value > goal;
+  return (
+    <div className={styles.progressTrack}>
+      <div
+        className={`${styles.progressFill} ${over ? styles.progressFillOver : ''}`}
+        style={{ width: `${pct}%` }}
+        role="progressbar"
+        aria-valuenow={Math.round(pct)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+      />
+    </div>
+  );
+}
+
+// ---- Main component ----
+
+export default function NutritionTracker() {
+  const [selectedDate, setSelectedDate] = useState<string>(getTodayLocalDate);
+
+  // Editor state
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editorMode, setEditorMode] = useState<EntryEditorMode>({
+    kind: 'manual-add',
+    date: selectedDate,
+  });
+
+  // Goals modal
+  const [goalsModalOpen, setGoalsModalOpen] = useState(false);
+
+  // Pending delete
+  const [pendingDeleteEntry, setPendingDeleteEntry] = useState<EntryRow | null>(null);
+
+  const dayQuery = useDay(selectedDate);
+  const goalsQuery = useGoals();
+  const deleteMutation = useDeleteEntry(selectedDate);
+
+  const data = dayQuery.data;
+  const goals = goalsQuery.data ?? {};
+
+  // ---- Handlers ----
+
+  function handlePrevDay() {
+    setSelectedDate(prev => shiftDate(prev, -1));
+  }
+
+  function handleNextDay() {
+    setSelectedDate(prev => shiftDate(prev, 1));
+  }
+
+  function openAddEditor() {
+    setEditorMode({ kind: 'manual-add', date: selectedDate });
+    setEditorOpen(true);
+  }
+
+  function openEditEditor(entry: EntryRow) {
+    setEditorMode({ kind: 'manual-edit', date: selectedDate, entry });
+    setEditorOpen(true);
+  }
+
+  function handleEditorClose() {
+    setEditorOpen(false);
+  }
+
+  function handleDeleteConfirm() {
+    if (!pendingDeleteEntry) return;
+    const id = pendingDeleteEntry.id;
+    setPendingDeleteEntry(null);
+    deleteMutation.mutate(id);
+  }
+
+  // ---- Render ----
+
+  const totals = data?.totals;
+  const entries = data?.entries ?? [];
+
+  // Group entries by meal in MEALS order
+  const grouped = MEALS.map(meal => ({
+    meal,
+    entries: entries.filter(e => e.meal === meal),
+  })).filter(g => g.entries.length > 0);
+
+  const mealLabel = (meal: string) =>
+    meal.charAt(0).toUpperCase() + meal.slice(1);
+
+  return (
+    <section className={styles.container}>
+      {/* Date nav */}
+      <div className={styles.dateNav}>
+        <button
+          className={styles.arrowBtn}
+          onClick={handlePrevDay}
+          aria-label="Previous day"
+        >
+          <svg
+            className={styles.arrowIcon}
+            viewBox="0 0 18 18"
+            fill="none"
+            aria-hidden="true"
+          >
+            <path
+              d="M11 4L6 9l5 5"
+              stroke="currentColor"
+              strokeWidth="2.2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+
+        <input
+          className={styles.dateInput}
+          type="date"
+          value={selectedDate}
+          onChange={e => setSelectedDate(e.target.value)}
+          aria-label="Select date"
+        />
+
+        <button
+          className={styles.arrowBtn}
+          onClick={handleNextDay}
+          aria-label="Next day"
+        >
+          <svg
+            className={styles.arrowIcon}
+            viewBox="0 0 18 18"
+            fill="none"
+            aria-hidden="true"
+          >
+            <path
+              d="M7 4l5 5-5 5"
+              stroke="currentColor"
+              strokeWidth="2.2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
+
+      {/* Actions row */}
+      <div className={styles.actions}>
+        <button className={styles.addBtn} onClick={openAddEditor}>
+          + Add food
+        </button>
+
+        <button
+          className={styles.aiBtn}
+          disabled
+          aria-label="Ask AI (coming soon)"
+          title="AI logging coming in Phase 2"
+        >
+          Ask AI
+          <span className={styles.aiBadge}>soon</span>
+        </button>
+
+        <button
+          className={styles.settingsBtn}
+          onClick={() => setGoalsModalOpen(true)}
+          aria-label="Nutrition goals"
+          title="Set nutrition goals"
+        >
+          <svg
+            className={styles.settingsIcon}
+            viewBox="0 0 20 20"
+            fill="none"
+            aria-hidden="true"
+          >
+            <circle cx="10" cy="10" r="2.5" stroke="currentColor" strokeWidth="1.8" />
+            <path
+              d="M10 2v2M10 16v2M2 10h2M16 10h2M4.22 4.22l1.42 1.42M14.36 14.36l1.42 1.42M4.22 15.78l1.42-1.42M14.36 5.64l1.42-1.42"
+              stroke="currentColor"
+              strokeWidth="1.8"
+              strokeLinecap="round"
+            />
+          </svg>
+        </button>
+      </div>
+
+      {/* Totals card */}
+      <div className={styles.totalsCard}>
+        <div className={styles.caloriesRow}>
+          <span className={styles.caloriesBig}>
+            {totals ? Math.round(totals.calories) : 0}
+          </span>
+          <span className={styles.caloriesUnit}>kcal</span>
+          {goals.calories != null && (
+            <span className={styles.caloriesGoal}>
+              / {goals.calories} goal
+            </span>
+          )}
+        </div>
+
+        {/* Calorie progress bar — only if calorie goal set */}
+        {goals.calories != null && totals && (
+          <ProgressBar value={totals.calories} goal={goals.calories} />
+        )}
+
+        {/* Macro bars — only for macros that have a goal */}
+        {totals && (
+          <div className={styles.macrosRow}>
+            {goals.protein_g != null && (
+              <div className={styles.macroItem}>
+                <div className={styles.macroHeader}>
+                  <span className={styles.macroName}>Protein</span>
+                  <span className={styles.macroValue}>
+                    {Math.round(totals.protein_g)}g / {goals.protein_g}g
+                  </span>
+                </div>
+                <ProgressBar value={totals.protein_g} goal={goals.protein_g} />
+              </div>
+            )}
+
+            {goals.carbs_g != null && (
+              <div className={styles.macroItem}>
+                <div className={styles.macroHeader}>
+                  <span className={styles.macroName}>Carbs</span>
+                  <span className={styles.macroValue}>
+                    {Math.round(totals.carbs_g)}g / {goals.carbs_g}g
+                  </span>
+                </div>
+                <ProgressBar value={totals.carbs_g} goal={goals.carbs_g} />
+              </div>
+            )}
+
+            {goals.fat_g != null && (
+              <div className={styles.macroItem}>
+                <div className={styles.macroHeader}>
+                  <span className={styles.macroName}>Fat</span>
+                  <span className={styles.macroValue}>
+                    {Math.round(totals.fat_g)}g / {goals.fat_g}g
+                  </span>
+                </div>
+                <ProgressBar value={totals.fat_g} goal={goals.fat_g} />
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Loading / error */}
+      {dayQuery.isLoading && (
+        <p className={styles.loadingMsg}>Loading…</p>
+      )}
+      {dayQuery.isError && (
+        <p className={styles.errorMsg}>Failed to load entries.</p>
+      )}
+
+      {/* Meal groups */}
+      {!dayQuery.isLoading && !dayQuery.isError && grouped.length === 0 && (
+        <p className={styles.emptyDay}>No food logged for this day. Tap + Add food to start.</p>
+      )}
+
+      {grouped.map(({ meal, entries: mealEntries }) => (
+        <div key={meal} className={styles.mealGroup}>
+          <div className={styles.mealHeader}>{mealLabel(meal)}</div>
+
+          {mealEntries.map(entry => (
+            <div key={entry.id} className={styles.entryRow}>
+              <div className={styles.entryTop}>
+                <span className={styles.entryName}>{entry.name}</span>
+                <span className={styles.entryCalories}>{Math.round(entry.calories)} kcal</span>
+                <div className={styles.entryBtns}>
+                  <button
+                    className={styles.editBtn}
+                    onClick={() => openEditEditor(entry)}
+                    aria-label={`Edit ${entry.name}`}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    className={styles.deleteBtn}
+                    onClick={() => setPendingDeleteEntry(entry)}
+                    aria-label={`Delete ${entry.name}`}
+                  >
+                    ✕
+                  </button>
+                </div>
+              </div>
+
+              <div className={styles.macroChips}>
+                <span className={styles.chip}>{Math.round(entry.protein_g)}g prot</span>
+                <span className={styles.chip}>{Math.round(entry.carbs_g)}g carbs</span>
+                <span className={styles.chip}>{Math.round(entry.fat_g)}g fat</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      ))}
+
+      {/* EntryEditor (always mounted, controlled by open) */}
+      <EntryEditor
+        open={editorOpen}
+        mode={editorMode}
+        onClose={handleEditorClose}
+      />
+
+      {/* Goals modal */}
+      <NutritionGoalsModal
+        open={goalsModalOpen}
+        onClose={() => setGoalsModalOpen(false)}
+      />
+
+      {/* Delete confirmation */}
+      {pendingDeleteEntry !== null && (
+        <ConfirmModal
+          message={`Delete "${pendingDeleteEntry.name}"?`}
+          onConfirm={handleDeleteConfirm}
+          onCancel={() => setPendingDeleteEntry(null)}
+        />
+      )}
+    </section>
+  );
+}

--- a/client/src/features/nutrition/api.ts
+++ b/client/src/features/nutrition/api.ts
@@ -1,0 +1,97 @@
+// React Query hooks + imperative helpers for the Nutrition feature.
+// All calls go through the shared axios instance (same-origin /api base) and
+// unwrap the backend's { data, message } envelope.
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import clientApi from '../../api/clientApi.js';
+import type {
+  DayResponse,
+  EntryInput,
+  EntryRow,
+  Goals,
+  FoodSearchResult,
+} from './types';
+
+export const nutritionKeys = {
+  day: (date: string) => ['nutrition', 'day', date] as const,
+  goals: ['nutrition', 'goals'] as const,
+};
+
+export function useDay(date: string) {
+  return useQuery({
+    queryKey: nutritionKeys.day(date),
+    queryFn: async (): Promise<DayResponse> => {
+      const res = await clientApi.get(`/nutrition/day/${date}`);
+      return res.data.data;
+    },
+    enabled: !!date,
+  });
+}
+
+export function useGoals() {
+  return useQuery({
+    queryKey: nutritionKeys.goals,
+    queryFn: async (): Promise<Goals> => {
+      const res = await clientApi.get('/nutrition/goals');
+      return res.data.data;
+    },
+  });
+}
+
+export function usePutGoals() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (goals: Goals): Promise<Goals> => {
+      const res = await clientApi.put('/nutrition/goals', goals);
+      return res.data.data;
+    },
+    onSuccess: (data) => qc.setQueryData(nutritionKeys.goals, data),
+  });
+}
+
+export function useCreateEntry(date: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: EntryInput): Promise<{ id: number; totals: EntryRow }> => {
+      const res = await clientApi.post('/nutrition/entries', input);
+      return res.data.data;
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: nutritionKeys.day(date) }),
+  });
+}
+
+export function useUpdateEntry(date: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, input }: { id: number; input: EntryInput }): Promise<EntryRow> => {
+      const res = await clientApi.patch(`/nutrition/entries/${id}`, input);
+      return res.data.data;
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: nutritionKeys.day(date) }),
+  });
+}
+
+export function useDeleteEntry(date: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: number): Promise<void> => {
+      await clientApi.delete(`/nutrition/entries/${id}`);
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: nutritionKeys.day(date) }),
+  });
+}
+
+// Imperative helpers (used by the editor for search-as-you-type & barcode scan).
+export async function searchFoods(query: string): Promise<FoodSearchResult[]> {
+  const res = await clientApi.get('/nutrition/foods/search', { params: { q: query } });
+  return res.data.data;
+}
+
+export async function lookupBarcode(code: string): Promise<FoodSearchResult | null> {
+  try {
+    const res = await clientApi.get(`/nutrition/barcode/${code}`);
+    return res.data.data;
+  } catch (err: any) {
+    if (err?.response?.status === 404) return null;
+    throw err;
+  }
+}

--- a/client/src/features/nutrition/types.ts
+++ b/client/src/features/nutrition/types.ts
@@ -1,0 +1,107 @@
+// Client-side mirror of the backend contract in main/workout-log/schemas/nutrition.ts.
+// Kept in sync by hand (the client is a separate Vite/TS project).
+
+export type Meal = 'breakfast' | 'lunch' | 'dinner' | 'snack';
+export type EntrySource = 'manual' | 'text' | 'photo' | 'barcode' | 'mixed';
+export type IngredientSource = 'usda' | 'off' | 'manual';
+
+export const MEALS: Meal[] = ['breakfast', 'lunch', 'dinner', 'snack'];
+
+export interface Per100g {
+  calories: number;
+  protein_g: number;
+  carbs_g: number;
+  fat_g: number;
+  fiber_g?: number | null;
+  sugar_g?: number | null;
+  sodium_mg?: number | null;
+}
+
+export interface FoodSearchResult {
+  name: string;
+  source: 'usda' | 'off';
+  source_ref: string;
+  per100g: Per100g;
+  serving_grams?: number | null;
+}
+
+export interface IngredientInput {
+  name: string;
+  grams: number;
+  source: IngredientSource;
+  source_ref?: string | null;
+  calories: number;
+  protein_g: number;
+  carbs_g: number;
+  fat_g: number;
+}
+export interface IngredientRow extends IngredientInput {
+  id: number;
+}
+
+export interface EntryInput {
+  localDate: string; // YYYY-MM-DD
+  meal: Meal;
+  name: string;
+  source: EntrySource;
+  barcode?: string | null;
+  raw_llm_json?: unknown;
+  ingredients: IngredientInput[];
+}
+
+export interface EntryRow {
+  id: number;
+  date: string; // YYYY-MM-DD
+  logged_at: string;
+  meal: Meal;
+  name: string;
+  source: EntrySource;
+  calories: number;
+  protein_g: number;
+  carbs_g: number;
+  fat_g: number;
+  fiber_g: number | null;
+  sugar_g: number | null;
+  sodium_mg: number | null;
+  barcode: string | null;
+  ingredients: IngredientRow[];
+}
+
+export interface DayTotals {
+  calories: number;
+  protein_g: number;
+  carbs_g: number;
+  fat_g: number;
+  fiber_g: number;
+  sugar_g: number;
+  sodium_mg: number;
+}
+export interface DayResponse {
+  date: string;
+  totals: DayTotals;
+  entries: EntryRow[];
+}
+
+export interface Goals {
+  calories?: number | null;
+  protein_g?: number | null;
+  carbs_g?: number | null;
+  fat_g?: number | null;
+}
+
+// ---- EntryEditor props contract (S2 implements the component) ----
+// Phase 1 implements 'manual-add' and 'manual-edit'. 'proposal' is wired in Phase 2.
+export type EntryEditorMode =
+  | { kind: 'manual-add'; date: string; defaultMeal?: Meal }
+  | { kind: 'manual-edit'; date: string; entry: EntryRow }
+  | { kind: 'proposal'; date: string; proposal: EntryInput };
+
+export interface EntryEditorProps {
+  open: boolean;
+  mode: EntryEditorMode;
+  onClose: () => void;
+  // Manual modes save via the api hooks internally, then call onClose.
+  // Proposal mode (Phase 2) calls these instead of saving directly:
+  onConfirm?: (input: EntryInput) => void;
+  onDeny?: () => void;
+}

--- a/client/src/pages/Workouts.jsx
+++ b/client/src/pages/Workouts.jsx
@@ -2,6 +2,7 @@ import Section from '../components/Section.jsx';
 import AddSection from '../components/AddSection.jsx';
 import BodyWeightTracker from '../components/BodyWeightTracker.jsx';
 import HabitTracker from '../components/HabitTracker.jsx';
+import NutritionTracker from '../features/nutrition/NutritionTracker';
 import { useState, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import styles from "../styles/Workouts.module.scss";
@@ -14,6 +15,7 @@ const TABS = {
   WORKOUTS: 'workouts',
   BODY_WEIGHT: 'body-weight',
   HABITS: 'habits',
+  NUTRITION: 'nutrition',
 };
 
 const VALID_TABS = new Set(Object.values(TABS));
@@ -82,6 +84,12 @@ function Workouts() {
               >
                 Habits
               </button>
+              <button
+                className={`${styles.tab} ${activeTab === TABS.NUTRITION ? styles.tabActive : ''}`}
+                onClick={() => switchTab(TABS.NUTRITION)}
+              >
+                Nutrition
+              </button>
             </>
           )}
         </nav>
@@ -107,6 +115,12 @@ function Workouts() {
         {user && (
           <div style={{ display: activeTab === TABS.HABITS ? undefined : 'none' }}>
             <HabitTracker />
+          </div>
+        )}
+
+        {user && (
+          <div style={{ display: activeTab === TABS.NUTRITION ? undefined : 'none' }}>
+            <NutritionTracker />
           </div>
         )}
       </main>

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -1,0 +1,14 @@
+/// <reference types="vite/client" />
+
+// Allow TypeScript to import *.module.scss files in .tsx files.
+// The JSX files use allowJs + checkJs:false so they don't need this;
+// new .tsx files do.
+declare module '*.module.scss' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}
+
+declare module '*.scss' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}

--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,7 @@ import variations from './routes/variations';
 import auth from './routes/auth';
 import bodyWeight from './routes/bodyWeight';
 import habits from './routes/habits';
+import nutrition from './routes/nutrition';
 import apiV1 from './routes/apiV1';
 
 dotenv.config();
@@ -33,6 +34,7 @@ app.use('/api/movements', movements);
 app.use('/api/variations', variations);
 app.use('/api/body-weight', bodyWeight);
 app.use('/api/habits', habits);
+app.use('/api/nutrition', nutrition);
 app.use('/api/v1', apiV1);
 
 app.get('/api', (req, res) => {

--- a/migrations/007_nutrition.sql
+++ b/migrations/007_nutrition.sql
@@ -1,0 +1,47 @@
+-- Nutrition tracker (Peak 4th tab). Mirrors existing table conventions:
+-- INT AUTO_INCREMENT PK, user_uuid BINARY(16), no FK (ownership enforced in SQL),
+-- user's LOCAL date stored as DATE. migrate.js tolerates 1050/1060 so re-runs are safe.
+
+CREATE TABLE IF NOT EXISTS food_entries (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_uuid BINARY(16) NOT NULL,
+  date DATE NOT NULL,                       -- user's LOCAL date (client localDate)
+  logged_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  meal ENUM('breakfast','lunch','dinner','snack') NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  source ENUM('manual','text','photo','barcode','mixed') NOT NULL,
+  calories FLOAT NOT NULL DEFAULT 0,
+  protein_g FLOAT NOT NULL DEFAULT 0,
+  carbs_g FLOAT NOT NULL DEFAULT 0,
+  fat_g FLOAT NOT NULL DEFAULT 0,
+  fiber_g FLOAT NULL,
+  sugar_g FLOAT NULL,
+  sodium_mg FLOAT NULL,
+  barcode VARCHAR(32) NULL,
+  raw_llm_json JSON NULL,                    -- only set for agent-created entries
+  KEY idx_user_date (user_uuid, date),
+  FULLTEXT KEY ft_name (name)                -- memory: search past meals by name
+);
+
+CREATE TABLE IF NOT EXISTS food_entry_ingredients (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  entry_id INT NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  grams FLOAT NOT NULL,
+  source ENUM('usda','off','manual') NOT NULL,
+  source_ref VARCHAR(64) NULL,              -- USDA fdcId or OFF barcode
+  calories FLOAT NOT NULL DEFAULT 0,        -- contribution of THIS row at its grams
+  protein_g FLOAT NOT NULL DEFAULT 0,
+  carbs_g FLOAT NOT NULL DEFAULT 0,
+  fat_g FLOAT NOT NULL DEFAULT 0,
+  KEY idx_entry (entry_id)
+);
+
+CREATE TABLE IF NOT EXISTS nutrition_goals (
+  user_uuid BINARY(16) NOT NULL PRIMARY KEY,
+  calories FLOAT NULL,
+  protein_g FLOAT NULL,
+  carbs_g FLOAT NULL,
+  fat_g FLOAT NULL,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);

--- a/routes/nutrition.ts
+++ b/routes/nutrition.ts
@@ -1,0 +1,154 @@
+import { Router } from 'express';
+import { authenticateToken } from './auth';
+import { validateId } from '../utils/validation';
+import handleSqlError from '../utils/handleSqlError';
+import { User } from '../types';
+import { entryInputSchema, goalsSchema } from '../schemas/nutrition';
+import * as store from '../services/nutrition/store';
+import { searchFoods, lookupBarcode } from '../services/nutrition/providers';
+
+const router = Router();
+router.use(authenticateToken);
+
+// GET /day/:date — full day view
+router.get('/day/:date', async (req, res): Promise<any> => {
+  const { uuid }: User = res.locals.user;
+  const { date } = req.params;
+
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return res.status(400).json({ message: 'date must be in YYYY-MM-DD format' });
+  }
+
+  try {
+    const data = await store.getDay(uuid, date);
+    return res.status(200).json({ data, message: `Successfully retrieved nutrition for ${date}` });
+  } catch (error) {
+    return handleSqlError(error, res);
+  }
+});
+
+// POST /entries — create entry
+router.post('/entries', async (req, res): Promise<any> => {
+  const { uuid }: User = res.locals.user;
+  const parsed = entryInputSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ message: parsed.error.issues[0]?.message ?? 'Invalid request body' });
+  }
+
+  try {
+    const { id, totals } = await store.createEntry(uuid, parsed.data);
+    return res.status(201).json({ data: { ...totals, id }, message: 'Entry created' });
+  } catch (error) {
+    return handleSqlError(error, res);
+  }
+});
+
+// GET /entries/:id — single entry
+router.get('/entries/:id', async (req, res): Promise<any> => {
+  const { uuid }: User = res.locals.user;
+  if (!validateId(req.params.id, res)) return;
+  const id = Number(req.params.id);
+
+  try {
+    const data = await store.getEntry(uuid, id);
+    if (!data) return res.status(404).json({ message: `Entry ${id} not found` });
+    return res.status(200).json({ data, message: `Successfully retrieved entry ${id}` });
+  } catch (error) {
+    return handleSqlError(error, res);
+  }
+});
+
+// PATCH /entries/:id — update entry
+router.patch('/entries/:id', async (req, res): Promise<any> => {
+  const { uuid }: User = res.locals.user;
+  if (!validateId(req.params.id, res)) return;
+  const id = Number(req.params.id);
+
+  const parsed = entryInputSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ message: parsed.error.issues[0]?.message ?? 'Invalid request body' });
+  }
+
+  try {
+    const data = await store.updateEntry(uuid, id, parsed.data);
+    if (!data) return res.status(404).json({ message: `Entry ${id} not found` });
+    return res.status(200).json({ data, message: `Entry ${id} updated` });
+  } catch (error) {
+    return handleSqlError(error, res);
+  }
+});
+
+// DELETE /entries/:id
+router.delete('/entries/:id', async (req, res): Promise<any> => {
+  const { uuid }: User = res.locals.user;
+  if (!validateId(req.params.id, res)) return;
+  const id = Number(req.params.id);
+
+  try {
+    const deleted = await store.deleteEntry(uuid, id);
+    if (!deleted) return res.status(404).json({ message: `Entry ${id} not found` });
+    return res.status(200).json({ message: `Entry ${id} deleted` });
+  } catch (error) {
+    return handleSqlError(error, res);
+  }
+});
+
+// GET /foods/search?q=...
+router.get('/foods/search', async (req, res): Promise<any> => {
+  const q = (req.query.q ?? '') as string;
+  if (!q.trim()) {
+    return res.status(400).json({ message: 'Query parameter q is required' });
+  }
+
+  try {
+    const data = await searchFoods(q.trim());
+    return res.status(200).json({ data, message: `Found ${data.length} result(s)` });
+  } catch (error) {
+    return handleSqlError(error, res);
+  }
+});
+
+// GET /barcode/:code
+router.get('/barcode/:code', async (req, res): Promise<any> => {
+  const { code } = req.params;
+  if (!/^\d+$/.test(code)) {
+    return res.status(400).json({ message: 'Barcode must contain digits only' });
+  }
+
+  try {
+    const data = await lookupBarcode(code);
+    if (!data) return res.status(404).json({ message: `Product with barcode ${code} not found` });
+    return res.status(200).json({ data, message: `Found product for barcode ${code}` });
+  } catch (error) {
+    return handleSqlError(error, res);
+  }
+});
+
+// GET /goals
+router.get('/goals', async (req, res): Promise<any> => {
+  const { uuid }: User = res.locals.user;
+  try {
+    const data = await store.getGoals(uuid);
+    return res.status(200).json({ data, message: 'Successfully retrieved nutrition goals' });
+  } catch (error) {
+    return handleSqlError(error, res);
+  }
+});
+
+// PUT /goals
+router.put('/goals', async (req, res): Promise<any> => {
+  const { uuid }: User = res.locals.user;
+  const parsed = goalsSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ message: parsed.error.issues[0]?.message ?? 'Invalid request body' });
+  }
+
+  try {
+    const data = await store.putGoals(uuid, parsed.data);
+    return res.status(200).json({ data, message: 'Goals saved' });
+  } catch (error) {
+    return handleSqlError(error, res);
+  }
+});
+
+export default router;

--- a/schemas/nutrition.ts
+++ b/schemas/nutrition.ts
@@ -1,0 +1,105 @@
+// Shared contract for the Nutrition feature: zod request schemas + TypeScript
+// row/response types. Backend validates requests with these; the client mirrors
+// the types in client/src/features/nutrition/types.ts (kept in sync by hand —
+// the two npm projects don't share a tsconfig).
+import { z } from 'zod';
+
+export const MEALS = ['breakfast', 'lunch', 'dinner', 'snack'] as const;
+export const ENTRY_SOURCES = ['manual', 'text', 'photo', 'barcode', 'mixed'] as const;
+export const INGREDIENT_SOURCES = ['usda', 'off', 'manual'] as const;
+
+// Per-100g nutrient profile returned by food search / barcode lookup.
+export const per100gSchema = z.object({
+  calories: z.number().nonnegative(),
+  protein_g: z.number().nonnegative(),
+  carbs_g: z.number().nonnegative(),
+  fat_g: z.number().nonnegative(),
+  fiber_g: z.number().nonnegative().nullable().optional(),
+  sugar_g: z.number().nonnegative().nullable().optional(),
+  sodium_mg: z.number().nonnegative().nullable().optional(),
+});
+
+// One ingredient row as sent by the client. Macros are the contribution at
+// `grams` (client computes per100g * grams/100, or types them for manual rows).
+export const ingredientInputSchema = z.object({
+  name: z.string().min(1).max(255),
+  grams: z.number().positive(),
+  source: z.enum(INGREDIENT_SOURCES),
+  source_ref: z.string().max(64).nullable().optional(),
+  calories: z.number().nonnegative(),
+  protein_g: z.number().nonnegative(),
+  carbs_g: z.number().nonnegative(),
+  fat_g: z.number().nonnegative(),
+});
+
+// Create/replace an entry (POST /entries, PATCH /entries/:id share this shape).
+export const entryInputSchema = z.object({
+  localDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  meal: z.enum(MEALS),
+  name: z.string().min(1).max(255),
+  source: z.enum(ENTRY_SOURCES),
+  barcode: z.string().max(32).nullable().optional(),
+  raw_llm_json: z.unknown().nullable().optional(),
+  ingredients: z.array(ingredientInputSchema).min(1),
+});
+
+// PUT /goals — every field optional/nullable (clear a goal by sending null).
+export const goalsSchema = z.object({
+  calories: z.number().nonnegative().nullable().optional(),
+  protein_g: z.number().nonnegative().nullable().optional(),
+  carbs_g: z.number().nonnegative().nullable().optional(),
+  fat_g: z.number().nonnegative().nullable().optional(),
+});
+
+export const foodSearchResultSchema = z.object({
+  name: z.string(),
+  source: z.enum(['usda', 'off']),
+  source_ref: z.string(),
+  per100g: per100gSchema,
+  serving_grams: z.number().positive().nullable().optional(),
+});
+
+export type Meal = (typeof MEALS)[number];
+export type EntrySource = (typeof ENTRY_SOURCES)[number];
+export type IngredientSource = (typeof INGREDIENT_SOURCES)[number];
+export type Per100g = z.infer<typeof per100gSchema>;
+export type IngredientInput = z.infer<typeof ingredientInputSchema>;
+export type EntryInput = z.infer<typeof entryInputSchema>;
+export type Goals = z.infer<typeof goalsSchema>;
+export type FoodSearchResult = z.infer<typeof foodSearchResultSchema>;
+
+// ---- DB row / response shapes returned to the client ----
+export interface IngredientRow extends IngredientInput {
+  id: number;
+}
+export interface EntryRow {
+  id: number;
+  date: string; // YYYY-MM-DD (normalize mysql2 DATE with String(x).slice(0,10))
+  logged_at: string;
+  meal: Meal;
+  name: string;
+  source: EntrySource;
+  calories: number;
+  protein_g: number;
+  carbs_g: number;
+  fat_g: number;
+  fiber_g: number | null;
+  sugar_g: number | null;
+  sodium_mg: number | null;
+  barcode: string | null;
+  ingredients: IngredientRow[];
+}
+export interface DayTotals {
+  calories: number;
+  protein_g: number;
+  carbs_g: number;
+  fat_g: number;
+  fiber_g: number;
+  sugar_g: number;
+  sodium_mg: number;
+}
+export interface DayResponse {
+  date: string;
+  totals: DayTotals;
+  entries: EntryRow[];
+}

--- a/services/nutrition/providers.ts
+++ b/services/nutrition/providers.ts
@@ -1,0 +1,254 @@
+// External nutrition data providers: USDA FoodData Central + Open Food Facts.
+// Uses native fetch (Node 23). No external HTTP dep.
+//
+// CONTRACT (signatures fixed in design; S1 fills in the bodies):
+//   - searchFoods: query USDA FDC foods/search (api key from process.env.USDA_FDC_API_KEY,
+//     dataType=Foundation,SR Legacy,Survey (FNDDS), pageSize=5), map the best matches to
+//     FoodSearchResult via a lightweight token-overlap scorer (normalize, Dice/Jaccard,
+//     bonus for Foundation/SR Legacy, penalty for very long descriptions); fall back to an
+//     OFF text search if FDC returns nothing. Extract per-100g macros by nutrient number
+//     (Energy 1008, Protein 1003, Carbs 1005, Fat 1004, Fiber 1079, Sugars 2000, Sodium 1093).
+//     In-memory cache keyed by fdcId. Never throw on a single bad match — return [].
+//   - lookupBarcode: GET https://world.openfoodfacts.org/api/v2/product/<code>.json
+//     (send a descriptive User-Agent). Return null when status:0 (not found).
+import { FoodSearchResult } from '../../schemas/nutrition';
+
+const USER_AGENT = 'WorkoutLogApp/1.0 (nutrition tracker; contact: admin@example.com)';
+
+// In-memory cache: source_ref → FoodSearchResult
+const cache = new Map<string, FoodSearchResult>();
+
+/** Normalize a string to a set of lowercase tokens. */
+function tokenize(str: string): Set<string> {
+  const tokens = str
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter((t) => t.length > 1);
+  return new Set(tokens);
+}
+
+/** Dice coefficient between two token sets. */
+function diceScore(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 1;
+  if (a.size === 0 || b.size === 0) return 0;
+  let intersection = 0;
+  for (const t of a) {
+    if (b.has(t)) intersection++;
+  }
+  return (2 * intersection) / (a.size + b.size);
+}
+
+/** Score a food name against the query tokens. Higher is better. */
+function scoreResult(name: string, queryTokens: Set<string>, dataType?: string): number {
+  const nameTokens = tokenize(name);
+  let score = diceScore(queryTokens, nameTokens);
+  // bonus for preferred data types
+  if (dataType === 'Foundation' || dataType === 'SR Legacy') score += 0.1;
+  // penalty for very long descriptions (likely composite or branded)
+  if (name.length > 80) score -= 0.1;
+  return score;
+}
+
+type NutrientMap = Record<number, number | null>;
+
+/** Extract macros by USDA nutrientId (Energy 1008, Protein 1003, Carbs 1005, Fat 1004,
+ *  Fiber 1079, Sugars 2000, Sodium 1093). NB: these are nutrient IDs — NOT nutrientNumber,
+ *  which uses the legacy codes "208"/"203"/"205"/"204" and would never match. */
+function extractNutrients(nutrients: Array<{ nutrientId?: number; value?: number }>): NutrientMap {
+  const map: NutrientMap = { 1008: null, 1003: null, 1005: null, 1004: null, 1079: null, 2000: null, 1093: null };
+  for (const n of nutrients) {
+    const id = n.nutrientId;
+    if (id !== undefined && id in map && n.value !== undefined && n.value !== null) {
+      map[id] = n.value;
+    }
+  }
+  return map;
+}
+
+/** Map USDA food item to FoodSearchResult. Returns null if essential macros missing. */
+function mapUsdaFood(food: any, queryTokens: Set<string>): FoodSearchResult | null {
+  try {
+    const name: string = food.description ?? '';
+    const nutrients: Array<{ nutrientId?: number; value?: number }> = food.foodNutrients ?? [];
+    const nm = extractNutrients(nutrients);
+
+    // Require energy; treat a MISSING macro as 0 (USDA omits legitimately-zero
+    // nutrients, e.g. carbs on raw chicken — don't drop the whole food for that).
+    const calories = nm[1008];
+    if (calories === null) return null;
+    const protein = nm[1003] ?? 0;
+    const carbs = nm[1005] ?? 0;
+    const fat = nm[1004] ?? 0;
+
+    const sourceRef = String(food.fdcId);
+    const result: FoodSearchResult = {
+      name,
+      source: 'usda',
+      source_ref: sourceRef,
+      per100g: {
+        calories,
+        protein_g: protein,
+        carbs_g: carbs,
+        fat_g: fat,
+        fiber_g: nm[1079] ?? null,
+        sugar_g: nm[2000] ?? null,
+        // USDA sodium in mg/100g already
+        sodium_mg: nm[1093] !== null ? nm[1093]! : null,
+      },
+      serving_grams: food.servingSize ?? null,
+    };
+
+    // cache by source_ref
+    cache.set(sourceRef, result);
+    return result;
+  } catch {
+    return null;
+  }
+}
+
+/** OFF text search fallback. */
+async function searchOFF(query: string): Promise<FoodSearchResult[]> {
+  try {
+    const url =
+      `https://world.openfoodfacts.org/cgi/search.pl?search_terms=${encodeURIComponent(query)}` +
+      `&search_simple=1&action=process&json=1&page_size=5&fields=product_name,nutriments,serving_quantity`;
+    const resp = await fetch(url, {
+      headers: { 'User-Agent': USER_AGENT },
+      signal: AbortSignal.timeout(8000),
+    });
+    if (!resp.ok) return [];
+    const data: any = await resp.json();
+    const products: any[] = data.products ?? [];
+    const results: FoodSearchResult[] = [];
+
+    for (const p of products) {
+      try {
+        const name: string = p.product_name ?? '';
+        if (!name) continue;
+        const n = p.nutriments ?? {};
+        const calories = n['energy-kcal_100g'] ?? n['energy_100g'];
+        if (calories === undefined || calories === null) continue;
+        const sourceRef = p.id ?? p._id ?? `off-${encodeURIComponent(name)}`;
+        const result: FoodSearchResult = {
+          name,
+          source: 'off',
+          source_ref: String(sourceRef),
+          per100g: {
+            calories: Number(calories),
+            protein_g: Number(n['proteins_100g'] ?? 0),
+            carbs_g: Number(n['carbohydrates_100g'] ?? 0),
+            fat_g: Number(n['fat_100g'] ?? 0),
+            fiber_g: n['fiber_100g'] != null ? Number(n['fiber_100g']) : null,
+            sugar_g: n['sugars_100g'] != null ? Number(n['sugars_100g']) : null,
+            // OFF sodium is in g/100g; convert to mg
+            sodium_mg: n['sodium_100g'] != null ? Number(n['sodium_100g']) * 1000 : null,
+          },
+          serving_grams: p.serving_quantity ? Number(p.serving_quantity) : null,
+        };
+        cache.set(String(sourceRef), result);
+        results.push(result);
+      } catch {
+        // skip bad product
+      }
+    }
+    return results;
+  } catch {
+    return [];
+  }
+}
+
+/** One USDA FDC search attempt → mapped + ranked results (empty on any failure). */
+async function searchUsdaOnce(
+  query: string,
+  apiKey: string,
+  queryTokens: Set<string>,
+): Promise<FoodSearchResult[]> {
+  try {
+    const url =
+      `https://api.nal.usda.gov/fdc/v1/foods/search?api_key=${encodeURIComponent(apiKey)}` +
+      `&query=${encodeURIComponent(query)}` +
+      `&dataType=Foundation,SR%20Legacy,Survey%20(FNDDS)&pageSize=10`;
+    const resp = await fetch(url, {
+      headers: { 'User-Agent': USER_AGENT },
+      signal: AbortSignal.timeout(8000),
+    });
+    if (!resp.ok) return [];
+    const data: any = await resp.json();
+    const foods: any[] = data.foods ?? [];
+    const mapped: Array<{ result: FoodSearchResult; score: number }> = [];
+    for (const food of foods) {
+      const result = mapUsdaFood(food, queryTokens);
+      if (!result) continue;
+      mapped.push({ result, score: scoreResult(result.name, queryTokens, food.dataType) });
+    }
+    mapped.sort((a, b) => b.score - a.score);
+    return mapped.slice(0, 5).map((m) => m.result);
+  } catch {
+    return [];
+  }
+}
+
+/** USDA + OFF text search → ranked candidate foods with per-100g macros. */
+export async function searchFoods(query: string): Promise<FoodSearchResult[]> {
+  const apiKey = process.env.USDA_FDC_API_KEY ?? 'DEMO_KEY';
+  const queryTokens = tokenize(query);
+
+  // USDA FDC search is intermittently flaky/rate-limited — retry once on empty
+  // before falling back to Open Food Facts (which is weak for generic whole foods).
+  let results = await searchUsdaOnce(query, apiKey, queryTokens);
+  if (results.length === 0) {
+    await new Promise((r) => setTimeout(r, 250));
+    results = await searchUsdaOnce(query, apiKey, queryTokens);
+  }
+  if (results.length === 0) {
+    results = await searchOFF(query);
+  }
+  return results;
+}
+
+/** Open Food Facts barcode lookup → product as a FoodSearchResult, or null if not found. */
+export async function lookupBarcode(code: string): Promise<FoodSearchResult | null> {
+  // Check cache first
+  const cached = cache.get(`off-barcode-${code}`);
+  if (cached) return cached;
+
+  try {
+    const url = `https://world.openfoodfacts.org/api/v2/product/${encodeURIComponent(code)}.json?fields=product_name,nutriments,serving_quantity`;
+    const resp = await fetch(url, {
+      headers: { 'User-Agent': USER_AGENT },
+      signal: AbortSignal.timeout(8000),
+    });
+    if (!resp.ok) return null;
+    const data: any = await resp.json();
+    if (data.status === 0 || !data.product) return null;
+
+    const p = data.product;
+    const name: string = p.product_name ?? '';
+    const n = p.nutriments ?? {};
+    const caloriesRaw = n['energy-kcal_100g'] ?? n['energy_100g'];
+    if (caloriesRaw === undefined || caloriesRaw === null) return null;
+
+    const result: FoodSearchResult = {
+      name: name || `Product ${code}`,
+      source: 'off',
+      source_ref: code,
+      per100g: {
+        calories: Number(caloriesRaw),
+        protein_g: Number(n['proteins_100g'] ?? 0),
+        carbs_g: Number(n['carbohydrates_100g'] ?? 0),
+        fat_g: Number(n['fat_100g'] ?? 0),
+        fiber_g: n['fiber_100g'] != null ? Number(n['fiber_100g']) : null,
+        sugar_g: n['sugars_100g'] != null ? Number(n['sugars_100g']) : null,
+        // OFF sodium is g/100g → mg
+        sodium_mg: n['sodium_100g'] != null ? Number(n['sodium_100g']) * 1000 : null,
+      },
+      serving_grams: p.serving_quantity ? Number(p.serving_quantity) : null,
+    };
+
+    cache.set(`off-barcode-${code}`, result);
+    return result;
+  } catch {
+    return null;
+  }
+}

--- a/services/nutrition/store.ts
+++ b/services/nutrition/store.ts
@@ -1,0 +1,288 @@
+// Nutrition data access — the single place that touches the food_* / nutrition_goals
+// tables. Called by BOTH routes/nutrition.ts and (Phase 2) the agent tools.
+//
+// CONTRACT (signatures fixed in design; S1 fills in the bodies):
+//   - Use the mysql2 promise pool from ../../database and utils/withTransaction
+//     for multi-table writes (entry + ingredients).
+//   - Scope every query to the user: `WHERE user_uuid = UUID_TO_BIN(?)`.
+//   - Entry-level totals are RECOMPUTED server-side as the SUM of the entry's
+//     ingredient rows (do not trust a client-sent entry total).
+//   - Normalize DATE columns to 'YYYY-MM-DD' before returning.
+import { RowDataPacket, ResultSetHeader } from 'mysql2';
+import pool from '../../database';
+import withTransaction from '../../utils/withTransaction';
+import { EntryInput, EntryRow, DayResponse, Goals, IngredientRow } from '../../schemas/nutrition';
+
+/** Sum ingredient macros to produce entry-level totals. */
+function sumIngredients(ingredients: IngredientInput[]): {
+  calories: number; protein_g: number; carbs_g: number; fat_g: number;
+} {
+  return ingredients.reduce(
+    (acc, ing) => ({
+      calories: acc.calories + ing.calories,
+      protein_g: acc.protein_g + ing.protein_g,
+      carbs_g: acc.carbs_g + ing.carbs_g,
+      fat_g: acc.fat_g + ing.fat_g,
+    }),
+    { calories: 0, protein_g: 0, carbs_g: 0, fat_g: 0 },
+  );
+}
+
+type IngredientInput = { calories: number; protein_g: number; carbs_g: number; fat_g: number };
+
+/** Fetch ingredients for a given entry id using the provided connection or pool. */
+async function fetchIngredients(entryId: number): Promise<IngredientRow[]> {
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `SELECT id, name, grams, source, source_ref, calories, protein_g, carbs_g, fat_g
+     FROM food_entry_ingredients
+     WHERE entry_id = ?
+     ORDER BY id ASC`,
+    [entryId],
+  );
+  return rows as IngredientRow[];
+}
+
+/** Day view: overall totals + entries (each with ingredients) for one local date. */
+export async function getDay(userUuid: string, date: string): Promise<DayResponse> {
+  const [entryRows] = await pool.query<RowDataPacket[]>(
+    `SELECT id, BIN_TO_UUID(user_uuid) as user_uuid, date, logged_at, meal, name, source,
+            calories, protein_g, carbs_g, fat_g, fiber_g, sugar_g, sodium_mg, barcode
+     FROM food_entries
+     WHERE user_uuid = UUID_TO_BIN(?) AND date = ?
+     ORDER BY logged_at ASC`,
+    [userUuid, date],
+  );
+
+  const entries: EntryRow[] = [];
+  for (const row of entryRows) {
+    const ingredients = await fetchIngredients(row.id as number);
+    const totals = sumIngredients(ingredients);
+    entries.push({
+      id: row.id as number,
+      date: (row.date instanceof Date ? row.date.toISOString() : String(row.date)).slice(0, 10),
+      logged_at: row.logged_at as string,
+      meal: row.meal,
+      name: row.name,
+      source: row.source,
+      calories: totals.calories,
+      protein_g: totals.protein_g,
+      carbs_g: totals.carbs_g,
+      fat_g: totals.fat_g,
+      fiber_g: null,
+      sugar_g: null,
+      sodium_mg: null,
+      barcode: row.barcode ?? null,
+      ingredients,
+    });
+  }
+
+  const dayTotals = {
+    calories: entries.reduce((s, e) => s + e.calories, 0),
+    protein_g: entries.reduce((s, e) => s + e.protein_g, 0),
+    carbs_g: entries.reduce((s, e) => s + e.carbs_g, 0),
+    fat_g: entries.reduce((s, e) => s + e.fat_g, 0),
+    fiber_g: 0,
+    sugar_g: 0,
+    sodium_mg: 0,
+  };
+
+  return { date, totals: dayTotals, entries };
+}
+
+/** Single entry with its ingredients, or null if not found / not owned. */
+export async function getEntry(userUuid: string, id: number): Promise<EntryRow | null> {
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `SELECT id, date, logged_at, meal, name, source, calories, protein_g, carbs_g, fat_g,
+            fiber_g, sugar_g, sodium_mg, barcode
+     FROM food_entries
+     WHERE id = ? AND user_uuid = UUID_TO_BIN(?)`,
+    [id, userUuid],
+  );
+  if (rows.length === 0) return null;
+  const row = rows[0];
+  const ingredients = await fetchIngredients(id);
+  const totals = sumIngredients(ingredients);
+  return {
+    id: row.id as number,
+    date: (row.date instanceof Date ? row.date.toISOString() : String(row.date)).slice(0, 10),
+    logged_at: row.logged_at as string,
+    meal: row.meal,
+    name: row.name,
+    source: row.source,
+    calories: totals.calories,
+    protein_g: totals.protein_g,
+    carbs_g: totals.carbs_g,
+    fat_g: totals.fat_g,
+    fiber_g: null,
+    sugar_g: null,
+    sodium_mg: null,
+    barcode: row.barcode ?? null,
+    ingredients,
+  };
+}
+
+/** Insert entry + ingredients in one transaction; totals = sum of ingredients. */
+export async function createEntry(
+  userUuid: string,
+  input: EntryInput,
+): Promise<{ id: number; totals: EntryRow }> {
+  const totals = sumIngredients(input.ingredients);
+
+  const id = await withTransaction(async (conn) => {
+    const [result] = await conn.query<ResultSetHeader>(
+      `INSERT INTO food_entries
+         (user_uuid, date, meal, name, source, calories, protein_g, carbs_g, fat_g,
+          fiber_g, sugar_g, sodium_mg, barcode, raw_llm_json)
+       VALUES (UUID_TO_BIN(?), ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, ?, NULL)`,
+      [
+        userUuid,
+        input.localDate,
+        input.meal,
+        input.name,
+        input.source,
+        totals.calories,
+        totals.protein_g,
+        totals.carbs_g,
+        totals.fat_g,
+        input.barcode ?? null,
+      ],
+    );
+    const entryId = result.insertId;
+
+    if (input.ingredients.length > 0) {
+      const placeholders = input.ingredients.map(() => '(?, ?, ?, ?, ?, ?, ?, ?, ?)').join(', ');
+      const values: unknown[] = [];
+      for (const ing of input.ingredients) {
+        values.push(entryId, ing.name, ing.grams, ing.source, ing.source_ref ?? null,
+          ing.calories, ing.protein_g, ing.carbs_g, ing.fat_g);
+      }
+      await conn.query(
+        `INSERT INTO food_entry_ingredients (entry_id, name, grams, source, source_ref, calories, protein_g, carbs_g, fat_g)
+         VALUES ${placeholders}`,
+        values,
+      );
+    }
+
+    return entryId;
+  });
+
+  const entry = await getEntry(userUuid, id);
+  return { id, totals: entry! };
+}
+
+/** Replace an entry's fields + ingredient rows (delete children + reinsert) in a txn. Null if not found. */
+export async function updateEntry(
+  userUuid: string,
+  id: number,
+  input: EntryInput,
+): Promise<EntryRow | null> {
+  const totals = sumIngredients(input.ingredients);
+
+  const updated = await withTransaction(async (conn) => {
+    const [check] = await conn.query<ResultSetHeader>(
+      `UPDATE food_entries
+       SET date = ?, meal = ?, name = ?, source = ?,
+           calories = ?, protein_g = ?, carbs_g = ?, fat_g = ?,
+           fiber_g = NULL, sugar_g = NULL, sodium_mg = NULL,
+           barcode = ?
+       WHERE id = ? AND user_uuid = UUID_TO_BIN(?)`,
+      [
+        input.localDate,
+        input.meal,
+        input.name,
+        input.source,
+        totals.calories,
+        totals.protein_g,
+        totals.carbs_g,
+        totals.fat_g,
+        input.barcode ?? null,
+        id,
+        userUuid,
+      ],
+    );
+    if (check.affectedRows === 0) return false;
+
+    await conn.query(`DELETE FROM food_entry_ingredients WHERE entry_id = ?`, [id]);
+
+    if (input.ingredients.length > 0) {
+      const placeholders = input.ingredients.map(() => '(?, ?, ?, ?, ?, ?, ?, ?, ?)').join(', ');
+      const values: unknown[] = [];
+      for (const ing of input.ingredients) {
+        values.push(id, ing.name, ing.grams, ing.source, ing.source_ref ?? null,
+          ing.calories, ing.protein_g, ing.carbs_g, ing.fat_g);
+      }
+      await conn.query(
+        `INSERT INTO food_entry_ingredients (entry_id, name, grams, source, source_ref, calories, protein_g, carbs_g, fat_g)
+         VALUES ${placeholders}`,
+        values,
+      );
+    }
+    return true;
+  });
+
+  if (!updated) return null;
+  return getEntry(userUuid, id);
+}
+
+/** Delete entry + its ingredients (txn). Returns false when nothing was deleted. */
+export async function deleteEntry(userUuid: string, id: number): Promise<boolean> {
+  return withTransaction(async (conn) => {
+    await conn.query(`DELETE FROM food_entry_ingredients WHERE entry_id = ?`, [id]);
+    const [result] = await conn.query<ResultSetHeader>(
+      `DELETE FROM food_entries WHERE id = ? AND user_uuid = UUID_TO_BIN(?)`,
+      [id, userUuid],
+    );
+    return result.affectedRows > 0;
+  });
+}
+
+/** Read goals (returns an all-null object if none set). */
+export async function getGoals(userUuid: string): Promise<Goals> {
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `SELECT calories, protein_g, carbs_g, fat_g
+     FROM nutrition_goals
+     WHERE user_uuid = UUID_TO_BIN(?)`,
+    [userUuid],
+  );
+  if (rows.length === 0) {
+    return { calories: null, protein_g: null, carbs_g: null, fat_g: null };
+  }
+  const row = rows[0];
+  return {
+    calories: row.calories ?? null,
+    protein_g: row.protein_g ?? null,
+    carbs_g: row.carbs_g ?? null,
+    fat_g: row.fat_g ?? null,
+  };
+}
+
+/** Upsert goals by user_uuid; returns the stored goals. */
+export async function putGoals(userUuid: string, goals: Goals): Promise<Goals> {
+  await pool.query(
+    `INSERT INTO nutrition_goals (user_uuid, calories, protein_g, carbs_g, fat_g)
+     VALUES (UUID_TO_BIN(?), ?, ?, ?, ?)
+     ON DUPLICATE KEY UPDATE
+       calories = VALUES(calories),
+       protein_g = VALUES(protein_g),
+       carbs_g = VALUES(carbs_g),
+       fat_g = VALUES(fat_g)`,
+    [
+      userUuid,
+      goals.calories ?? null,
+      goals.protein_g ?? null,
+      goals.carbs_g ?? null,
+      goals.fat_g ?? null,
+    ],
+  );
+  return getGoals(userUuid);
+}
+
+// ---- Memory (Phase 2/3) — signatures defined now, implemented later ----
+/** Last `days` days of entries for agent context injection. */
+export async function recentEntries(_userUuid: string, _days: number): Promise<EntryRow[]> {
+  throw new Error('not implemented — Phase 3');
+}
+/** FULLTEXT/LIKE search over past entry names (reuse a named meal). */
+export async function searchFoodHistory(_userUuid: string, _query: string): Promise<EntryRow[]> {
+  throw new Error('not implemented — Phase 3');
+}


### PR DESCRIPTION
First phase of the Nutrition feature — a **fully usable manual tracker** with **no AI** (the agent is Phase 2). Built per the approved plan: Opus authored the contracts, Sonnet subagents implemented backend / editor / day-log, verified end-to-end with Playwright.

## What's in it
- **Backend:** migration 007 (food_entries, food_entry_ingredients, nutrition_goals); `schemas/nutrition.ts` (zod); `services/nutrition/store.ts` (CRUD + day totals via `withTransaction`); `services/nutrition/providers.ts` (USDA FoodData Central + Open Food Facts); `routes/nutrition.ts` (`/day`, `/entries` CRUD, `/foods/search`, `/barcode`, `/goals`).
- **Frontend:** `NutritionTracker` (day log + optional goal bars + date nav + meal grouping + edit/delete), `EntryEditor` (search-autofill / barcode / hand-typed macros, live recompute), `BarcodeScanner`, `NutritionGoalsModal`, typed React Query hooks; 4th tab wired into `Workouts.jsx`.

## Verified (Playwright)
Add/edit/delete entries, goals + progress bars, food-search → autofill, barcode lookup, live totals — all working against the real DB.

## Notes
- Needs `USDA_FDC_API_KEY` (search/barcode) and, for Phase 2, `OPENAI_API_KEY`.
- USDA FDC search is intermittently flaky/rate-limited; mitigated with lenient macro mapping + a retry, falling back to Open Food Facts.
- "Ask AI" button is present but disabled (Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)