### PR TITLE
Body-weight time-scale chart + feedback success polish (#80 #63)

### DIFF
--- a/client/src/components/BodyWeightTracker.jsx
+++ b/client/src/components/BodyWeightTracker.jsx
@@ -117,7 +117,11 @@ function BodyWeightTracker() {
             <LineChart data={chartData} margin={{ top: 10, right: 16, left: 0, bottom: 0 }} style={{ fontFamily: 'Sarabun, sans-serif' }}>
               <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.08)" />
               <XAxis
-                dataKey="date"
+                dataKey="rawDate"
+                type="number"
+                scale="time"
+                domain={['dataMin', 'dataMax']}
+                tickFormatter={(ms) => format(new Date(ms), 'MMM d')}
                 tick={{ fill: '#EBEDE9', fontSize: 12, fontFamily: 'Sarabun, sans-serif' }}
                 axisLine={{ stroke: '#575757' }}
                 tickLine={false}
@@ -137,6 +141,7 @@ function BodyWeightTracker() {
                   color: '#EBEDE9',
                   fontFamily: 'Sarabun, sans-serif',
                 }}
+                labelFormatter={(ms) => format(new Date(ms), 'MMM d, yyyy')}
                 formatter={(value) => [`${value} lbs`, 'Weight']}
               />
               <Line

--- a/client/src/features/nutrition/FeedbackModal.module.scss
+++ b/client/src/features/nutrition/FeedbackModal.module.scss
@@ -138,7 +138,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 24px 0 12px;
+  // No extra padding — the parent .modal gap and existing header margin provide sufficient spacing
 }
 
 .successMsg {


### PR DESCRIPTION
## Summary

- **#80** Converts the body-weight chart X-axis from categorical string labels to a real numeric time scale (`type="number"`, `scale="time"`, `domain={['dataMin','dataMax']}`, `tickFormatter` using date-fns `format`). A month-wide gap now renders proportionally wider than a one-day gap. Tooltip `labelFormatter` added so hover still shows a readable date.
- **#63** Removes the excess `padding: 24px 0 12px` on `.successState` in `FeedbackModal.module.scss`. The thank-you message now sits compactly inside the modal's existing flex gap, eliminating the large empty region visible after feedback submission.

## Files changed

- `client/src/components/BodyWeightTracker.jsx`
- `client/src/features/nutrition/FeedbackModal.module.scss`

## Test plan

- [ ] Log multiple body-weight entries spread across different weeks/months; confirm the X-axis tick spacing reflects actual elapsed time (not uniform categorical spacing).
- [ ] Hover a data point; confirm tooltip shows "MMM d, yyyy" label and "X lbs / Weight" value.
- [ ] Open the Feedback modal, submit feedback, confirm the success message appears without excessive whitespace below the title.
- [ ] `npm run build` in `client/` passes with no new errors.

Closes #80
Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)