### PR TITLE
Nutrition polish: chat UX overhaul + agent tools + usage tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,13 @@ DB_NAME=workout_log
 USDA_FDC_API_KEY=
 OPENAI_API_KEY=
 
+# AI usage tracking
+# Set OWNER_EMAIL to your email to unlock the all-users cost breakdown at GET /api/nutrition/usage
+OWNER_EMAIL=
+# GPT-5.5 pricing (USD per 1 million tokens). Update once OpenAI publishes official rates.
+GPT55_INPUT_PER_1M=
+GPT55_OUTPUT_PER_1M=
+
 # Frontend env vars (Vite) — place these in client/.env.local for local dev
 # In production (Heroku), set them via: heroku config:set VITE_API_URL=... --app peak-pr-tracker
 VITE_API_URL=

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -21,6 +21,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.80.0",
+        "react-markdown": "^10.1.0",
         "react-router-dom": "^7.0.2",
         "recharts": "^3.7.0",
         "sass": "^1.77.8",
@@ -2007,11 +2008,38 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/http-proxy": {
       "version": "1.17.15",
@@ -2021,6 +2049,21 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.10.7",
@@ -2035,14 +2078,12 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2059,11 +2100,23 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
+      "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
+      "license": "ISC"
     },
     "node_modules/@vercel/oidc": {
       "version": "3.2.0",
@@ -2203,6 +2256,16 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
@@ -2301,6 +2364,56 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -2337,6 +2450,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2360,7 +2483,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -2517,6 +2639,19 @@
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -2553,6 +2688,19 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2679,6 +2827,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -2693,6 +2851,12 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -2871,6 +3035,56 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/http-proxy": {
       "version": "1.18.1",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
@@ -2908,6 +3122,12 @@
       "integrity": "sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw==",
       "license": "MIT"
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -2915,6 +3135,40 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-extglob": {
@@ -2938,6 +3192,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2945,6 +3209,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-plain-object": {
@@ -3012,6 +3288,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -3041,6 +3327,601 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -3111,6 +3992,31 @@
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -3215,6 +4121,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -3268,6 +4184,33 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
@@ -3473,6 +4416,39 @@
         "redux": "^5.0.0"
       }
     },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -3559,6 +4535,48 @@
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/swr": {
@@ -3677,6 +4695,26 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-custom-error": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
@@ -3711,6 +4749,93 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -3805,6 +4930,34 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/victory-vendor": {
@@ -4013,6 +5166,16 @@
       "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.80.0",
+    "react-markdown": "^10.1.0",
     "react-router-dom": "^7.0.2",
     "recharts": "^3.7.0",
     "sass": "^1.77.8",

--- a/client/src/features/nutrition/NutritionChat.module.scss
+++ b/client/src/features/nutrition/NutritionChat.module.scss
@@ -1,36 +1,70 @@
 @import "../../styles/variables";
 
-// ---- Overlay ----
+// ---- Dim overlay — shown only when the sheet is expanded ----
 .overlay {
   position: fixed;
   inset: 0;
-  background-color: rgba(0, 0, 0, 0.55);
-  z-index: 999;
-
-  &[data-state="open"]  { animation: fadeIn 120ms ease; }
-  &[data-state="closed"] { animation: fadeOut 100ms ease; }
+  background-color: rgba(0, 0, 0, 0.45);
+  z-index: 998;
+  animation: fadeIn 120ms ease;
 }
 
-// ---- Bottom-sheet panel ----
+// ---- Custom CSS bottom sheet (item 1) ----
+// Always peeks at the bottom; animates `height` between peek and expanded.
 .sheet {
   position: fixed;
   bottom: 0;
   left: 0;
   right: 0;
-  z-index: 1000;
+  max-width: 680px;
+  margin: 0 auto;
+  z-index: 999;
   background-color: $surface;
   border-radius: 20px 20px 0 0;
   display: flex;
   flex-direction: column;
-  max-height: 85dvh;
-  // Width cap on desktop
-  max-width: 680px;
-  margin: 0 auto;
+  overflow: hidden;
+  transition: height 0.3s cubic-bezier(0.32, 0.72, 0, 1);
+  // Item 7: kill iOS text-auto-inflation
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
 
   &:focus { outline: none; }
+}
 
-  &[data-state="open"]  { animation: slideUp 180ms cubic-bezier(0.16, 1, 0.3, 1); }
-  &[data-state="closed"] { animation: slideDown 140ms ease; }
+// Peek: just the drag handle + composer visible (messages flex to 0)
+.sheetPeek {
+  height: 96px;
+}
+
+// Expanded: full chat
+.sheetExpanded {
+  height: 88dvh;
+}
+
+// ---- Drag handle (tap to toggle, drag to expand/collapse) ----
+.dragHandleBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  // Generous tap/drag target while keeping the visual grabber small
+  padding: 8px 0 6px;
+  background: transparent;
+  border: none;
+  cursor: grab;
+  flex-shrink: 0;
+  touch-action: none; // let pointer-drag work without page scroll interference
+
+  &:active { cursor: grabbing; }
+}
+
+.dragHandle {
+  display: block;
+  width: 36px;
+  height: 4px;
+  background-color: rgba($surface-border, 0.6);
+  border-radius: 2px;
 }
 
 // Accessibility: visually hidden title
@@ -51,7 +85,7 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 14px 16px 12px;
+  padding: 8px 16px 10px;
   border-bottom: 1px solid rgba($surface-border, 0.4);
   flex-shrink: 0;
 }
@@ -105,15 +139,29 @@
   height: 14px;
 }
 
+// Collapse chevron (down arrow) in the expanded header
+.collapseSvg {
+  display: block; // iOS Safari SVG fix
+  width: 14px;
+  height: 8px;
+}
+
 // ---- Message list ----
+// flex:1 + min-height:0 → collapses to 0 height at the peek, leaving only
+// the composer visible. Expands to fill the sheet when expanded.
 .messages {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
+  overflow-x: hidden; // Item 6: no horizontal scroll
   -webkit-overflow-scrolling: touch;
   padding: 12px 14px;
   display: flex;
   flex-direction: column;
   gap: 12px;
+  // Item 6: ensure content never exceeds viewport width
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
 .emptyHint {
@@ -140,6 +188,9 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
+  // Item 6: prevent overflow
+  max-width: 100%;
+  min-width: 0;
 }
 
 .messageGroupUser {
@@ -155,6 +206,11 @@
   max-width: min(80%, 500px);
   border-radius: 16px;
   padding: 10px 14px;
+  // Item 6: prevent bubble from overflowing
+  min-width: 0;
+  box-sizing: border-box;
+  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 .bubbleUser {
@@ -170,15 +226,99 @@
 .bubbleText {
   margin: 0;
   font-family: $sarabun;
-  font-size: 15px;
+  font-size: 15px; // Item 7: explicit size
   line-height: 1.5;
   letter-spacing: $sarabun-spacing;
   color: $text;
   white-space: pre-wrap;
   word-break: break-word;
+  overflow-wrap: anywhere;
 
   .bubbleUser & {
     color: $background;
+  }
+}
+
+// Item 4: markdown container in assistant bubbles
+.bubbleMarkdown {
+  font-family: $sarabun;
+  font-size: 15px; // Item 7: explicit size
+  line-height: 1.5;
+  letter-spacing: $sarabun-spacing;
+  color: $text;
+  // Item 6: no overflow
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  min-width: 0;
+
+  // Tight spacing for markdown elements inside bubble
+  p {
+    margin: 0 0 6px;
+    &:last-child { margin-bottom: 0; }
+  }
+
+  ul, ol {
+    margin: 4px 0 6px;
+    padding-left: 18px;
+    &:last-child { margin-bottom: 0; }
+  }
+
+  li {
+    margin-bottom: 2px;
+  }
+
+  h1, h2, h3, h4 {
+    font-size: 15px;
+    font-weight: 700;
+    margin: 6px 0 3px;
+    &:first-child { margin-top: 0; }
+  }
+
+  strong { font-weight: 700; }
+  em { font-style: italic; }
+
+  code {
+    font-family: "SFMono-Regular", "Consolas", "Liberation Mono", monospace;
+    font-size: 13px;
+    background-color: rgba($background, 0.5);
+    border-radius: 4px;
+    padding: 1px 5px;
+  }
+
+  pre {
+    margin: 4px 0 6px;
+    background-color: rgba($background, 0.5);
+    border-radius: 6px;
+    padding: 8px 10px;
+    overflow-x: auto; // Item 6: scroll within pre box only
+    font-size: 12px;
+    max-width: 100%;
+    box-sizing: border-box;
+
+    code {
+      background: none;
+      padding: 0;
+      font-size: 12px;
+    }
+  }
+
+  a {
+    color: $primary;
+    text-decoration: underline;
+    word-break: break-all;
+  }
+
+  hr {
+    border: none;
+    border-top: 1px solid rgba($surface-border, 0.4);
+    margin: 8px 0;
+  }
+
+  blockquote {
+    border-left: 3px solid rgba($primary-border, 0.5);
+    margin: 4px 0 6px 0;
+    padding-left: 10px;
+    color: rgba($text, 0.7);
   }
 }
 
@@ -197,6 +337,8 @@
   border: 1px solid rgba($surface-border, 0.3);
   border-radius: 10px;
   overflow: hidden;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .reasoningToggle {
@@ -209,7 +351,7 @@
   border: none;
   cursor: pointer;
   font-family: $sarabun;
-  font-size: 12px;
+  font-size: 12px; // Item 7: explicit size
   font-weight: 600;
   letter-spacing: $sarabun-spacing;
   color: rgba($text, 0.4);
@@ -219,23 +361,69 @@
 }
 
 .reasoningChevron {
-  display: block;
+  display: block; // iOS Safari SVG fix
   width: 10px;
   height: 6px;
   flex-shrink: 0;
   color: rgba($text, 0.35);
 }
 
+// Item 4: markdown in reasoning text
 .reasoningText {
-  margin: 0;
   padding: 4px 12px 10px;
   font-family: $sarabun;
-  font-size: 12px;
+  font-size: 12px; // Item 7: explicit size
   line-height: 1.5;
-  color: rgba($text, 0.45);
+  color: rgba($text, 0.55);
   letter-spacing: $sarabun-spacing;
-  white-space: pre-wrap;
+  overflow-wrap: anywhere;
   word-break: break-word;
+  min-width: 0;
+
+  p {
+    margin: 0 0 4px;
+    &:last-child { margin-bottom: 0; }
+  }
+
+  ul, ol {
+    margin: 2px 0 4px;
+    padding-left: 16px;
+  }
+
+  li { margin-bottom: 1px; }
+
+  strong { font-weight: 700; }
+  em { font-style: italic; }
+
+  code {
+    font-family: "SFMono-Regular", "Consolas", "Liberation Mono", monospace;
+    font-size: 11px;
+    background-color: rgba($background, 0.5);
+    border-radius: 3px;
+    padding: 1px 4px;
+  }
+
+  pre {
+    margin: 2px 0 4px;
+    background-color: rgba($background, 0.5);
+    border-radius: 5px;
+    padding: 6px 8px;
+    overflow-x: auto; // Item 6
+    font-size: 11px;
+    max-width: 100%;
+    box-sizing: border-box;
+
+    code {
+      background: none;
+      padding: 0;
+    }
+  }
+
+  a {
+    color: $primary;
+    text-decoration: underline;
+    word-break: break-all;
+  }
 }
 
 // ---- Proposal outcomes ----
@@ -374,11 +562,11 @@
   display: flex;
   align-items: flex-end;
   gap: 6px;
-  padding: 10px 12px 14px;
+  padding: 8px 12px;
   border-top: 1px solid rgba($surface-border, 0.3);
   flex-shrink: 0;
   // Safe area for iOS home indicator
-  padding-bottom: max(14px, env(safe-area-inset-bottom));
+  padding-bottom: max(10px, env(safe-area-inset-bottom));
 }
 
 .composerBtn {
@@ -412,6 +600,7 @@
   display: none;
 }
 
+// Item 3: auto-grow textarea
 .composerInput {
   flex: 1;
   background-color: rgba($background, 0.4);
@@ -420,13 +609,18 @@
   border-radius: 12px;
   padding: 10px 12px;
   font-family: $sarabun;
-  font-size: 15px;
+  font-size: 15px; // Item 7: explicit size
   letter-spacing: $sarabun-spacing;
   resize: none;
   line-height: 1.4;
+  // min-height for one line, grows via JS
   min-height: 40px;
-  max-height: 120px;
-  overflow-y: auto;
+  // max-height capped at ~8 lines; JS handles overflow-y toggle
+  max-height: 180px;
+  overflow-y: hidden; // JS sets to auto when at max
+  box-sizing: border-box;
+  // Item 6: no horizontal overflow
+  overflow-x: hidden;
 
   &::placeholder {
     color: rgba($text, 0.35);
@@ -473,16 +667,4 @@
 @keyframes fadeIn {
   from { opacity: 0; }
   to   { opacity: 1; }
-}
-@keyframes fadeOut {
-  from { opacity: 1; }
-  to   { opacity: 0; }
-}
-@keyframes slideUp {
-  from { transform: translateY(60%); opacity: 0.5; }
-  to   { transform: translateY(0);   opacity: 1; }
-}
-@keyframes slideDown {
-  from { transform: translateY(0);   opacity: 1; }
-  to   { transform: translateY(60%); opacity: 0; }
 }

--- a/client/src/features/nutrition/NutritionChat.tsx
+++ b/client/src/features/nutrition/NutritionChat.tsx
@@ -1,7 +1,16 @@
 /**
- * NutritionChat — Phase 2 AI chat bottom-sheet.
+ * NutritionChat — Phase 2 AI chat bottom-sheet (custom CSS sheet).
  *
- * - Radix Dialog bottom-sheet
+ * Changes (polish pass):
+ * 1. Custom CSS bottom sheet with peeking composer + tap/drag-to-expand.
+ * 2. localStorage persistence keyed by selectedDate; cleared between days.
+ * 3. Auto-growing textarea (up to ~8 lines), Enter to send / Shift+Enter newline.
+ * 4. Markdown rendering (react-markdown) in assistant text + reasoning.
+ * 5. Empty reasoning parts filtered out (no toggle rendered).
+ * 6. No horizontal scroll on mobile (overflow-wrap, contained JSON <pre>).
+ * 7. Consistent font sizes on mobile (text-size-adjust, explicit sizes).
+ * 8. Human-readable tool names via TOOL_LABEL_MAP in ToolCallCard.
+ *
  * - useChat → POST /api/nutrition/chat (auth header + credentials:include)
  * - Composer: text + photo attach (downscale via canvas → FileUIPart) + barcode
  * - Renders message.parts: text, tool calls, propose_entry→EntryEditor, reasoning
@@ -12,10 +21,10 @@ import {
   useCallback,
   useEffect,
 } from 'react';
-import * as Dialog from '@radix-ui/react-dialog';
 import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport, isToolUIPart, getToolName } from 'ai';
 import type { FileUIPart, UIMessage, ToolUIPart, DynamicToolUIPart } from 'ai';
+import ReactMarkdown from 'react-markdown';
 import { useCreateEntry } from './api';
 import EntryEditor from './EntryEditor';
 import BarcodeScanner from './BarcodeScanner';
@@ -29,8 +38,6 @@ import styles from './NutritionChat.module.scss';
 const VITE_API_URL = (import.meta as unknown as { env: Record<string, string> }).env.VITE_API_URL || '/api';
 
 async function getAccessToken(): Promise<string> {
-  // Attempt to use cached token from sessionStorage.
-  // If expired, call /api/auth/token to refresh (same as clientApi.js).
   let token = sessionStorage.getItem('accessToken');
   if (token) {
     try {
@@ -93,12 +100,73 @@ async function downscaleImage(file: File): Promise<string> {
 // ---------------------------------------------------------------------------
 interface PendingPhoto {
   file: File;
-  previewUrl: string; // always the original blob URL for fast preview
-  dataUrl?: string;   // JPEG data URL (set after downscale)
+  previewUrl: string;
+  dataUrl?: string;
 }
 
 // ---------------------------------------------------------------------------
-// Reasoning collapsible
+// localStorage persistence helpers (item 2)
+// ---------------------------------------------------------------------------
+const LS_PREFIX = 'peak.nutritionChat.';
+const MAX_STORED_DAYS = 7;
+
+function lsKey(date: string) {
+  return `${LS_PREFIX}${date}`;
+}
+
+function loadMessagesForDate(date: string): UIMessage[] {
+  try {
+    const raw = localStorage.getItem(lsKey(date));
+    if (!raw) return [];
+    return JSON.parse(raw) as UIMessage[];
+  } catch {
+    return [];
+  }
+}
+
+function saveMessagesForDate(date: string, messages: UIMessage[]) {
+  try {
+    localStorage.setItem(lsKey(date), JSON.stringify(messages));
+    pruneOldDays(date);
+  } catch {
+    // storage full — ignore
+  }
+}
+
+function pruneOldDays(currentDate: string) {
+  const keys: string[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const k = localStorage.key(i);
+    if (k && k.startsWith(LS_PREFIX)) keys.push(k);
+  }
+  if (keys.length <= MAX_STORED_DAYS) return;
+  // Sort ascending by date suffix and remove oldest
+  keys.sort();
+  const currentKey = lsKey(currentDate);
+  const toRemove = keys
+    .filter(k => k !== currentKey)
+    .slice(0, keys.length - MAX_STORED_DAYS);
+  toRemove.forEach(k => localStorage.removeItem(k));
+}
+
+// ---------------------------------------------------------------------------
+// Auto-grow textarea hook (item 3)
+// ---------------------------------------------------------------------------
+function useAutoGrow(ref: React.RefObject<HTMLTextAreaElement | null>, value: string) {
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    const lineHeight = parseFloat(getComputedStyle(el).lineHeight) || 21;
+    const maxLines = 8;
+    const maxHeight = lineHeight * maxLines + 20; // 20px for padding
+    el.style.height = Math.min(el.scrollHeight, maxHeight) + 'px';
+    el.style.overflowY = el.scrollHeight > maxHeight ? 'auto' : 'hidden';
+  }, [value, ref]);
+}
+
+// ---------------------------------------------------------------------------
+// Reasoning collapsible (item 4 — markdown; item 5 — filter empty)
 // ---------------------------------------------------------------------------
 interface ReasoningBubbleProps {
   text: string;
@@ -107,6 +175,9 @@ interface ReasoningBubbleProps {
 
 function ReasoningBubble({ text, streaming }: ReasoningBubbleProps) {
   const [open, setOpen] = useState(false);
+  // Item 5: filter empty/whitespace reasoning
+  if (!streaming && !text.trim()) return null;
+
   return (
     <div className={styles.reasoning}>
       <button
@@ -115,7 +186,7 @@ function ReasoningBubble({ text, streaming }: ReasoningBubbleProps) {
         onClick={() => setOpen(p => !p)}
         aria-expanded={open}
       >
-        <svg className={styles.reasoningChevron} viewBox="0 0 10 6" fill="none" aria-hidden="true">
+        <svg className={styles.reasoningChevron} viewBox="0 0 10 6" fill="none" aria-hidden="true" style={{ display: 'block' }}>
           <path
             d={open ? 'M1 5l4-4 4 4' : 'M1 1l4 4 4-4'}
             stroke="currentColor"
@@ -127,7 +198,10 @@ function ReasoningBubble({ text, streaming }: ReasoningBubbleProps) {
         {streaming ? 'Thinking…' : 'Reasoning'}
       </button>
       {open && (
-        <p className={styles.reasoningText}>{text}</p>
+        <div className={styles.reasoningText}>
+          {/* Item 4: render reasoning as markdown */}
+          <ReactMarkdown>{text}</ReactMarkdown>
+        </div>
       )}
     </div>
   );
@@ -177,7 +251,15 @@ function ChatMessage({
               key={idx}
               className={`${styles.bubble} ${isUser ? styles.bubbleUser : styles.bubbleAssistant}`}
             >
-              <p className={styles.bubbleText}>{part.text}</p>
+              {isUser ? (
+                // User messages: plain text with whitespace preserved
+                <p className={styles.bubbleText}>{part.text}</p>
+              ) : (
+                // Item 4: render assistant text as markdown
+                <div className={styles.bubbleMarkdown}>
+                  <ReactMarkdown>{part.text}</ReactMarkdown>
+                </div>
+              )}
             </div>
           );
         }
@@ -194,7 +276,7 @@ function ChatMessage({
           );
         }
 
-        // ---- Reasoning part ----
+        // ---- Reasoning part (item 4 + item 5) ----
         if (part.type === 'reasoning') {
           return (
             <ReasoningBubble
@@ -231,11 +313,9 @@ function ChatMessage({
               );
             }
             if (part.state !== 'input-available' && part.state !== 'output-available') {
-              // Still streaming input
               return <ToolCallCard key={idx} part={part as ToolUIPart | DynamicToolUIPart} />;
             }
 
-            // Prefer output (echoed args) when available, fall back to input
             const rawArgs = (part.state === 'output-available'
               ? (part as { output: unknown }).output
               : part.input) as ProposeEntryArgs;
@@ -292,7 +372,6 @@ function ProposalCard({ proposal, selectedDate, onConfirm, onDeny }: ProposalCar
 
   return (
     <>
-      {/* Collapsed placeholder when editor is closed */}
       {!editorOpen && (
         <div className={styles.proposalPlaceholder}>
           <span className={styles.proposalName}>{proposal.name}</span>
@@ -324,7 +403,13 @@ function ProposalCard({ proposal, selectedDate, onConfirm, onDeny }: ProposalCar
 }
 
 // ---------------------------------------------------------------------------
-// NutritionChat
+// NutritionChat — custom CSS bottom sheet (item 1)
+//
+// A plain fixed-position panel that animates its `height` between a peek
+// (96px — just drag handle + composer) and expanded (88dvh — full chat).
+// vaul was removed: it reveals content top-down at the snap line, which
+// hid our bottom-pinned composer. Driving `height` with an `expanded`
+// boolean keeps the composer at the bottom and always visible at the peek.
 // ---------------------------------------------------------------------------
 interface NutritionChatProps {
   open: boolean;
@@ -333,8 +418,14 @@ interface NutritionChatProps {
 }
 
 export default function NutritionChat({ open, onClose, selectedDate }: NutritionChatProps) {
+  // Item 2: load messages from localStorage on mount / date change
+  const initialMessages = loadMessagesForDate(selectedDate);
+
+  // Track last loaded date to detect day change
+  const loadedDateRef = useRef(selectedDate);
+
   // ---- useChat setup ----
-  const { messages, sendMessage, status, stop } = useChat({
+  const { messages, setMessages, sendMessage, status, stop } = useChat({
     transport: new DefaultChatTransport({
       api: `${VITE_API_URL}/nutrition/chat`,
       credentials: 'include',
@@ -344,7 +435,37 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
       },
       body: { selectedDate },
     }),
+    messages: initialMessages,
   });
+
+  // Item 2: persist messages on every change
+  useEffect(() => {
+    if (messages.length > 0) {
+      saveMessagesForDate(selectedDate, messages);
+    }
+  }, [messages, selectedDate]);
+
+  // Item 2: when selectedDate changes, load the new day's messages
+  useEffect(() => {
+    if (selectedDate !== loadedDateRef.current) {
+      loadedDateRef.current = selectedDate;
+      const newDayMessages = loadMessagesForDate(selectedDate);
+      setMessages(newDayMessages);
+    }
+  }, [selectedDate, setMessages]);
+
+  // ---- Custom sheet expand/collapse state (item 1) ----
+  const [expanded, setExpanded] = useState(false);
+
+  // When the parent sets `open` (the "Ask AI" button) → expand.
+  useEffect(() => {
+    if (open) setExpanded(true);
+  }, [open]);
+
+  const collapse = useCallback(() => {
+    setExpanded(false);
+    onClose();
+  }, [onClose]);
 
   // ---- Entry creation for confirmed proposals ----
   const createEntry = useCreateEntry(selectedDate);
@@ -366,6 +487,9 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
 
   const isStreaming = status === 'streaming' || status === 'submitted';
 
+  // Item 3: auto-grow textarea
+  useAutoGrow(textareaRef, text);
+
   // Auto-scroll to bottom on new messages
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -382,10 +506,8 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
       previewUrl: URL.createObjectURL(file),
     }));
 
-    // Start downscaling in background
     setPendingPhotos(prev => [...prev, ...newPhotos]);
 
-    // Downscale each
     const settled = await Promise.allSettled(newPhotos.map(p => downscaleImage(p.file)));
     setPendingPhotos(prev => {
       const updated = [...prev];
@@ -404,7 +526,6 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
     if (e.target.files && e.target.files.length > 0) {
       await handlePhotoFiles(e.target.files);
     }
-    // Reset the input so the same file can be reselected
     if (fileInputRef.current) fileInputRef.current.value = '';
   }, [handlePhotoFiles]);
 
@@ -429,16 +550,17 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
   const handleSend = useCallback(async () => {
     if (!canSend) return;
 
-    // Build FileUIPart[] from downscaled photos
+    // Expand sheet when sending a message
+    setExpanded(true);
+
     const files: FileUIPart[] = pendingPhotos.map(p => ({
       type: 'file' as const,
       mediaType: 'image/jpeg',
-      url: p.dataUrl ?? p.previewUrl, // fall back to original if downscale not done yet
+      url: p.dataUrl ?? p.previewUrl,
     }));
 
     const msgText = text.trim();
 
-    // Revoke object URLs
     pendingPhotos.forEach(p => URL.revokeObjectURL(p.previewUrl));
     setText('');
     setPendingPhotos([]);
@@ -451,8 +573,8 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
     );
   }, [canSend, text, pendingPhotos, selectedDate, sendMessage]);
 
+  // Item 3: Enter to send, Shift+Enter for newline
   const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    // Send on Enter (not Shift+Enter)
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       handleSend();
@@ -462,77 +584,141 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
   // ---- Proposal handlers ----
   const handleProposalDeny = useCallback((partKey: string) => {
     setDeniedProposals(prev => new Set([...prev, partKey]));
-    // Send a follow-up message so the agent knows
     sendMessage(
       { text: 'That proposal doesn\'t look right, please try again with a different approach.' },
       { body: { selectedDate } },
     );
   }, [selectedDate, sendMessage]);
 
-  // We also need to track confirmed proposals — wrapped in a callback passed down
   const handleProposalConfirmWithTracking = useCallback(async (input: EntryInput, partKey: string) => {
     await createEntry.mutateAsync(input);
     setConfirmedProposals(prev => new Set([...prev, partKey]));
   }, [createEntry]);
 
+  // ---- Drag handle: pointer-drag enhancement (item 1) ----
+  // Tap toggles; drag up > 40px expands, drag down > 40px collapses.
+  const dragStartY = useRef<number | null>(null);
+  const dragMoved = useRef(false);
+
+  const handleDragPointerDown = useCallback((e: React.PointerEvent) => {
+    dragStartY.current = e.clientY;
+    dragMoved.current = false;
+    (e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId);
+  }, []);
+
+  const handleDragPointerMove = useCallback((e: React.PointerEvent) => {
+    if (dragStartY.current === null) return;
+    const delta = e.clientY - dragStartY.current;
+    if (Math.abs(delta) > 40) {
+      dragMoved.current = true;
+      if (delta < 0) {
+        setExpanded(true);
+      } else {
+        collapse(); // keeps parent `open` state in sync
+      }
+      dragStartY.current = null; // commit once per gesture
+    }
+  }, [collapse]);
+
+  const handleDragPointerUp = useCallback(() => {
+    // Tap (no significant movement) → toggle
+    if (!dragMoved.current) {
+      if (expanded) {
+        collapse(); // keeps parent `open` state in sync
+      } else {
+        setExpanded(true);
+      }
+    }
+    dragStartY.current = null;
+    dragMoved.current = false;
+  }, [collapse, expanded]);
+
+  const isExpanded = expanded;
+
   // ---- Render ----
   return (
     <>
-      <Dialog.Root open={open} onOpenChange={v => { if (!v) onClose(); }}>
-        <Dialog.Portal>
-          <Dialog.Overlay className={styles.overlay} />
-          <Dialog.Content className={styles.sheet} aria-label="Nutrition AI chat">
-            <Dialog.Title className={styles.srOnly}>Nutrition AI</Dialog.Title>
+      {/* Dim overlay behind the sheet — only when expanded; click to collapse */}
+      {isExpanded && (
+        <div
+          className={styles.overlay}
+          onClick={collapse}
+          aria-hidden="true"
+        />
+      )}
 
-            {/* Header */}
-            <div className={styles.header}>
-              <span className={styles.headerTitle}>Ask AI</span>
-              {isStreaming && (
-                <button
-                  type="button"
-                  className={styles.stopBtn}
-                  onClick={stop}
-                  aria-label="Stop generation"
-                >
-                  Stop
-                </button>
-              )}
+      {/* Custom CSS bottom sheet — always peeks, animates height */}
+      <div
+        className={`${styles.sheet} ${isExpanded ? styles.sheetExpanded : styles.sheetPeek}`}
+        aria-label="Nutrition AI chat"
+        role="dialog"
+      >
+        <span className={styles.srOnly}>Nutrition AI</span>
+
+        {/* Drag handle (tap to toggle, drag up/down to expand/collapse) */}
+        <button
+          type="button"
+          className={styles.dragHandleBtn}
+          onPointerDown={handleDragPointerDown}
+          onPointerMove={handleDragPointerMove}
+          onPointerUp={handleDragPointerUp}
+          aria-label={isExpanded ? 'Collapse AI chat' : 'Expand AI chat'}
+          aria-expanded={isExpanded}
+        >
+          <span className={styles.dragHandle} aria-hidden="true" />
+        </button>
+
+        {/* Header — only shown when expanded */}
+        {isExpanded && (
+          <div className={styles.header}>
+            <span className={styles.headerTitle}>Ask AI</span>
+            {isStreaming && (
               <button
                 type="button"
-                className={styles.closeBtn}
-                onClick={onClose}
-                aria-label="Close"
+                className={styles.stopBtn}
+                onClick={stop}
+                aria-label="Stop generation"
               >
-                <svg className={styles.closeSvg} viewBox="0 0 14 14" fill="none" aria-hidden="true">
-                  <path d="M1 1l12 12M13 1L1 13" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-                </svg>
+                Stop
               </button>
+            )}
+            <button
+              type="button"
+              className={styles.closeBtn}
+              onClick={collapse}
+              aria-label="Collapse"
+            >
+              <svg className={styles.collapseSvg} viewBox="0 0 14 8" fill="none" aria-hidden="true">
+                <path d="M1 1l6 6 6-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </button>
+          </div>
+        )}
+
+        {/* Messages — collapses to 0 height in peek (flex:1, min-height:0) */}
+        <div className={styles.messages}>
+          {messages.length === 0 && (
+            <div className={styles.emptyHint}>
+              <p>Describe what you ate, scan a barcode, or attach a photo of your food.</p>
             </div>
+          )}
 
-            {/* Messages */}
-            <div className={styles.messages}>
-              {messages.length === 0 && (
-                <div className={styles.emptyHint}>
-                  <p>Describe what you ate, scan a barcode, or attach a photo of your food.</p>
-                </div>
-              )}
+          {messages.map(message => (
+            <ChatMessage
+              key={message.id}
+              message={message}
+              selectedDate={selectedDate}
+              onProposalConfirm={handleProposalConfirmWithTracking}
+              onProposalDeny={handleProposalDeny}
+              deniedProposals={deniedProposals}
+              confirmedProposals={confirmedProposals}
+            />
+          ))}
 
-              {messages.map(message => (
-                <ChatMessage
-                  key={message.id}
-                  message={message}
-                  selectedDate={selectedDate}
-                  onProposalConfirm={handleProposalConfirmWithTracking}
-                  onProposalDeny={handleProposalDeny}
-                  deniedProposals={deniedProposals}
-                  confirmedProposals={confirmedProposals}
-                />
-              ))}
+          <div ref={messagesEndRef} />
+        </div>
 
-              <div ref={messagesEndRef} />
-            </div>
-
-            {/* Photo thumbnails */}
+        {/* Photo thumbnails */}
             {pendingPhotos.length > 0 && (
               <div className={styles.thumbnails}>
                 {pendingPhotos.map(p => (
@@ -556,7 +742,7 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
               <p className={styles.photoError}>{photoError}</p>
             )}
 
-            {/* Composer */}
+            {/* Composer — always visible in both peek and expanded states */}
             <div className={styles.composer}>
               {/* Photo attach button */}
               <button
@@ -573,7 +759,6 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
                 </svg>
               </button>
 
-              {/* Hidden file input — accepts images, prefers camera on mobile */}
               <input
                 ref={fileInputRef}
                 type="file"
@@ -603,7 +788,7 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
                 </svg>
               </button>
 
-              {/* Text input */}
+              {/* Item 3: auto-grow textarea */}
               <textarea
                 ref={textareaRef}
                 className={styles.composerInput}
@@ -611,6 +796,10 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
                 value={text}
                 onChange={e => setText(e.target.value)}
                 onKeyDown={handleKeyDown}
+                onFocus={() => {
+                  // Expand the sheet when user focuses the input
+                  setExpanded(true);
+                }}
                 rows={1}
                 aria-label="Chat message"
               />
@@ -628,11 +817,9 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
                 </svg>
               </button>
             </div>
-          </Dialog.Content>
-        </Dialog.Portal>
-      </Dialog.Root>
+      </div>
 
-      {/* Barcode scanner — rendered outside dialog */}
+      {/* Barcode scanner — rendered outside the sheet */}
       {barcodeOpen && (
         <BarcodeScanner
           onDetected={handleBarcodeDetected}

--- a/client/src/features/nutrition/NutritionTracker.module.scss
+++ b/client/src/features/nutrition/NutritionTracker.module.scss
@@ -1,8 +1,9 @@
 @import "../../styles/variables";
 
 // ---- Container ----
+// Extra bottom padding to keep content from hiding behind the peeking chat bar (~88px)
 .container {
-  padding: 16px 14px 24px;
+  padding: 16px 14px 120px;
   display: flex;
   flex-direction: column;
   gap: 16px;

--- a/client/src/features/nutrition/ToolCallCard.module.scss
+++ b/client/src/features/nutrition/ToolCallCard.module.scss
@@ -1,10 +1,18 @@
 @import "../../styles/variables";
 
+// Item 7: Consistent font sizes — explicit px, no iOS auto-inflation
+// The parent .sheet already sets text-size-adjust:100%, but we also set
+// explicit sizes on name vs description so the hierarchy is intentional.
+
 .card {
   background-color: rgba($surface, 0.6);
   border: 1px solid rgba($surface-border, 0.5);
   border-radius: 10px;
   overflow: hidden;
+  // Item 6: never overflow the chat column
+  max-width: 100%;
+  box-sizing: border-box;
+  min-width: 0;
 
   &.cardError {
     border-color: rgba($error, 0.4);
@@ -22,6 +30,9 @@
   cursor: pointer;
   text-align: left;
   min-height: 44px; // mobile tap target
+  // Item 6: allow wrapping, no overflow
+  flex-wrap: wrap;
+  box-sizing: border-box;
 }
 
 .chevron {
@@ -37,13 +48,19 @@
   height: 6px;
 }
 
+// Item 7: tool name is the primary label — 13px, medium weight
 .toolName {
   font-family: $sarabun;
-  font-size: 13px;
+  font-size: 13px; // Item 7: explicit size
   font-weight: 600;
   letter-spacing: $sarabun-spacing;
   color: rgba($text, 0.75);
   font-variant-ligatures: none;
+  // Item 6: prevent overflow
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  flex-shrink: 1;
+  min-width: 0;
 }
 
 // Status chip
@@ -54,11 +71,14 @@
   padding: 2px 8px;
   border-radius: 6px;
   font-family: $sarabun;
-  font-size: 11px;
+  font-size: 11px; // Item 7: explicit, smaller than toolName
   font-weight: 600;
   letter-spacing: 0.5px;
   text-transform: uppercase;
   flex-shrink: 0;
+  // Item 7: don't let chip auto-inflate
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
 }
 
 .chip_running {
@@ -91,16 +111,22 @@
   50%       { opacity: 0.3; }
 }
 
+// Item 7: summary is smaller than toolName and wraps
 .summary {
-  flex: 1;
+  // Take remaining space but allow wrapping
+  flex: 1 1 100%; // wrap to new line so it never competes with name/chip
   font-family: $sarabun;
-  font-size: 12px;
+  font-size: 12px; // Item 7: explicit, clearly less than toolName 13px
   color: rgba($text, 0.45);
   letter-spacing: $sarabun-spacing;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  // Item 6: wrap long text instead of overflowing
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  white-space: normal; // allow wrapping
   min-width: 0;
+  // Item 7: prevent iOS auto-inflation
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
 }
 
 // Expanded body
@@ -110,12 +136,17 @@
   flex-direction: column;
   gap: 10px;
   border-top: 1px solid rgba($surface-border, 0.3);
+  // Item 6: never overflow
+  max-width: 100%;
+  box-sizing: border-box;
+  overflow: hidden;
 }
 
 .section {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  min-width: 0;
 }
 
 .sectionLabel {
@@ -127,6 +158,7 @@
   text-transform: uppercase;
 }
 
+// Item 6: JSON block scrolls within its own box, never causes page scroll
 .jsonBlock {
   margin: 0;
   font-family: "SFMono-Regular", "Consolas", "Liberation Mono", monospace;
@@ -136,11 +168,15 @@
   background-color: rgba($background, 0.6);
   border-radius: 6px;
   padding: 8px 10px;
+  // Horizontal scroll contained to this block only
   overflow-x: auto;
-  white-space: pre-wrap;
-  word-break: break-all;
+  // Prevent word-wrap from breaking JSON structure; use overflow-x instead
+  white-space: pre;
   max-height: 200px;
   overflow-y: auto;
+  // Item 6: constrain width to parent
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
 .jsonNull {
@@ -155,4 +191,7 @@
   font-size: 13px;
   color: $error;
   letter-spacing: $sarabun-spacing;
+  // Item 6
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }

--- a/client/src/features/nutrition/ToolCallCard.tsx
+++ b/client/src/features/nutrition/ToolCallCard.tsx
@@ -1,8 +1,13 @@
 /**
  * ToolCallCard — collapsible card for a single AI tool invocation.
  *
- * Collapsed: tool name + status chip.
+ * Collapsed: tool name + status chip + summary.
  * Expanded: input args + output result (pretty JSON) + one-line friendly summary.
+ *
+ * Polish changes:
+ * 6. No horizontal scroll on mobile — overflow-wrap + contained JSON <pre>.
+ * 7. Consistent font sizes — explicit px on both name and description.
+ * 8. Human-readable tool names via TOOL_LABEL_MAP; title-case fallback.
  */
 import { useState } from 'react';
 import { getToolName } from 'ai';
@@ -10,6 +15,33 @@ import type { DynamicToolUIPart, ToolUIPart } from 'ai';
 import styles from './ToolCallCard.module.scss';
 
 type AnyToolUIPart = ToolUIPart | DynamicToolUIPart;
+
+// ---- Item 8: Human-readable tool name map ----
+const TOOL_LABEL_MAP: Record<string, string> = {
+  search_usda: 'USDA search',
+  search_foods_batch: 'USDA search',
+  lookup_barcode: 'Barcode lookup',
+  get_portions: 'Serving sizes',
+  search_food_history: 'Food history',
+  get_goals_and_today: 'Goals & today',
+  convert_units: 'Unit conversion',
+  convert_to_grams: 'Unit conversion',
+  web_search: 'Web search',
+  web_search_preview: 'Web search',
+  propose_entry: 'Propose entry',
+};
+
+/** Convert snake_case / camelCase to Title Case as a fallback. */
+function toTitleCase(name: string): string {
+  return name
+    .replace(/[_-]/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/\b\w/g, c => c.toUpperCase());
+}
+
+function friendlyToolName(rawName: string): string {
+  return TOOL_LABEL_MAP[rawName] ?? toTitleCase(rawName);
+}
 
 // ---- Friendly summary for known tools ----
 function toolSummary(toolName: string, input: unknown, output: unknown): string {
@@ -40,7 +72,7 @@ function toolSummary(toolName: string, input: unknown, output: unknown): string 
     const meal = (input as { meal?: string })?.meal ?? '';
     return `Proposed ${meal ? meal + ': ' : ''}${name}`;
   }
-  return toolName;
+  return '';
 }
 
 // ---- Status chip ----
@@ -78,7 +110,7 @@ function StatusChip({ state }: StatusChipProps) {
   );
 }
 
-// ---- Pretty JSON ----
+// ---- Pretty JSON (item 6: scrolls within its own box) ----
 function PrettyJson({ value }: { value: unknown }) {
   if (value === undefined || value === null) return <span className={styles.jsonNull}>—</span>;
   return (
@@ -96,7 +128,10 @@ interface ToolCallCardProps {
 export default function ToolCallCard({ part }: ToolCallCardProps) {
   const [expanded, setExpanded] = useState(false);
 
-  const toolName = getToolName(part as ToolUIPart | DynamicToolUIPart);
+  const rawToolName = getToolName(part as ToolUIPart | DynamicToolUIPart);
+  // Item 8: use friendly label in UI; keep raw name for summary lookup
+  const displayName = friendlyToolName(rawToolName);
+
   const isDone = part.state === 'output-available';
   const isError = part.state === 'output-error';
   const input = (part as { input?: unknown }).input as unknown;
@@ -104,7 +139,7 @@ export default function ToolCallCard({ part }: ToolCallCardProps) {
   const errorText = isError ? (part as { errorText: string }).errorText : undefined;
 
   const summary = (isDone || isError)
-    ? toolSummary(toolName, input, output)
+    ? toolSummary(rawToolName, input, output)
     : null;
 
   return (
@@ -116,7 +151,6 @@ export default function ToolCallCard({ part }: ToolCallCardProps) {
         aria-expanded={expanded}
       >
         <span className={styles.chevron} aria-hidden="true">
-          {/* SVG chevron: display:block per iOS SVG rule */}
           <svg
             className={styles.chevronIcon}
             viewBox="0 0 10 6"
@@ -133,7 +167,8 @@ export default function ToolCallCard({ part }: ToolCallCardProps) {
           </svg>
         </span>
 
-        <span className={styles.toolName}>{toolName}</span>
+        {/* Item 8: show friendly name */}
+        <span className={styles.toolName}>{displayName}</span>
 
         <StatusChip state={part.state} />
 

--- a/client/src/styles/Workouts.module.scss
+++ b/client/src/styles/Workouts.module.scss
@@ -10,10 +10,22 @@
 
 .tabs {
   display: flex;
+  flex-wrap: wrap; // never let the 4 tabs cause horizontal page scroll
   gap: 4px;
   margin-bottom: 1.5rem;
   border-bottom: 2px solid $surface;
   padding-bottom: 0;
+}
+
+// Shrink tabs on small screens so all four fit on one row at phone widths
+@media (max-width: 480px) {
+  .tab {
+    padding: 8px 12px;
+    font-size: 15px;
+  }
+  .tabs {
+    gap: 2px;
+  }
 }
 
 .tab {

--- a/migrations/008_ai_usage.sql
+++ b/migrations/008_ai_usage.sql
@@ -1,0 +1,17 @@
+-- AI usage tracking for the nutrition chat agent.
+-- Records per-request token usage and estimated cost per user.
+-- OWNER_EMAIL env var gates the all-users breakdown endpoint.
+-- migrate.js tolerates 1050/1060 so re-runs are safe.
+
+CREATE TABLE IF NOT EXISTS ai_usage (
+  id           INT AUTO_INCREMENT PRIMARY KEY,
+  user_uuid    BINARY(16)   NOT NULL,
+  created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  model        VARCHAR(64)  NULL,
+  input_tokens INT          NULL,
+  output_tokens INT         NULL,
+  reasoning_tokens INT      NULL,
+  total_tokens INT          NULL,
+  cost_usd     FLOAT        NULL,
+  KEY idx_user (user_uuid)
+);

--- a/routes/nutrition.ts
+++ b/routes/nutrition.ts
@@ -8,6 +8,7 @@ import { entryInputSchema, goalsSchema } from '../schemas/nutrition';
 import * as store from '../services/nutrition/store';
 import { searchFoods, lookupBarcode, getPortions } from '../services/nutrition/providers';
 import { streamNutritionChat } from '../services/nutrition/agent';
+import { getUserUsageTotals, getAllUsersUsage, getUserEmail } from '../services/nutrition/usage';
 
 const router = Router();
 router.use(authenticateToken);
@@ -168,6 +169,35 @@ router.put('/goals', async (req, res): Promise<any> => {
   try {
     const data = await store.putGoals(uuid, parsed.data);
     return res.status(200).json({ data, message: 'Goals saved' });
+  } catch (error) {
+    return handleSqlError(error, res);
+  }
+});
+
+// GET /usage — caller's own AI usage totals; owner also gets per-user breakdown.
+// Set OWNER_EMAIL in env/Heroku config to enable the all-users view.
+router.get('/usage', async (req, res): Promise<any> => {
+  const { uuid }: User = res.locals.user;
+  try {
+    const ownTotals = await getUserUsageTotals(uuid);
+
+    // Check if this user is the owner
+    const ownerEmail = process.env.OWNER_EMAIL;
+    let allUsers = undefined;
+    if (ownerEmail) {
+      const callerEmail = await getUserEmail(uuid);
+      if (callerEmail && callerEmail.toLowerCase() === ownerEmail.toLowerCase()) {
+        allUsers = await getAllUsersUsage();
+      }
+    }
+
+    return res.status(200).json({
+      data: {
+        own: ownTotals,
+        ...(allUsers !== undefined ? { allUsers } : {}),
+      },
+      message: 'AI usage retrieved',
+    });
   } catch (error) {
     return handleSqlError(error, res);
   }

--- a/services/nutrition/agent.ts
+++ b/services/nutrition/agent.ts
@@ -7,6 +7,7 @@ import { z } from 'zod';
 import { proposeEntryArgsSchema } from '../../schemas/nutrition';
 import * as store from './store';
 import * as providers from './providers';
+import { recordUsage } from './usage';
 
 export interface NutritionChatOptions {
   userUuid: string;
@@ -65,10 +66,18 @@ TODAY'S DATE: ${selectedDate}
 ## Your job
 Help the user identify, quantify, and log what they ate. When the user describes food:
 1. Search for it with \`search_usda\` (or \`lookup_barcode\` for barcodes) to get accurate per-100g macros — NEVER invent or estimate calories without grounding them in a tool result.
+   - For a **multi-item meal** (two or more distinct foods in one message), use ONE \`search_foods_batch\` call with all queries at once instead of multiple \`search_usda\` calls. Use \`search_usda\` only for single-item lookups.
 2. Use \`get_portions\` to find common household serving sizes when helpful.
 3. Check \`search_food_history\` first for foods the user has logged before — prefer reusing those if the food matches.
-4. Estimate the portion in **grams**. Ask one brief clarifying question if the portion or food identity is genuinely ambiguous (e.g. "Was that a small, medium, or large banana?"). Do not ask multiple questions at once.
+4. Estimate the portion in **grams**. When the user gives a weight in non-gram units (lbs, oz, kg, mg, etc.), call \`convert_to_grams\` — do NOT do the arithmetic yourself. Ask one brief clarifying question if the portion or food identity is genuinely ambiguous (e.g. "Was that a small, medium, or large banana?"). Do not ask multiple questions at once.
 5. When you are confident about identity + portion, call **\`propose_entry\`** with the fully structured entry. The user will review and confirm in the UI — you do NOT write to the database. After calling propose_entry, tell the user briefly what you proposed (e.g. "I've proposed logging 1 medium banana (118 g, ~105 kcal) for breakfast — check the entry below.").
+
+## Web-search fallback
+- Only use \`web_search\` when \`search_usda\`, \`search_foods_batch\`, and \`lookup_barcode\` all return nothing useful (e.g. a local restaurant item, branded boba, or a food not in USDA/OFF).
+- Prefer official brand or restaurant nutrition pages. Extract per-serving or per-100g macros.
+- **Always cite the source URL** in your reply when using web-search data.
+- Use ingredient \`source: 'manual'\` for any web-derived items.
+- Be conservative and explicitly note uncertainty: web nutrition data can be inaccurate.
 
 ## Rules
 - Ground all macros in tool results. If a search returns no results, say so and ask the user for more info.
@@ -99,15 +108,49 @@ ${summariseEntries(recent)}
         reasoningSummary: 'auto',
       },
     },
+    onFinish: ({ usage }) => {
+      // Best-effort usage recording — never await, never throw.
+      const inputTokens = usage.inputTokens ?? 0;
+      const outputTokens = usage.outputTokens ?? 0;
+      const reasoningTokens = usage.outputTokenDetails?.reasoningTokens ?? 0;
+      const totalTokens = usage.totalTokens ?? (inputTokens + outputTokens);
+      recordUsage(userUuid, 'gpt-5.5', {
+        inputTokens,
+        outputTokens,
+        reasoningTokens,
+        totalTokens,
+      });
+    },
     tools: {
       /** Full-text food search against USDA FoodData Central (+ OFF fallback). Returns per-100g macros. */
       search_usda: tool({
         description:
-          'Search for a food in USDA FoodData Central and Open Food Facts. Returns up to 5 candidates with per-100g macros. Always call this before estimating calories for a generic food.',
+          'Search for a SINGLE food in USDA FoodData Central and Open Food Facts. Returns up to 5 candidates with per-100g macros. Use search_foods_batch instead when the user describes two or more foods at once.',
         inputSchema: z.object({
           query: z.string().describe('Food name or description to search for, e.g. "banana" or "chicken breast raw"'),
         }),
         execute: async ({ query }) => providers.searchFoods(query),
+      }),
+
+      /** Batched USDA search — one call for multi-item meals. */
+      search_foods_batch: tool({
+        description:
+          'Search for multiple foods in one call. Use this when the user describes two or more distinct foods in a single message (e.g. "rice, chicken, and broccoli"). Runs all searches in parallel and returns results grouped per query.',
+        inputSchema: z.object({
+          queries: z
+            .array(z.string())
+            .min(2)
+            .describe('Array of food names/descriptions to search for, e.g. ["white rice", "chicken breast", "broccoli"]'),
+        }),
+        execute: async ({ queries }) => {
+          const results = await Promise.all(
+            queries.map(async (query) => ({
+              query,
+              results: await providers.searchFoods(query),
+            })),
+          );
+          return results;
+        },
       }),
 
       /** Open Food Facts barcode lookup. */
@@ -157,6 +200,64 @@ ${summariseEntries(recent)}
             }),
           ),
       }),
+
+      /**
+       * Deterministic weight-unit converter. Use this instead of doing math yourself
+       * to avoid unit-conversion errors (e.g. lbs→g or oz→g).
+       */
+      convert_to_grams: tool({
+        description:
+          'Convert a weight amount from a given unit to grams. Handles: lb/lbs/pound, oz/ounce, kg, g, mg. Returns null with a note for volume units (ml, cup, tbsp, tsp) since those require density.',
+        inputSchema: z.object({
+          amount: z.number().describe('Numeric quantity to convert, e.g. 1.5'),
+          unit: z.string().describe('Unit string, e.g. "lbs", "oz", "kg", "g", "mg"'),
+        }),
+        execute: async ({ amount, unit }) => {
+          const u = unit.trim().toLowerCase();
+          const massFactors: Record<string, number> = {
+            lb: 453.592,
+            lbs: 453.592,
+            pound: 453.592,
+            pounds: 453.592,
+            oz: 28.3495,
+            ounce: 28.3495,
+            ounces: 28.3495,
+            kg: 1000,
+            kilogram: 1000,
+            kilograms: 1000,
+            g: 1,
+            gram: 1,
+            grams: 1,
+            mg: 0.001,
+            milligram: 0.001,
+            milligrams: 0.001,
+          };
+          if (u in massFactors) {
+            const grams = amount * massFactors[u];
+            return { grams: Math.round(grams * 10) / 10, unit: u, original: amount };
+          }
+          // Volume units — cannot convert without density
+          const volumeUnits = ['ml', 'l', 'cup', 'cups', 'tbsp', 'tsp', 'fl oz', 'floz', 'litre', 'liter'];
+          if (volumeUnits.some((v) => u === v || u.startsWith(v))) {
+            return {
+              grams: null,
+              note: `Cannot convert volume unit "${unit}" to grams without knowing the food's density. Please estimate grams directly or look up a typical serving weight.`,
+            };
+          }
+          return {
+            grams: null,
+            note: `Unknown unit "${unit}". Supported mass units: lb/lbs/pound, oz/ounce, kg, g, mg.`,
+          };
+        },
+      }),
+
+      /**
+       * Web search — fallback for foods USDA/OFF don't have (e.g. local restaurant items,
+       * branded boba). Only use after search_usda / search_foods_batch / lookup_barcode
+       * all return nothing useful. Always cite the source URL in your reply.
+       * Use ingredient source: 'manual' for web-derived items.
+       */
+      web_search: openai.tools.webSearch(),
 
       /**
        * propose_entry: echoes its validated args as output so the stream terminates

--- a/services/nutrition/usage.ts
+++ b/services/nutrition/usage.ts
@@ -1,0 +1,142 @@
+// Nutrition AI usage tracking — records token usage + cost per /chat request.
+// All DB writes are best-effort: a failed insert must never break the chat stream.
+import { RowDataPacket } from 'mysql2';
+import pool from '../../database';
+
+// ---------------------------------------------------------------------------
+// Pricing constants (per 1 M tokens). Override via env vars if OpenAI changes
+// pricing; set to 0 if GPT-5.5 pricing is unknown until confirmed.
+//
+// NOTE: GPT-5.5 pricing has not been officially published as of the time this
+// code was written. Set OWNER_EMAIL, GPT55_INPUT_PER_1M, and GPT55_OUTPUT_PER_1M
+// in your .env / Heroku config vars once pricing is confirmed.
+// ---------------------------------------------------------------------------
+const INPUT_PER_1M = Number(process.env.GPT55_INPUT_PER_1M ?? 0);
+const OUTPUT_PER_1M = Number(process.env.GPT55_OUTPUT_PER_1M ?? 0);
+
+export interface UsageData {
+  inputTokens: number;
+  outputTokens: number;
+  /** Reasoning tokens are billed as output tokens. */
+  reasoningTokens: number;
+  totalTokens: number;
+}
+
+function computeCost(data: UsageData): number {
+  // Reasoning tokens are billed as output tokens (already included in outputTokens
+  // from the AI SDK's totalUsage). We compute cost on inputTokens + outputTokens.
+  const inputCost = (data.inputTokens / 1_000_000) * INPUT_PER_1M;
+  const outputCost = (data.outputTokens / 1_000_000) * OUTPUT_PER_1M;
+  return inputCost + outputCost;
+}
+
+/** Insert one ai_usage row. Never throws — failures are logged and silenced. */
+export async function recordUsage(
+  userUuid: string,
+  model: string,
+  data: UsageData,
+): Promise<void> {
+  try {
+    const costUsd = computeCost(data);
+    await pool.query(
+      `INSERT INTO ai_usage
+         (user_uuid, model, input_tokens, output_tokens, reasoning_tokens, total_tokens, cost_usd)
+       VALUES (UUID_TO_BIN(?), ?, ?, ?, ?, ?, ?)`,
+      [
+        userUuid,
+        model,
+        data.inputTokens,
+        data.outputTokens,
+        data.reasoningTokens,
+        data.totalTokens,
+        costUsd,
+      ],
+    );
+  } catch (err) {
+    // Best-effort: log but never propagate so the chat stream is unaffected.
+    console.error('[ai_usage] failed to record usage:', err);
+  }
+}
+
+export interface UserUsageTotals {
+  requestCount: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalReasoningTokens: number;
+  totalTokens: number;
+  totalCostUsd: number;
+}
+
+/** Return aggregated usage totals for the given user. */
+export async function getUserUsageTotals(userUuid: string): Promise<UserUsageTotals> {
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `SELECT
+       COUNT(*) AS requestCount,
+       COALESCE(SUM(input_tokens), 0)     AS totalInputTokens,
+       COALESCE(SUM(output_tokens), 0)    AS totalOutputTokens,
+       COALESCE(SUM(reasoning_tokens), 0) AS totalReasoningTokens,
+       COALESCE(SUM(total_tokens), 0)     AS totalTokens,
+       COALESCE(SUM(cost_usd), 0)         AS totalCostUsd
+     FROM ai_usage
+     WHERE user_uuid = UUID_TO_BIN(?)`,
+    [userUuid],
+  );
+  const row = rows[0];
+  return {
+    requestCount: Number(row.requestCount),
+    totalInputTokens: Number(row.totalInputTokens),
+    totalOutputTokens: Number(row.totalOutputTokens),
+    totalReasoningTokens: Number(row.totalReasoningTokens),
+    totalTokens: Number(row.totalTokens),
+    totalCostUsd: Number(row.totalCostUsd),
+  };
+}
+
+export interface AllUsersRow {
+  email: string;
+  userUuid: string;
+  requestCount: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalReasoningTokens: number;
+  totalTokens: number;
+  totalCostUsd: number;
+}
+
+/** Return per-user breakdown (all users). Only called for the owner. */
+export async function getAllUsersUsage(): Promise<AllUsersRow[]> {
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `SELECT
+       u.email,
+       BIN_TO_UUID(u.user_uuid) AS userUuid,
+       COUNT(a.id)                        AS requestCount,
+       COALESCE(SUM(a.input_tokens), 0)     AS totalInputTokens,
+       COALESCE(SUM(a.output_tokens), 0)    AS totalOutputTokens,
+       COALESCE(SUM(a.reasoning_tokens), 0) AS totalReasoningTokens,
+       COALESCE(SUM(a.total_tokens), 0)     AS totalTokens,
+       COALESCE(SUM(a.cost_usd), 0)         AS totalCostUsd
+     FROM users u
+     LEFT JOIN ai_usage a ON a.user_uuid = u.user_uuid
+     GROUP BY u.user_uuid, u.email
+     ORDER BY totalCostUsd DESC`,
+  );
+  return rows.map((row) => ({
+    email: row.email,
+    userUuid: row.userUuid,
+    requestCount: Number(row.requestCount),
+    totalInputTokens: Number(row.totalInputTokens),
+    totalOutputTokens: Number(row.totalOutputTokens),
+    totalReasoningTokens: Number(row.totalReasoningTokens),
+    totalTokens: Number(row.totalTokens),
+    totalCostUsd: Number(row.totalCostUsd),
+  }));
+}
+
+/** Look up a user's email by UUID (to compare against OWNER_EMAIL). */
+export async function getUserEmail(userUuid: string): Promise<string | null> {
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `SELECT email FROM users WHERE user_uuid = UUID_TO_BIN(?)`,
+    [userUuid],
+  );
+  return rows.length > 0 ? (rows[0].email as string) : null;
+}


### PR DESCRIPTION
Batch of gate-2 feedback (all delegated to Sonnet agents; verified end-to-end via Playwright on mobile).

**Chat UX:** custom peeking bottom sheet (vaul removed — wrong tool), per-day localStorage persistence, auto-grow textarea, markdown rendering, hide empty reasoning, no mobile horizontal scroll (incl. fixing the 4-tab nav overflow), consistent mobile font sizes, human-readable tool names.

**Agent:** batched USDA search (one card for multi-item meals), web-search fallback (`openai.tools.webSearch()`, only when USDA/OFF miss), deterministic unit-conversion tool, and per-user AI usage/cost tracking (migration 008, `onFinish` recording, `GET /api/nutrition/usage`).

Verified: peek sheet, batched search, 8 oz→226.8 g conversion, web-search fallback (asked a sugar-level follow-up), markdown reasoning, usage row ($0.125 @ $5/$30), no h-scroll, persistence. Needs Heroku: `GPT55_INPUT_PER_1M=5`, `GPT55_OUTPUT_PER_1M=30`, `OWNER_EMAIL`; migration 008.

🤖 Generated with [Claude Code](https://claude.com/claude-code)