### PR TITLE
Mobile tabs: hamburger menu (#79)

### DIFF
--- a/client/src/pages/Workouts.jsx
+++ b/client/src/pages/Workouts.jsx
@@ -3,7 +3,7 @@ import AddSection from '../components/AddSection.jsx';
 import BodyWeightTracker from '../components/BodyWeightTracker.jsx';
 import HabitTracker from '../components/HabitTracker.jsx';
 import NutritionTracker from '../features/nutrition/NutritionTracker';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import styles from "../styles/Workouts.module.scss";
 import Header from '../components/Header.jsx';
@@ -18,12 +18,21 @@ const TABS = {
   NUTRITION: 'nutrition',
 };
 
+const TAB_LABELS = {
+  [TABS.WORKOUTS]: 'Workouts',
+  [TABS.BODY_WEIGHT]: 'Body Weight',
+  [TABS.HABITS]: 'Habits',
+  [TABS.NUTRITION]: 'Nutrition',
+};
+
 const VALID_TABS = new Set(Object.values(TABS));
 
 function Workouts() {
   const [sections, setSections] = useState([]);
   const { user } = useAuth();
   const [searchParams, setSearchParams] = useSearchParams();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef(null);
 
   // Derive active tab from URL; fall back to WORKOUTS for unknown values
   const tabParam = searchParams.get('tab');
@@ -37,8 +46,32 @@ function Workouts() {
     }
   }, [user, activeTab, setSearchParams]);
 
+  // Close mobile menu on outside tap or Escape key
+  useEffect(() => {
+    if (!menuOpen) return;
+    function handlePointerDown(e) {
+      if (menuRef.current && !menuRef.current.contains(e.target)) {
+        setMenuOpen(false);
+      }
+    }
+    function handleKeyDown(e) {
+      if (e.key === 'Escape') setMenuOpen(false);
+    }
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [menuOpen]);
+
   const switchTab = (tab) => {
     setSearchParams({ tab }, { replace: false });
+  };
+
+  const handleMobileTabSelect = (tab) => {
+    switchTab(tab);
+    setMenuOpen(false);
   };
 
   const sectionsQuery = useQuery({
@@ -59,10 +92,17 @@ function Workouts() {
     }
   }, [sectionsQuery.data]);
 
+  // Build the list of available tabs (respecting auth gating)
+  const availableTabs = [
+    TABS.WORKOUTS,
+    ...(user ? [TABS.BODY_WEIGHT, TABS.HABITS, TABS.NUTRITION] : []),
+  ];
+
   return (
     <>
       <Header />
       <main className={styles.container}>
+        {/* Desktop tab row — hidden on mobile via CSS */}
         <nav className={styles.tabs}>
           <button
             className={`${styles.tab} ${activeTab === TABS.WORKOUTS ? styles.tabActive : ''}`}
@@ -93,6 +133,59 @@ function Workouts() {
             </>
           )}
         </nav>
+
+        {/* Mobile hamburger nav — shown on mobile, hidden on desktop via CSS */}
+        <div className={styles.mobileNav} ref={menuRef}>
+          <button
+            className={styles.mobileNavToggle}
+            onClick={() => setMenuOpen((v) => !v)}
+            aria-haspopup="listbox"
+            aria-expanded={menuOpen}
+            aria-label={`Current tab: ${TAB_LABELS[activeTab]}. Open tab menu`}
+          >
+            <span className={styles.mobileNavLabel}>{TAB_LABELS[activeTab]}</span>
+            {/* Chevron SVG — display:block to avoid iOS Safari inline-block bug */}
+            <svg
+              className={`${styles.mobileNavChevron} ${menuOpen ? styles.mobileNavChevronOpen : ''}`}
+              width="16"
+              height="16"
+              viewBox="0 0 16 16"
+              fill="none"
+              aria-hidden="true"
+              style={{ display: 'block' }}
+            >
+              <path d="M4 6l4 4 4-4" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </button>
+
+          {menuOpen && (
+            <ul className={styles.mobileNavMenu} role="listbox" aria-label="Select tab">
+              {availableTabs.map((tab) => (
+                <li key={tab} role="option" aria-selected={tab === activeTab}>
+                  <button
+                    className={`${styles.mobileNavItem} ${tab === activeTab ? styles.mobileNavItemActive : ''}`}
+                    onClick={() => handleMobileTabSelect(tab)}
+                  >
+                    {TAB_LABELS[tab]}
+                    {tab === activeTab && (
+                      /* Checkmark SVG — display:block to avoid iOS Safari inline-block bug */
+                      <svg
+                        width="14"
+                        height="14"
+                        viewBox="0 0 14 14"
+                        fill="none"
+                        aria-hidden="true"
+                        style={{ display: 'block' }}
+                      >
+                        <path d="M2.5 7l3.5 3.5 5.5-6" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+                      </svg>
+                    )}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
 
         {/* All panels stay mounted to preserve in-memory state; hidden via CSS */}
         <div style={{ display: activeTab === TABS.WORKOUTS ? undefined : 'none' }}>

--- a/client/src/styles/Workouts.module.scss
+++ b/client/src/styles/Workouts.module.scss
@@ -8,6 +8,8 @@
   }
 }
 
+// ── Desktop tab row ─────────────────────────────────────────────────────────
+// Visible on desktop, hidden on mobile (replaced by .mobileNav)
 .tabs {
   display: flex;
   flex-wrap: wrap; // never let the 4 tabs cause horizontal page scroll
@@ -15,16 +17,9 @@
   margin-bottom: 1.5rem;
   border-bottom: 2px solid $surface;
   padding-bottom: 0;
-}
 
-// Shrink tabs on small screens so all four fit on one row at phone widths
-@media (max-width: 480px) {
-  .tab {
-    padding: 8px 12px;
-    font-size: 15px;
-  }
-  .tabs {
-    gap: 2px;
+  @media (max-width: $mobile-width) {
+    display: none;
   }
 }
 
@@ -45,16 +40,108 @@
   &:hover {
     color: $text;
   }
-
-  @media (max-width: $mobile-width) {
-    font-size: 16px;
-    padding: 8px 14px;
-  }
 }
 
 .tabActive {
   color: $primary;
   border-bottom-color: $primary-border;
+}
+
+// ── Mobile hamburger nav ─────────────────────────────────────────────────────
+// Hidden on desktop, visible on mobile
+.mobileNav {
+  display: none;
+  position: relative;
+  margin-bottom: 1.5rem;
+  border-bottom: 2px solid $surface;
+  padding-bottom: 0;
+
+  @media (max-width: $mobile-width) {
+    display: block;
+  }
+}
+
+.mobileNavToggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: none;
+  border-bottom: 3px solid $primary-border;
+  margin-bottom: -2px;
+  padding: 10px 4px;
+  cursor: pointer;
+  color: $primary;
+  font-family: $sarabun;
+  font-size: 18px;
+  font-weight: 500;
+  letter-spacing: $sarabun-spacing;
+  // Ensure good tap target size
+  min-height: 44px;
+  min-width: 44px;
+}
+
+.mobileNavLabel {
+  // no extra styles needed — inherits from toggle
+}
+
+.mobileNavChevron {
+  flex-shrink: 0;
+  transition: transform 0.2s ease;
+  color: $primary;
+}
+
+.mobileNavChevronOpen {
+  transform: rotate(180deg);
+}
+
+.mobileNavMenu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 100;
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+  background: $surface;
+  border: 1px solid $surface-border;
+  border-radius: $border-radius;
+  min-width: 160px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+
+  li {
+    margin: 0;
+    padding: 0;
+  }
+}
+
+.mobileNavItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  background: transparent;
+  border: none;
+  padding: 12px 16px;
+  cursor: pointer;
+  color: rgba($text, 0.7);
+  font-family: $sarabun;
+  font-size: 17px;
+  font-weight: 500;
+  letter-spacing: $sarabun-spacing;
+  text-align: left;
+  // Ensure good tap target size on mobile
+  min-height: 44px;
+  transition: background 0.12s ease, color 0.12s ease;
+
+  &:active {
+    background: $primary-translucent;
+  }
+}
+
+.mobileNavItemActive {
+  color: $primary;
 }
 
 .sectionWrapper {


### PR DESCRIPTION
## Summary

- On mobile (≤ 885 px) the four-tab row is hidden and replaced by a hamburger-style dropdown: a toggle button shows the active tab name + chevron, opening a positioned menu of available tabs.
- On desktop the existing horizontal tab row is completely unchanged.
- Auth-gated tabs (Body Weight / Habits / Nutrition) still only appear in the menu when the user is logged in.
- URL `?tab=` state, `switchTab`, and `setSearchParams` are fully preserved — back/forward navigation works as before.

## Files changed

- `client/src/pages/Workouts.jsx` — added `menuOpen` state, `menuRef`, outside-tap/Escape listener, `availableTabs` list, and mobile `<div class=mobileNav>` markup.
- `client/src/styles/Workouts.module.scss` — added `.mobileNav*` classes; desktop `.tabs` hidden via `display:none` at `$mobile-width` (885 px); removed the now-redundant `@media (max-width: 480px)` shrink block.

## Test plan

- [ ] On a narrow viewport (< 885 px): hamburger toggle is visible; desktop tab row is not.
- [ ] Tapping toggle opens the dropdown; tapping a tab switches the URL `?tab=` and closes the menu.
- [ ] Tapping outside the dropdown closes it; pressing Escape also closes it.
- [ ] Logged-out user only sees "Workouts" in the menu.
- [ ] Logged-in user sees all four tabs; selecting a gated tab renders the correct component.
- [ ] On desktop (> 885 px): normal tab row visible, hamburger hidden.
- [ ] `npm run build` in `client/` passes with no errors.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)