### PR TITLE
Nutrition gate fixes: derive entry name + cache search

### DIFF
--- a/client/src/features/nutrition/EntryEditor.tsx
+++ b/client/src/features/nutrition/EntryEditor.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react';
 import Modal from '../../components/Modal.jsx';
 import BarcodeScanner from './BarcodeScanner';
-import { useCreateEntry, useUpdateEntry, searchFoods, lookupBarcode } from './api';
+import { useCreateEntry, useUpdateEntry, useFoodSearch, lookupBarcode } from './api';
 import type {
   EntryEditorProps,
   Meal,
@@ -104,32 +104,17 @@ interface SearchDropdownProps {
 }
 
 function SearchDropdown({ query, onSelect }: SearchDropdownProps) {
-  const [results, setResults] = useState<FoodSearchResult[]>([]);
-  const [loading, setLoading] = useState(false);
   const debouncedQuery = useDebounce(query, 300);
+  const { data: results = [], isFetching } = useFoodSearch(debouncedQuery);
 
-  useEffect(() => {
-    if (debouncedQuery.trim().length < 2) {
-      setResults([]);
-      return;
-    }
-    let cancelled = false;
-    setLoading(true);
-    searchFoods(debouncedQuery)
-      .then(res => { if (!cancelled) setResults(res); })
-      .catch(() => { if (!cancelled) setResults([]); })
-      .finally(() => { if (!cancelled) setLoading(false); });
-    return () => { cancelled = true; };
-  }, [debouncedQuery]);
-
-  if (!query.trim() || (results.length === 0 && !loading)) return null;
+  if (!query.trim() || (results.length === 0 && !isFetching)) return null;
 
   return (
     <ul className={styles.dropdown} role="listbox">
-      {loading && (
+      {isFetching && (
         <li className={styles.dropdownHint}>Searching…</li>
       )}
-      {!loading && results.length === 0 && (
+      {!isFetching && results.length === 0 && (
         <li className={styles.dropdownHint}>No results</li>
       )}
       {results.map(food => (
@@ -502,8 +487,12 @@ export default function EntryEditor({ open, mode, onClose, onConfirm, onDeny }: 
   }, []);
 
   // ----- Save -----
+  // If the user left the entry name blank, fall back to the first ingredient's name.
+  const firstValidIngredient = rows.find(r => r.name.trim().length > 0 && r.grams > 0);
+  const effectiveName = entryName.trim() || firstValidIngredient?.name.trim() || '';
+
   const canSave =
-    entryName.trim().length > 0 &&
+    effectiveName.length > 0 &&
     rows.length > 0 &&
     !isPending;
 
@@ -525,7 +514,7 @@ export default function EntryEditor({ open, mode, onClose, onConfirm, onDeny }: 
     const input: EntryInput = {
       localDate: date,
       meal,
-      name: entryName.trim(),
+      name: effectiveName,
       source: 'manual',
       ingredients,
     };
@@ -561,7 +550,7 @@ export default function EntryEditor({ open, mode, onClose, onConfirm, onDeny }: 
       onConfirm({
         localDate: date,
         meal,
-        name: entryName.trim(),
+        name: effectiveName,
         source: 'manual',
         ingredients,
       });

--- a/client/src/features/nutrition/api.ts
+++ b/client/src/features/nutrition/api.ts
@@ -86,6 +86,28 @@ export async function searchFoods(query: string): Promise<FoodSearchResult[]> {
   return res.data.data;
 }
 
+/**
+ * React Query hook for food search with in-memory caching.
+ *
+ * Cache key: ['nutrition', 'foodSearch', normalizedQuery]
+ * staleTime: 5 minutes — cached results are returned immediately on refocus
+ * without triggering a new network request while still fresh.
+ * gcTime: 10 minutes — keeps results in memory after the component unmounts.
+ *
+ * Pass the already-debounced query so typing doesn't spam the network.
+ * The hook is disabled when the normalised query is shorter than 2 chars.
+ */
+export function useFoodSearch(debouncedQuery: string) {
+  const normalizedQuery = debouncedQuery.trim().toLowerCase();
+  return useQuery<FoodSearchResult[]>({
+    queryKey: ['nutrition', 'foodSearch', normalizedQuery],
+    queryFn: () => searchFoods(debouncedQuery.trim()),
+    enabled: normalizedQuery.length >= 2,
+    staleTime: 5 * 60 * 1000,  // 5 minutes
+    gcTime: 10 * 60 * 1000,    // 10 minutes
+  });
+}
+
 export async function lookupBarcode(code: string): Promise<FoodSearchResult | null> {
   try {
     const res = await clientApi.get(`/nutrition/barcode/${code}`);


### PR DESCRIPTION
Two QoL fixes from gate testing:
- Blank entry name defaults to the first ingredient's name (lone-snack case); Save enables with just an ingredient.
- Food search cached via React Query (5-min staleTime) — blur→refocus reuses results, no refetch.

Verified: Playwright (name-derivation save) + clean `vite build`/`tsc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)