### PR TITLE
Nutrition serving-size polish: filter junk labels + restyle row

### DIFF
--- a/client/src/features/nutrition/EntryEditor.module.scss
+++ b/client/src/features/nutrition/EntryEditor.module.scss
@@ -196,12 +196,32 @@
   height: 20px;
 }
 
-// Row: nutrient fields in a flex row
+// Row: nutrient fields — two-zone layout
+// Zone 1 (portionGroup): Qty + Unit — flex, shrink together
+// Zone 2 (macrosGroup): the four macro fields
+// Remove button: pushed to end
 .rowNutrients {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px 14px;
+  gap: 10px 12px;
   align-items: flex-end;
+}
+
+// Qty + Unit travel together; they shrink but never disappear
+.portionGroup {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+  flex-shrink: 0;
+}
+
+// The four macros also stay together and can wrap as a unit
+.macrosGroup {
+  display: flex;
+  gap: 8px 12px;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  flex: 1 1 auto;
 }
 
 .nutrientLabel {
@@ -212,6 +232,60 @@
   font-size: 11px;
   letter-spacing: $sarabun-spacing;
   color: rgba($text, 0.55);
+}
+
+// Styled unit select — matches inputSmall visually
+.unitSelect {
+  // Reset browser defaults completely
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+
+  // Match inputSmall base (from .input)
+  background-color: transparent;
+  color: $text;
+  border: none;
+  border-bottom: 2px solid $primary-border;
+  padding: 4px 20px 4px 2px; // right padding for chevron
+  font-family: $sarabun;
+  font-size: 14px;
+  letter-spacing: $sarabun-spacing;
+  min-height: 36px;
+  min-width: 60px;
+  max-width: 140px;
+  cursor: pointer;
+  box-sizing: border-box;
+
+  // Inline SVG chevron as background image using theme color
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath d='M1 1l5 5 5-5' stroke='%23EBEDE9' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round' fill='none'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 2px center;
+
+  &:focus {
+    outline: none;
+    border-bottom-color: $primary;
+  }
+
+  // Style the dropdown list on supported browsers
+  option {
+    background-color: $surface;
+    color: $text;
+  }
+}
+
+// Static "g" badge when only grams is available
+.unitStatic {
+  display: inline-block;
+  font-family: $sarabun;
+  font-size: 14px;
+  letter-spacing: $sarabun-spacing;
+  color: rgba($text, 0.55);
+  border-bottom: 2px solid rgba($surface-border, 0.5);
+  padding: 4px 2px;
+  min-height: 36px;
+  min-width: 24px;
+  box-sizing: border-box;
+  line-height: 1.6;
 }
 
 .removeRowBtn {

--- a/client/src/features/nutrition/EntryEditor.tsx
+++ b/client/src/features/nutrition/EntryEditor.tsx
@@ -364,7 +364,7 @@ function IngredientRowEditor({ row, onChange, onRemove, onOpenBarcode }: Ingredi
       </div>
 
       <div className={styles.rowNutrients}>
-        {/* Quantity + unit selector */}
+        {/* Zone 1: Quantity + unit — stay together */}
         <div className={styles.portionGroup}>
           <label className={styles.nutrientLabel} aria-label="Quantity">
             <span>Qty</span>
@@ -402,61 +402,64 @@ function IngredientRowEditor({ row, onChange, onRemove, onOpenBarcode }: Ingredi
           )}
         </div>
 
-        <label className={styles.nutrientLabel}>
-          <span>kcal</span>
-          <input
-            className={styles.inputSmall}
-            type="number"
-            min="0"
-            step="0.1"
-            value={row.calories === 0 ? '' : row.calories}
-            onChange={e => handleMacroChange('calories', e.target.value)}
-            readOnly={macrosReadOnly}
-            aria-label="Calories"
-          />
-        </label>
+        {/* Zone 2: Macro fields — wrap together */}
+        <div className={styles.macrosGroup}>
+          <label className={styles.nutrientLabel}>
+            <span>kcal</span>
+            <input
+              className={styles.inputSmall}
+              type="number"
+              min="0"
+              step="0.1"
+              value={row.calories === 0 ? '' : row.calories}
+              onChange={e => handleMacroChange('calories', e.target.value)}
+              readOnly={macrosReadOnly}
+              aria-label="Calories"
+            />
+          </label>
 
-        <label className={styles.nutrientLabel}>
-          <span>Prot</span>
-          <input
-            className={styles.inputSmall}
-            type="number"
-            min="0"
-            step="0.1"
-            value={row.protein_g === 0 ? '' : row.protein_g}
-            onChange={e => handleMacroChange('protein_g', e.target.value)}
-            readOnly={macrosReadOnly}
-            aria-label="Protein g"
-          />
-        </label>
+          <label className={styles.nutrientLabel}>
+            <span>Prot</span>
+            <input
+              className={styles.inputSmall}
+              type="number"
+              min="0"
+              step="0.1"
+              value={row.protein_g === 0 ? '' : row.protein_g}
+              onChange={e => handleMacroChange('protein_g', e.target.value)}
+              readOnly={macrosReadOnly}
+              aria-label="Protein g"
+            />
+          </label>
 
-        <label className={styles.nutrientLabel}>
-          <span>Carbs</span>
-          <input
-            className={styles.inputSmall}
-            type="number"
-            min="0"
-            step="0.1"
-            value={row.carbs_g === 0 ? '' : row.carbs_g}
-            onChange={e => handleMacroChange('carbs_g', e.target.value)}
-            readOnly={macrosReadOnly}
-            aria-label="Carbs g"
-          />
-        </label>
+          <label className={styles.nutrientLabel}>
+            <span>Carbs</span>
+            <input
+              className={styles.inputSmall}
+              type="number"
+              min="0"
+              step="0.1"
+              value={row.carbs_g === 0 ? '' : row.carbs_g}
+              onChange={e => handleMacroChange('carbs_g', e.target.value)}
+              readOnly={macrosReadOnly}
+              aria-label="Carbs g"
+            />
+          </label>
 
-        <label className={styles.nutrientLabel}>
-          <span>Fat</span>
-          <input
-            className={styles.inputSmall}
-            type="number"
-            min="0"
-            step="0.1"
-            value={row.fat_g === 0 ? '' : row.fat_g}
-            onChange={e => handleMacroChange('fat_g', e.target.value)}
-            readOnly={macrosReadOnly}
-            aria-label="Fat g"
-          />
-        </label>
+          <label className={styles.nutrientLabel}>
+            <span>Fat</span>
+            <input
+              className={styles.inputSmall}
+              type="number"
+              min="0"
+              step="0.1"
+              value={row.fat_g === 0 ? '' : row.fat_g}
+              onChange={e => handleMacroChange('fat_g', e.target.value)}
+              readOnly={macrosReadOnly}
+              aria-label="Fat g"
+            />
+          </label>
+        </div>
 
         <button
           type="button"

--- a/services/nutrition/providers.ts
+++ b/services/nutrition/providers.ts
@@ -276,6 +276,8 @@ export async function getPortions(source: 'usda' | 'off', ref: string): Promise<
 
         label = label.trim();
         if (!label) continue;
+        // Skip non-informative USDA portion labels.
+        if (/^(quantity not specified|not specified|undetermined)$/i.test(label)) continue;
         if (seen.has(label)) continue;
         seen.add(label);
 


### PR DESCRIPTION
- Backend: filter out non-informative USDA portion labels ("quantity not specified", etc.).
- Frontend: restyle the ingredient row so fields don't wrap randomly (quantity+unit grouped, macros grouped) and the unit dropdown is styled to match the macro inputs instead of the default OS select.

Builds clean; filter verified against real USDA. Visual pending (Playwright MCP down).

🤖 Generated with [Claude Code](https://claude.com/claude-code)