### PR TITLE
Entry editor + AI proposal: notes, grams total, unit dropdown (#67 #68 #69)

### DIFF
--- a/client/src/features/nutrition/EntryEditor.module.scss
+++ b/client/src/features/nutrition/EntryEditor.module.scss
@@ -10,13 +10,15 @@
 
 // #9: Inline proposal card — renders in-flow inside the chat message list.
 // No Dialog overlay; the card is visually contained within the chat thread.
+// overflow: visible (not hidden) so the native <select> popup and search dropdowns
+// are not clipped by the card boundary (#69).
 .inlineEditorCard {
   width: 100%;
   max-width: 100%;
   background-color: $surface;
   border: 1px solid rgba($primary-border, 0.4);
   border-radius: 14px;
-  overflow: hidden;
+  overflow: visible;
   box-sizing: border-box;
 }
 
@@ -225,12 +227,15 @@
   align-items: flex-end;
 }
 
-// Qty + Unit travel together; they shrink but never disappear
+// Qty + Unit travel together; they shrink but never disappear.
+// overflow: visible ensures the native <select> popup is not clipped (#69).
 .portionGroup {
   display: flex;
   gap: 8px;
   align-items: flex-end;
   flex-shrink: 0;
+  overflow: visible;
+  position: relative;
 }
 
 // The four macros also stay together and can wrap as a unit
@@ -445,6 +450,21 @@
   font-size: 14px;
   color: $error;
   letter-spacing: $sarabun-spacing;
+}
+
+// AI proposal notes — shown conditionally only when the LLM supplies non-obvious
+// context (e.g. why odd decimal grams were chosen). Styled as a subtle aside.
+.proposalNotes {
+  margin: 0;
+  padding: 8px 12px;
+  font-family: $sarabun;
+  font-size: 13px;
+  color: rgba($text, 0.6);
+  letter-spacing: $sarabun-spacing;
+  background-color: rgba($surface-border, 0.15);
+  border-left: 3px solid rgba($primary-border, 0.5);
+  border-radius: 0 6px 6px 0;
+  line-height: 1.5;
 }
 
 // Footer

--- a/client/src/features/nutrition/EntryEditor.tsx
+++ b/client/src/features/nutrition/EntryEditor.tsx
@@ -579,17 +579,21 @@ interface TotalsProps {
 function Totals({ rows }: TotalsProps) {
   const totals = rows.reduce(
     (acc, r) => ({
+      grams: acc.grams + r.grams,
       calories: acc.calories + r.calories,
       protein_g: acc.protein_g + r.protein_g,
       carbs_g: acc.carbs_g + r.carbs_g,
       fat_g: acc.fat_g + r.fat_g,
     }),
-    { calories: 0, protein_g: 0, carbs_g: 0, fat_g: 0 },
+    { grams: 0, calories: 0, protein_g: 0, carbs_g: 0, fat_g: 0 },
   );
 
   return (
     <div className={styles.totals}>
       <span className={styles.totalsLabel}>Total</span>
+      <span className={styles.totalsStat}>
+        <strong>{round2(totals.grams)}</strong>g
+      </span>
       <span className={styles.totalsStat}>
         <strong>{Math.round(totals.calories)}</strong> kcal
       </span>
@@ -893,6 +897,11 @@ export default function EntryEditor({
 
       {/* Live totals */}
       <Totals rows={rows} />
+
+      {/* AI proposal notes — only shown when present (explains non-obvious choices) */}
+      {isProposal && mode.kind === 'proposal' && mode.proposal.notes && (
+        <p className={styles.proposalNotes}>{mode.proposal.notes}</p>
+      )}
 
       {/* Save error */}
       {saveError && (

--- a/client/src/features/nutrition/types.ts
+++ b/client/src/features/nutrition/types.ts
@@ -58,6 +58,9 @@ export interface ProposeIngredient extends IngredientInput {
 }
 
 // What the agent's propose_entry tool emits (no localDate; serving-aware rows).
+// `notes` is OPTIONAL — populated ONLY when the AI needs to explain a confusing
+// or non-obvious choice (e.g. odd decimal grams, ambiguous food selection). Must
+// NOT be an always-present summary.
 export interface ProposeEntryArgs {
   meal: Meal;
   name: string;
@@ -65,6 +68,7 @@ export interface ProposeEntryArgs {
   barcode?: string | null;
   raw_llm_json?: unknown;
   ingredients: ProposeIngredient[];
+  notes?: string | null;
 }
 
 export interface EntryInput {

--- a/schemas/nutrition.ts
+++ b/schemas/nutrition.ts
@@ -101,9 +101,17 @@ export type ProposeIngredient = z.infer<typeof proposeIngredientSchema>;
 // (the client supplies the selected day on confirm), with serving-aware ingredients.
 // Rendered as the EntryEditor in proposal mode; on confirm the client adds
 // localDate -> EntryInput -> POST /entries.
+//
+// `notes` is OPTIONAL and should be populated ONLY when the AI needs to explain
+// a confusing or non-obvious choice (e.g. why odd decimal grams were used, or
+// why a particular database entry was selected over others). It must NOT be an
+// always-on summary of the proposal.
 export const proposeEntryArgsSchema = entryInputSchema
   .omit({ localDate: true, ingredients: true })
-  .extend({ ingredients: z.array(proposeIngredientSchema).min(1) });
+  .extend({
+    ingredients: z.array(proposeIngredientSchema).min(1),
+    notes: z.string().max(400).nullable().optional(),
+  });
 export type ProposeEntryArgs = z.infer<typeof proposeEntryArgsSchema>;
 export type FoodSearchResult = z.infer<typeof foodSearchResultSchema>;
 

--- a/services/nutrition/agent.ts
+++ b/services/nutrition/agent.ts
@@ -89,6 +89,14 @@ When proposing an entry with \`propose_entry\`, for EACH ingredient:
 6. Sum ingredient macros to produce the entry's total macros. Do NOT use a different total than this sum.
 7. If a food was previously logged (from \`search_food_history\`), prefer the same serving and grams unless the user specifies otherwise.
 
+## The `notes` field in propose_entry (OPTIONAL — use sparingly)
+The `notes` field on a proposal is OPTIONAL and should only be populated when you need to explain a confusing or non-obvious choice to the user — for example:
+- Why an odd decimal gram weight was chosen (e.g. "1 medium egg from USDA is 49.6 g per the database serving size")
+- Why a less-obvious food database entry was selected over an alternative
+- Why a specific portion size was picked when the user's description was ambiguous
+
+DO NOT populate `notes` when the proposal is straightforward (e.g. "200g chicken breast"). Do NOT use `notes` as an always-present summary of what you logged — your chat reply already serves that purpose. Leave `notes` null/absent in the vast majority of proposals.
+
 ## Other rules
 - Ground all macros in tool results. If a search returns no results, say so and ask the user for more info.
 - For mixed dishes (e.g. "chicken stir-fry"), break into constituent ingredients, each with their own source_ref.


### PR DESCRIPTION
## Summary

- **#67** Add an optional `notes` field to `propose_entry` so the LLM can explain non-obvious choices (odd decimal grams, ambiguous food selection) without spamming users with an always-on summary. Backend zod schema (`proposeEntryArgsSchema`), client `ProposeEntryArgs` type, and system-prompt guidance in `agent.ts` all updated. `EntryEditor` renders the note conditionally below the Totals bar with a subtle left-border callout style.
- **#68** The Totals bar now sums effective grams (sum of each ingredient row's `grams`) in addition to calories / protein / carbs / fat.
- **#69** Fix native `<select>` popup clipping: `.inlineEditorCard` changed from `overflow: hidden` to `overflow: visible` so the OS dropdown isn't clipped by the proposal card boundary. `.portionGroup` gains `overflow: visible; position: relative` for the same reason.

## Files changed

- `schemas/nutrition.ts` — `proposeEntryArgsSchema` extended with `notes?: string | null`
- `services/nutrition/agent.ts` — system prompt guidance for `notes` usage
- `client/src/features/nutrition/types.ts` — `ProposeEntryArgs.notes?: string | null`
- `client/src/features/nutrition/EntryEditor.tsx` — grams total in `Totals`; conditional `notes` display in proposal mode
- `client/src/features/nutrition/EntryEditor.module.scss` — `.proposalNotes` style; overflow fix on `.inlineEditorCard` and `.portionGroup`

## Test plan

- [ ] Client `vite build` passes (verified: 0 errors)
- [ ] Backend `tsc --noEmit` passes (verified: 0 errors)
- [ ] Propose a simple food entry — no `notes` field appears in the UI
- [ ] Propose an entry where the LLM populates `notes` — the callout appears below Totals
- [ ] Totals bar shows a grams value matching the sum of ingredient rows
- [ ] Open the entry editor in a chat proposal card — the unit dropdown popup is not clipped

Closes #67
Closes #68
Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)