### PR TITLE
Nutrition chrome + app-wide feedback (#60 #72 #73)

### DIFF
--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -1,28 +1,70 @@
+import { useState } from "react";
 import styles from "../styles/Header.module.scss";
 import { Link } from "react-router-dom";
 import { useUser } from "../context/UserProvider";
 import AccountMenu from "./AccountMenu";
+import FeedbackModal from "../features/nutrition/FeedbackModal";
 
 function Header() {
   const { user } = useUser();
+  const [feedbackOpen, setFeedbackOpen] = useState(false);
 
   return (
-    <header className={styles.header}>
-      <Link to="/" className={styles.logo}>
-        <span className={styles.title}>Peak</span>
-      </Link>
-      <div className={styles.authLinks}>
-        {user == null
-          ? (
-            <>
-              <Link to="/sign-up" className={styles.transparentButton}>Sign Up</Link>
-              <Link to="/sign-in" className={styles.solidButton}>Sign In</Link>
-            </>
-          )
-          : <AccountMenu />
-        }
-      </div>
-    </header>
+    <>
+      <header className={styles.header}>
+        <Link to="/" className={styles.logo}>
+          <span className={styles.title}>Peak</span>
+        </Link>
+
+        <div className={styles.headerRight}>
+          {/* #60: Feedback icon button — visible on every tab, logged in or not */}
+          <button
+            className={styles.feedbackBtn}
+            onClick={() => setFeedbackOpen(true)}
+            aria-label="Send feedback"
+            title="Send feedback"
+          >
+            {/* Speech bubble with a heart — clearly "feedback", not settings */}
+            <svg
+              className={styles.feedbackIcon}
+              viewBox="0 0 22 22"
+              fill="none"
+              aria-hidden="true"
+            >
+              <path
+                d="M4 2h14a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H7l-5 4V4a2 2 0 0 1 2-2z"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M8.5 9.5c0-1.1.9-2 2-2s2 .9 2 2c0 1.5-2 3-2 3s-2-1.5-2-3z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+
+          <div className={styles.authLinks}>
+            {user == null
+              ? (
+                <>
+                  <Link to="/sign-up" className={styles.transparentButton}>Sign Up</Link>
+                  <Link to="/sign-in" className={styles.solidButton}>Sign In</Link>
+                </>
+              )
+              : <AccountMenu />
+            }
+          </div>
+        </div>
+      </header>
+
+      {/* #60: FeedbackModal mounted globally at app level via Header */}
+      <FeedbackModal
+        open={feedbackOpen}
+        onClose={() => setFeedbackOpen(false)}
+      />
+    </>
   );
 }
 

--- a/client/src/features/nutrition/NutritionTracker.module.scss
+++ b/client/src/features/nutrition/NutritionTracker.module.scss
@@ -119,27 +119,6 @@
   }
 }
 
-// Item 1: Feedback button — clearly placed, clearly tappable on mobile
-.feedbackBtn {
-  flex: 0 1 auto;
-  min-height: 48px;
-  padding: 10px 16px;
-  background: transparent;
-  color: rgba($text, 0.6);
-  border: 2px solid rgba($surface-border, 0.6);
-  border-radius: $border-radius;
-  font-family: $sarabun;
-  font-size: 14px;
-  font-weight: 600;
-  letter-spacing: $sarabun-spacing;
-  cursor: pointer;
-
-  &:active {
-    color: $primary;
-    border-color: $primary-border;
-    background-color: rgba($primary, 0.08);
-  }
-}
 
 .settingsBtn {
   min-width: 48px;
@@ -289,23 +268,23 @@
   gap: 8px;
 }
 
-// Item 16: Give entry name more room.
-// Name gets its own full-width line; kcal + buttons share a second row.
+// #72: Entry top row — name on left (wraps up to 2 lines), three-dots on right
 .entryTop {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
+  align-items: flex-start;
+  gap: 8px;
 }
 
-// Name takes the full width and wraps naturally (up to 2 lines via line-clamp)
+// Name takes available space and wraps naturally (up to 2 lines via line-clamp)
 .entryName {
+  flex: 1;
   font-family: $sarabun;
   font-size: 16px;
   font-weight: 600;
   color: $text;
   letter-spacing: $sarabun-spacing;
   min-width: 0;
-  // Allow up to 2 lines before clamping — much better than 1-line ellipsis
+  // Allow up to 2 lines before clamping
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -313,11 +292,88 @@
   word-break: break-word;
 }
 
-// Row: kcal on left, buttons on right
+// #72: Three-dots menu wrapper (positioned relative so dropdown anchors to it)
+.entryMenuWrapper {
+  position: relative;
+  flex-shrink: 0;
+}
+
+// #72: The ⋮ trigger button
+.dotsBtn {
+  min-width: 36px;
+  min-height: 36px;
+  background: transparent;
+  border: none;
+  border-radius: 8px;
+  color: rgba($text, 0.4);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+
+  &:active {
+    background-color: rgba($primary, 0.1);
+    color: $primary;
+  }
+}
+
+.dotsIcon {
+  display: block;
+  width: 4px;
+  height: 18px;
+}
+
+// #72: Dropdown menu
+.entryDropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  background-color: $surface;
+  border: 1px solid $surface-border;
+  border-radius: 10px;
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 110px;
+  z-index: 200;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.45);
+}
+
+.entryDropdownItem {
+  background: transparent;
+  border: none;
+  color: $text;
+  font-family: $sarabun;
+  font-size: 15px;
+  letter-spacing: $sarabun-spacing;
+  padding: 10px 14px;
+  border-radius: 7px;
+  cursor: pointer;
+  text-align: left;
+  // Explicit tap target
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+
+  &:active {
+    background-color: rgba($primary, 0.12);
+    color: $primary;
+  }
+}
+
+.entryDropdownItemDanger {
+  &:active {
+    background-color: rgba($error, 0.12);
+    color: $error;
+  }
+}
+
+// Row: kcal on left
 .entryMeta {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 8px;
 }
 
@@ -328,44 +384,6 @@
   color: $primary;
   letter-spacing: $sarabun-spacing;
   flex-shrink: 0;
-}
-
-.entryBtns {
-  display: flex;
-  gap: 6px;
-  flex-shrink: 0;
-}
-
-.editBtn,
-.deleteBtn {
-  min-width: 36px;
-  min-height: 36px;
-  background: transparent;
-  border: 1px solid rgba($surface-border, 0.6);
-  border-radius: 8px;
-  color: rgba($text, 0.5);
-  font-size: 13px;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 4px 8px;
-  font-family: $sarabun;
-  letter-spacing: $sarabun-spacing;
-
-  &:active {
-    color: $primary;
-    border-color: $primary-border;
-    background-color: rgba($primary, 0.08);
-  }
-}
-
-.deleteBtn {
-  &:active {
-    color: $error;
-    border-color: rgba($error, 0.5);
-    background-color: rgba($error, 0.08);
-  }
 }
 
 .macroChips {

--- a/client/src/features/nutrition/NutritionTracker.tsx
+++ b/client/src/features/nutrition/NutritionTracker.tsx
@@ -1,8 +1,7 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useDay, useGoals, useDeleteEntry } from './api';
 import EntryEditor from './EntryEditor';
 import NutritionGoalsModal from './NutritionGoalsModal';
-import FeedbackModal from './FeedbackModal';
 import NutritionChat from './NutritionChat';
 import ConfirmModal from '../../components/ConfirmModal.jsx';
 import type { EntryEditorMode, EntryRow } from './types';
@@ -57,6 +56,93 @@ function ProgressBar({ value, goal }: ProgressBarProps) {
   );
 }
 
+// ---- Three-dots entry menu (#72) ----
+
+interface EntryMenuProps {
+  entry: EntryRow;
+  onEdit: (entry: EntryRow) => void;
+  onDelete: (entry: EntryRow) => void;
+}
+
+function EntryMenu({ entry, onEdit, onDelete }: EntryMenuProps) {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const btnRef = useRef<HTMLButtonElement>(null);
+
+  // Close on outside tap/click
+  useEffect(() => {
+    if (!open) return;
+    function handleOutside(e: MouseEvent | TouchEvent) {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleOutside);
+    document.addEventListener('touchstart', handleOutside, { passive: true });
+    return () => {
+      document.removeEventListener('mousedown', handleOutside);
+      document.removeEventListener('touchstart', handleOutside);
+    };
+  }, [open]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        setOpen(false);
+        btnRef.current?.focus();
+      }
+    }
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [open]);
+
+  return (
+    <div className={styles.entryMenuWrapper} ref={wrapperRef}>
+      <button
+        ref={btnRef}
+        className={styles.dotsBtn}
+        onClick={() => setOpen(v => !v)}
+        aria-label={`Options for ${entry.name}`}
+        aria-haspopup="true"
+        aria-expanded={open}
+      >
+        {/* Vertical three-dots icon */}
+        <svg
+          className={styles.dotsIcon}
+          viewBox="0 0 4 18"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <circle cx="2" cy="2" r="1.6" />
+          <circle cx="2" cy="9" r="1.6" />
+          <circle cx="2" cy="16" r="1.6" />
+        </svg>
+      </button>
+
+      {open && (
+        <div className={styles.entryDropdown} role="menu">
+          <button
+            className={styles.entryDropdownItem}
+            role="menuitem"
+            onClick={() => { setOpen(false); onEdit(entry); }}
+          >
+            Edit
+          </button>
+          <button
+            className={`${styles.entryDropdownItem} ${styles.entryDropdownItemDanger}`}
+            role="menuitem"
+            onClick={() => { setOpen(false); onDelete(entry); }}
+          >
+            Delete
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ---- Main component ----
 
 export default function NutritionTracker() {
@@ -74,9 +160,6 @@ export default function NutritionTracker() {
 
   // Goals modal
   const [goalsModalOpen, setGoalsModalOpen] = useState(false);
-
-  // Feedback modal
-  const [feedbackOpen, setFeedbackOpen] = useState(false);
 
   // Pending delete
   const [pendingDeleteEntry, setPendingDeleteEntry] = useState<EntryRow | null>(null);
@@ -188,7 +271,7 @@ export default function NutritionTracker() {
         </button>
       </div>
 
-      {/* Actions row */}
+      {/* Actions row — Feedback button removed (#60: moved to Header) */}
       <div className={styles.actions}>
         <button className={styles.addBtn} onClick={openAddEditor}>
           + Add food
@@ -203,15 +286,7 @@ export default function NutritionTracker() {
           Ask AI
         </button>
 
-        <button
-          className={styles.feedbackBtn}
-          onClick={() => setFeedbackOpen(true)}
-          aria-label="Send feedback"
-          title="Send feedback"
-        >
-          Feedback
-        </button>
-
+        {/* Goals button — #73: bullseye/target icon instead of sun-like glyph */}
         <button
           className={styles.settingsBtn}
           onClick={() => setGoalsModalOpen(true)}
@@ -224,13 +299,10 @@ export default function NutritionTracker() {
             fill="none"
             aria-hidden="true"
           >
-            <circle cx="10" cy="10" r="2.5" stroke="currentColor" strokeWidth="1.8" />
-            <path
-              d="M10 2v2M10 16v2M2 10h2M16 10h2M4.22 4.22l1.42 1.42M14.36 14.36l1.42 1.42M4.22 15.78l1.42-1.42M14.36 5.64l1.42-1.42"
-              stroke="currentColor"
-              strokeWidth="1.8"
-              strokeLinecap="round"
-            />
+            {/* Bullseye / target icon: outer ring, middle ring, centre dot */}
+            <circle cx="10" cy="10" r="8" stroke="currentColor" strokeWidth="1.8" />
+            <circle cx="10" cy="10" r="4.5" stroke="currentColor" strokeWidth="1.8" />
+            <circle cx="10" cy="10" r="1.5" fill="currentColor" />
           </svg>
         </button>
       </div>
@@ -315,28 +387,18 @@ export default function NutritionTracker() {
 
           {mealEntries.map(entry => (
             <div key={entry.id} className={styles.entryRow}>
-              {/* Item 16: name on its own row (wraps up to 2 lines), kcal+buttons below */}
+              {/* #72: three-dots menu at top-right; name wraps up to 2 lines */}
               <div className={styles.entryTop}>
                 <span className={styles.entryName}>{entry.name}</span>
-                <div className={styles.entryMeta}>
-                  <span className={styles.entryCalories}>{Math.round(entry.calories)} kcal</span>
-                  <div className={styles.entryBtns}>
-                    <button
-                      className={styles.editBtn}
-                      onClick={() => openEditEditor(entry)}
-                      aria-label={`Edit ${entry.name}`}
-                    >
-                      Edit
-                    </button>
-                    <button
-                      className={styles.deleteBtn}
-                      onClick={() => setPendingDeleteEntry(entry)}
-                      aria-label={`Delete ${entry.name}`}
-                    >
-                      ✕
-                    </button>
-                  </div>
-                </div>
+                <EntryMenu
+                  entry={entry}
+                  onEdit={openEditEditor}
+                  onDelete={setPendingDeleteEntry}
+                />
+              </div>
+
+              <div className={styles.entryMeta}>
+                <span className={styles.entryCalories}>{Math.round(entry.calories)} kcal</span>
               </div>
 
               <div className={styles.macroChips}>
@@ -367,12 +429,6 @@ export default function NutritionTracker() {
       <NutritionGoalsModal
         open={goalsModalOpen}
         onClose={() => setGoalsModalOpen(false)}
-      />
-
-      {/* Feedback modal */}
-      <FeedbackModal
-        open={feedbackOpen}
-        onClose={() => setFeedbackOpen(false)}
       />
 
       {/* Delete confirmation */}

--- a/client/src/styles/Header.module.scss
+++ b/client/src/styles/Header.module.scss
@@ -16,52 +16,95 @@
 
   .title, .subtitle {
     color: $text;
-  
+
     font: {
       family: 'Sarabun';
       size: 1.5rem;
       weight: 700;
     }
   }
-  
+
   .logo {
     display: flex;
     align-items: flex-end;
   }
+}
 
-  > .authLinks {
-    display: flex;
-    align-items: baseline;
-    gap: 10px;
-    font: {
-      family: $sarabun;
-      size: 18px;
-      weight: 400;
+// #60: Right side wrapper — feedback icon + auth links
+.headerRight {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+// #60: Feedback icon button in the header
+.feedbackBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  background: transparent;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  color: rgba($text, 0.55);
+  // Ensure tap target is at least 44px on mobile
+  min-width: 44px;
+  min-height: 44px;
+
+  &:active {
+    background-color: rgba($primary, 0.1);
+    color: $primary;
+  }
+
+  @media (hover: hover) {
+    &:hover {
+      background-color: rgba($primary, 0.08);
+      color: $primary;
     }
+  }
+}
 
-    span, a, a:visited {
-      color: inherit;
-      text-decoration: none;
-      padding: 8px 15px;
-      border-radius: 20px;
+.feedbackIcon {
+  // iOS Safari SVG fix: block on a flex child
+  display: block;
+  width: 22px;
+  height: 22px;
+}
+
+.authLinks {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  font: {
+    family: $sarabun;
+    size: 18px;
+    weight: 400;
+  }
+
+  span, a, a:visited {
+    color: inherit;
+    text-decoration: none;
+    padding: 8px 15px;
+    border-radius: 20px;
+  }
+
+  .transparentButton {
+    color: $primary !important;
+    cursor: pointer;
+    transition: ease 0.2s;
+    &:hover {
+      background-color: rgba($primary, 0.1);
     }
+  }
 
-    .transparentButton {
-      color: $primary !important;
-      cursor: pointer;
-      transition: ease 0.2s;
-      &:hover {
-        background-color: rgba($primary, 0.1);
-      } 
-    }
-
-    .solidButton {
-      background-color: $primary;
-      cursor: pointer;
-      transition: ease 0.2s;
-      &:hover {
-        background-color: $button-hover;
-      }
+  .solidButton {
+    background-color: $primary;
+    cursor: pointer;
+    transition: ease 0.2s;
+    &:hover {
+      background-color: $button-hover;
     }
   }
 }


### PR DESCRIPTION
## Summary

- **#60 App-wide feedback**: Feedback icon button (speech bubble with heart) added to global `Header` — visible on every tab, logged in or not. `FeedbackModal` mounted from Header. Feedback button and its state removed from `NutritionTracker`.
- **#72 Entry three-dots menu**: Replaced per-entry "Edit" / "✕" buttons with a vertical three-dots (⋮) button at the card's top-right. Opens an accessible custom dropdown (Edit / Delete) on tap; dismisses on outside tap or Escape. Entry name still wraps up to 2 lines. Existing `openEditEditor` / `setPendingDeleteEntry` handlers preserved.
- **#73 Goals icon**: Replaced sun-like glyph (read as light/dark toggle) with a bullseye/target icon (three concentric circles + centre dot).

## Files changed

- `client/src/components/Header.jsx` — feedback button + FeedbackModal mount
- `client/src/styles/Header.module.scss` — `.headerRight`, `.feedbackBtn`, `.feedbackIcon`
- `client/src/features/nutrition/NutritionTracker.tsx` — `EntryMenu` component, removed feedback state, bullseye icon
- `client/src/features/nutrition/NutritionTracker.module.scss` — three-dots menu styles, removed `.feedbackBtn`

## Test plan

- [ ] Feedback button visible in Header on every tab (Workouts, Nutrition, Body Weight)
- [ ] Feedback button visible when logged out (sign-in page)
- [ ] Tapping feedback button opens FeedbackModal; form submits, success state shows, modal closes
- [ ] Each food entry shows a ⋮ button at top-right; tapping it opens Edit / Delete menu
- [ ] Tapping Edit opens the entry editor; tapping Delete triggers the confirm dialog
- [ ] Menu closes on outside tap; menu closes on Escape key
- [ ] Entry name wraps up to 2 lines with three-dots button present
- [ ] Goals button (actions row) shows a bullseye/target icon, not a sun

Closes #60
Closes #72
Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)