### PR TITLE
Fix chat sheet & reasoning UX (#61 #64 #65 #66 #70 #71 #74 #76 #77)

### DIFF
--- a/client/src/features/nutrition/NutritionChat.module.scss
+++ b/client/src/features/nutrition/NutritionChat.module.scss
@@ -28,13 +28,17 @@
   transition: height 0.3s cubic-bezier(0.32, 0.72, 0, 1);
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
+  // #61: safe-area-inset-bottom on the sheet itself ensures the entire sheet
+  // (including rounded corners) clears the home indicator on iPhone.
+  padding-bottom: env(safe-area-inset-bottom);
 
   &:focus { outline: none; }
 }
 
 // Peek: just the drag handle + composer visible
+// #61: height now uses max() to account for safe-area on iPhone
 .sheetPeek {
-  height: 96px;
+  height: calc(96px + env(safe-area-inset-bottom));
 }
 
 // Expanded: full chat
@@ -50,7 +54,9 @@
 }
 
 // ---- Drag handle ----
-// #2: touch-action:none is critical — prevents browser scroll from competing
+// #2/#65: touch-action:none is critical — prevents browser scroll from competing.
+// #65: Acts as drag handle for the pill strip at the top.
+// #64: overscroll-behavior:none prevents iOS rubber-band from firing here.
 .dragHandleBtn {
   display: flex;
   align-items: center;
@@ -61,7 +67,11 @@
   border: none;
   cursor: grab;
   flex-shrink: 0;
-  touch-action: none; // let pointer events work without browser scroll interference
+  // #64: prevent touch scroll events on handle from propagating to page
+  touch-action: none;
+  overscroll-behavior: none;
+  // keyboard nav
+  outline: none;
 
   &:active { cursor: grabbing; }
 }
@@ -88,6 +98,9 @@
 }
 
 // ---- Header ----
+// #65: header also acts as a drag surface (pointer handlers on the element).
+// #64: touch-action:none prevents the browser from stealing scroll events
+//      when the user touches the header to drag the sheet.
 .header {
   display: flex;
   align-items: center;
@@ -95,6 +108,12 @@
   padding: 8px 16px 10px;
   border-bottom: 1px solid rgba($surface-border, 0.4);
   flex-shrink: 0;
+  // #64/#65: steal touch events so dragging header doesn't scroll page behind
+  touch-action: none;
+  overscroll-behavior: none;
+  cursor: grab;
+
+  &:active { cursor: grabbing; }
 }
 
 .headerTitle {
@@ -104,6 +123,9 @@
   font-weight: 700;
   letter-spacing: $sarabun-spacing;
   color: $text;
+  // Prevent text selection while dragging
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 // #7: Clear-chat trash icon button
@@ -119,6 +141,8 @@
   justify-content: center;
   border-radius: 8px;
   padding: 0;
+  // Allow tap through even though parent has touch-action:none
+  touch-action: auto;
 
   &:active {
     color: $error;
@@ -143,6 +167,7 @@
   align-items: center;
   justify-content: center;
   border-radius: 8px;
+  touch-action: auto;
 
   &:active {
     background-color: rgba($text, 0.1);
@@ -172,6 +197,13 @@
   gap: 12px;
   max-width: 100%;
   box-sizing: border-box;
+}
+
+// #74: When the sheet is collapsed (peek state), disable scroll entirely
+// so touch events don't accidentally scroll hidden content.
+.messagesPeek {
+  overflow-y: hidden;
+  pointer-events: none;
 }
 
 .emptyHint {
@@ -336,46 +368,83 @@
   object-fit: cover;
 }
 
-// ---- Reasoning bubble ----
+// ---- Reasoning bubble (#66/#77) ----
+// #77: Collapsed state now matches ToolCallCard's compact .header styling —
+//      single muted line, chevron rotates, no visible border when collapsed.
+// #66: Body animates open/close via max-height transition (same as ToolCallCard AnimatedBody).
 .reasoning {
   max-width: min(80%, 500px);
-  background-color: rgba($background, 0.4);
-  border: 1px solid rgba($surface-border, 0.3);
-  border-radius: 10px;
-  overflow: hidden;
   min-width: 0;
   box-sizing: border-box;
+  border-radius: 8px;
 }
 
+// #77: Matches ToolCallCard .header — single muted collapsed line
 .reasoningToggle {
   display: flex;
   align-items: center;
   gap: 6px;
   width: 100%;
-  padding: 8px 12px;
+  // #77: tight vertical padding matches ToolCallCard
+  padding: 4px 2px;
   background: transparent;
   border: none;
   cursor: pointer;
+  text-align: left;
+  // #77: same comfortable tap target as ToolCallCard
+  min-height: 32px;
+  box-sizing: border-box;
   font-family: $sarabun;
   font-size: 12px;
-  font-weight: 600;
+  font-weight: 500;
   letter-spacing: $sarabun-spacing;
-  color: rgba($text, 0.4);
-  text-transform: uppercase;
-  text-align: left;
-  min-height: 36px;
+  // #77: same muted color as ToolCallCard .toolName
+  color: rgba($text, 0.45);
 }
 
+// #77: Same chevron treatment as ToolCallCard — rotates on open
 .reasoningChevron {
   display: block; // iOS Safari SVG fix
-  width: 10px;
-  height: 6px;
+  width: 8px;
+  height: 5px;
   flex-shrink: 0;
-  color: rgba($text, 0.35);
+  color: rgba($text, 0.3);
+  transition: transform 0.2s ease;
+}
+
+.reasoningChevronOpen {
+  transform: rotate(180deg);
+}
+
+// #77: Pulsing dot while thinking — mirrors ToolCallCard .spinner
+.reasoningSpinner {
+  display: block;
+  flex-shrink: 0;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background-color: rgba($primary, 0.7);
+  animation: pulse 1.2s ease-in-out infinite;
+}
+
+// #66: Animated body wrapper — same max-height technique as ToolCallCard AnimatedBody
+.reasoningBody {
+  overflow: hidden;
+  max-height: 0;
+  opacity: 0;
+  transition: max-height 0.22s ease, opacity 0.18s ease;
+}
+
+.reasoningBodyOpen {
+  opacity: 1;
+  transition: max-height 0.22s ease, opacity 0.18s ease 0.04s;
 }
 
 .reasoningText {
-  padding: 4px 12px 10px;
+  // #77: Left border accent matches ToolCallCard .body
+  border-left: 2px solid rgba($surface-border, 0.2);
+  margin-left: 2px;
+  padding: 4px 10px 8px;
   font-family: $sarabun;
   font-size: 12px;
   line-height: 1.5;
@@ -550,16 +619,16 @@
 }
 
 // ---- Composer row ----
-// #3: safe-area for iOS home indicator — composer sits above the home bar.
+// #3/#61: safe-area for iOS home indicator.
+// The sheet has padding-bottom: env(safe-area-inset-bottom) so the composer
+// only needs a consistent inner padding — the sheet's padding handles the gap.
 .composer {
   display: flex;
   align-items: flex-end;
   gap: 6px;
-  padding: 8px 12px;
+  padding: 8px 12px 10px;
   border-top: 1px solid rgba($surface-border, 0.3);
   flex-shrink: 0;
-  // #3: safe-area inset so controls clear the iPhone home indicator
-  padding-bottom: max(10px, env(safe-area-inset-bottom));
 }
 
 .composerBtn {
@@ -676,4 +745,9 @@
 @keyframes fadeIn {
   from { opacity: 0; }
   to   { opacity: 1; }
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.25; }
 }

--- a/client/src/features/nutrition/NutritionChat.tsx
+++ b/client/src/features/nutrition/NutritionChat.tsx
@@ -14,6 +14,17 @@
  * #14 Send→Stop button during streaming (stop icon, calls useChat stop())
  * #15 Transcripts = DB source of truth (fetchTranscript on open/day-change/focus)
  * #17 Interrupted marker for assistant rows that ended without onFinish
+ *
+ * Feedback-issues fixes:
+ * #61 Safe-area on sheet bottom so composer clears iOS home indicator
+ * #64 overscroll-behavior containment + touch-action on header to stop page scroll bleed
+ * #65 Entire header row acts as drag handle (not just the thin pill)
+ * #66 Animate reasoning open/close (max-height transition, same as ToolCallCard)
+ * #70 Confirm before clearing chat (ConfirmModal)
+ * #71 Confirmed-proposal line includes entry name (rawArgs.name)
+ * #74 Messages not scrollable while sheet is in peek state
+ * #76 Collapse adjacent reasoning parts into one block per message
+ * #77 ReasoningBubble collapsed state matches ToolCallCard styling
  */
 import {
   useState,
@@ -30,6 +41,7 @@ import type { StoredChatMessage } from './api';
 import EntryEditor from './EntryEditor';
 import BarcodeScanner from './BarcodeScanner';
 import ToolCallCard from './ToolCallCard';
+import ConfirmModal from '../../components/ConfirmModal';
 import type { EntryInput, EntryEditorMode, ProposeEntryArgs } from './types';
 import styles from './NutritionChat.module.scss';
 
@@ -177,7 +189,7 @@ function useAutoGrow(ref: React.RefObject<HTMLTextAreaElement | null>, value: st
 }
 
 // ---------------------------------------------------------------------------
-// Reasoning collapsible
+// #66/#77: Reasoning collapsible — animated like ToolCallCard
 // ---------------------------------------------------------------------------
 interface ReasoningBubbleProps {
   text: string;
@@ -186,19 +198,29 @@ interface ReasoningBubbleProps {
 
 function ReasoningBubble({ text, streaming }: ReasoningBubbleProps) {
   const [open, setOpen] = useState(false);
+  const innerRef = useRef<HTMLDivElement>(null);
+
   if (!streaming && !text.trim()) return null;
 
   return (
     <div className={styles.reasoning}>
+      {/* #77: collapsed header matches ToolCallCard .header styling */}
       <button
         type="button"
         className={styles.reasoningToggle}
         onClick={() => setOpen(p => !p)}
         aria-expanded={open}
       >
-        <svg className={styles.reasoningChevron} viewBox="0 0 10 6" fill="none" aria-hidden="true" style={{ display: 'block' }}>
+        {/* #77: same chevron pattern as ToolCallCard */}
+        <svg
+          className={`${styles.reasoningChevron} ${open ? styles.reasoningChevronOpen : ''}`}
+          viewBox="0 0 10 6"
+          fill="none"
+          aria-hidden="true"
+          style={{ display: 'block' }}
+        >
           <path
-            d={open ? 'M1 5l4-4 4 4' : 'M1 1l4 4 4-4'}
+            d="M1 1l4 4 4-4"
             stroke="currentColor"
             strokeWidth="1.8"
             strokeLinecap="round"
@@ -206,14 +228,68 @@ function ReasoningBubble({ text, streaming }: ReasoningBubbleProps) {
           />
         </svg>
         {streaming ? 'Thinking…' : 'Reasoning'}
+        {/* Streaming pulse dot — matches ToolCallCard spinner */}
+        {streaming && <span className={styles.reasoningSpinner} aria-hidden="true" />}
       </button>
-      {open && (
-        <div className={styles.reasoningText}>
+
+      {/* #66: Animated body — max-height transition same as ToolCallCard AnimatedBody */}
+      <div
+        className={`${styles.reasoningBody} ${open ? styles.reasoningBodyOpen : ''}`}
+        style={
+          open
+            ? { maxHeight: innerRef.current ? innerRef.current.scrollHeight + 'px' : '800px' }
+            : { maxHeight: '0px' }
+        }
+        aria-hidden={!open}
+      >
+        <div ref={innerRef} className={styles.reasoningText}>
           <ReactMarkdown>{text}</ReactMarkdown>
         </div>
-      )}
+      </div>
     </div>
   );
+}
+
+// ---------------------------------------------------------------------------
+// #76: Merge adjacent reasoning parts in a message into a single combined block
+// ---------------------------------------------------------------------------
+type MergedPart =
+  | { type: 'merged-reasoning'; text: string; streaming: boolean; originalIndices: number[] }
+  | { type: 'other'; part: UIMessage['parts'][number]; originalIndex: number };
+
+function mergeReasoningParts(parts: UIMessage['parts']): MergedPart[] {
+  const result: MergedPart[] = [];
+
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    if (part.type === 'reasoning') {
+      // Start a merged reasoning block
+      const texts: string[] = [part.text];
+      const indices: number[] = [i];
+      const isStreaming = part.state === 'streaming';
+      let mergedStreaming = isStreaming;
+
+      // Consume all consecutive reasoning parts
+      while (i + 1 < parts.length && parts[i + 1].type === 'reasoning') {
+        i++;
+        const next = parts[i] as { type: 'reasoning'; text: string; state?: string };
+        texts.push(next.text);
+        indices.push(i);
+        if (next.state === 'streaming') mergedStreaming = true;
+      }
+
+      result.push({
+        type: 'merged-reasoning',
+        text: texts.join('\n\n'),
+        streaming: mergedStreaming,
+        originalIndices: indices,
+      });
+    } else {
+      result.push({ type: 'other', part, originalIndex: i });
+    }
+  }
+
+  return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -227,7 +303,7 @@ interface MessageProps {
   onProposalConfirm: (input: EntryInput, partKey: string) => void;
   onProposalDeny: (partKey: string) => void;
   deniedProposals: Set<string>;
-  confirmedProposals: Set<string>;
+  confirmedProposals: Map<string, string>; // partKey → entry name
 }
 
 function ChatMessage({
@@ -245,9 +321,25 @@ function ChatMessage({
   const interrupted = !!(message as unknown as { interrupted?: boolean }).interrupted;
   const isStreamingThis = isLastAssistant && isStreaming;
 
+  // #76: merge adjacent reasoning parts before rendering
+  const mergedParts = mergeReasoningParts(message.parts);
+
   return (
     <div className={`${styles.messageGroup} ${isUser ? styles.messageGroupUser : styles.messageGroupAssistant}`}>
-      {message.parts.map((part, idx) => {
+      {mergedParts.map((merged, renderIdx) => {
+        // ---- Merged reasoning block (#76) ----
+        if (merged.type === 'merged-reasoning') {
+          return (
+            <ReasoningBubble
+              key={`reasoning-${renderIdx}`}
+              text={merged.text}
+              streaming={merged.streaming}
+            />
+          );
+        }
+
+        const { part, originalIndex: idx } = merged;
+
         // ---- Text part ----
         if (part.type === 'text') {
           if (!part.text) return null;
@@ -279,17 +371,6 @@ function ChatMessage({
           );
         }
 
-        // ---- Reasoning part ----
-        if (part.type === 'reasoning') {
-          return (
-            <ReasoningBubble
-              key={idx}
-              text={part.text}
-              streaming={part.state === 'streaming'}
-            />
-          );
-        }
-
         // ---- Tool invocation part ----
         if (isToolUIPart(part)) {
           const toolName = getToolName(part as ToolUIPart | DynamicToolUIPart);
@@ -299,7 +380,8 @@ function ChatMessage({
           if (toolName === 'propose_entry') {
             const partKey = `${message.id}-${toolCallId}`;
             const isDenied = deniedProposals.has(partKey);
-            const isConfirmed = confirmedProposals.has(partKey);
+            const confirmedName = confirmedProposals.get(partKey);
+            const isConfirmed = confirmedName !== undefined;
 
             if (isDenied) {
               return (
@@ -308,10 +390,11 @@ function ChatMessage({
                 </div>
               );
             }
+            // #71: include entry name in confirmed message
             if (isConfirmed) {
               return (
                 <div key={idx} className={styles.proposalConfirmed}>
-                  Entry logged!
+                  {confirmedName ? `Logged: ${confirmedName}` : 'Entry logged!'}
                 </div>
               );
             }
@@ -478,13 +561,17 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
 
   // ---- Proposal state tracking ----
   const [deniedProposals, setDeniedProposals] = useState<Set<string>>(new Set());
-  const [confirmedProposals, setConfirmedProposals] = useState<Set<string>>(new Set());
+  // #71: store name alongside confirmation so the message can display it
+  const [confirmedProposals, setConfirmedProposals] = useState<Map<string, string>>(new Map());
 
   // ---- Composer state ----
   const [text, setText] = useState('');
   const [pendingPhotos, setPendingPhotos] = useState<PendingPhoto[]>([]);
   const [photoError, setPhotoError] = useState<string | null>(null);
   const [barcodeOpen, setBarcodeOpen] = useState(false);
+
+  // #70: confirm-clear-chat dialog state
+  const [showClearConfirm, setShowClearConfirm] = useState(false);
 
   // ---- Refs ----
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -628,11 +715,14 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
 
   const handleProposalConfirmWithTracking = useCallback(async (input: EntryInput, partKey: string) => {
     await createEntry.mutateAsync(input);
-    setConfirmedProposals(prev => new Set([...prev, partKey]));
+    // #71: store the entry name so the confirmed message can display it
+    const entryName = (input as unknown as { name?: string }).name ?? '';
+    setConfirmedProposals(prev => new Map([...prev, [partKey, entryName]]));
   }, [createEntry]);
 
-  // ---- #7: Clear chat ----
-  const handleClearChat = useCallback(async () => {
+  // ---- #7/#70: Clear chat — guarded by ConfirmModal ----
+  const executeClearChat = useCallback(async () => {
+    setShowClearConfirm(false);
     try {
       await clearTranscript(selectedDate);
     } catch {
@@ -641,8 +731,12 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
     dropMessagesForDate(selectedDate);
     setMessages([]);
     setDeniedProposals(new Set());
-    setConfirmedProposals(new Set());
+    setConfirmedProposals(new Map());
   }, [selectedDate, setMessages]);
+
+  const handleClearChat = useCallback(() => {
+    setShowClearConfirm(true);
+  }, []);
 
   // ---- #2: Bottom sheet follows finger (continuous pointermove, snap on release) ----
   // We drive sheetHeight as an integer px value while dragging.
@@ -747,30 +841,48 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
       >
         <span className={styles.srOnly}>Nutrition AI</span>
 
-        {/* #2: Drag handle — continuous pointer tracking */}
-        <button
-          type="button"
+        {/* #65: Entire header area is the drag target.
+            When collapsed, this is the only visible region — a thin strip.
+            When expanded, the header row (with title + buttons) also drags.
+            We keep a separate visual pill inside for discoverability. */}
+        <div
           className={styles.dragHandleBtn}
           onPointerDown={handleDragPointerDown}
           onPointerMove={handleDragPointerMove}
           onPointerUp={handleDragPointerUp}
           onPointerCancel={handleDragPointerUp}
+          role="button"
+          tabIndex={0}
           aria-label={isExpanded ? 'Collapse AI chat' : 'Expand AI chat'}
           aria-expanded={isExpanded}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              isExpanded ? collapse() : setExpanded(true);
+            }
+          }}
         >
+          {/* #65: Visual pill — inside the drag zone, just a cue */}
           <span className={styles.dragHandle} aria-hidden="true" />
-        </button>
+        </div>
 
-        {/* Header — only shown when expanded */}
+        {/* #65: Header row also participates in drag (#64: touch-action:none stops page scroll) */}
         {isExpanded && (
-          <div className={styles.header}>
+          <div
+            className={styles.header}
+            onPointerDown={handleDragPointerDown}
+            onPointerMove={handleDragPointerMove}
+            onPointerUp={handleDragPointerUp}
+            onPointerCancel={handleDragPointerUp}
+          >
             <span className={styles.headerTitle}>Ask AI</span>
 
-            {/* #7: Clear chat button */}
+            {/* #7/#70: Clear chat — now opens confirmation dialog */}
             <button
               type="button"
               className={styles.clearBtn}
-              onClick={handleClearChat}
+              onClick={(e) => { e.stopPropagation(); handleClearChat(); }}
+              onPointerDown={(e) => e.stopPropagation()}
               aria-label="Clear chat"
               title="Clear today's chat"
             >
@@ -782,7 +894,8 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
             <button
               type="button"
               className={styles.closeBtn}
-              onClick={collapse}
+              onClick={(e) => { e.stopPropagation(); collapse(); }}
+              onPointerDown={(e) => e.stopPropagation()}
               aria-label="Collapse"
             >
               <svg className={styles.collapseSvg} viewBox="0 0 14 8" fill="none" aria-hidden="true">
@@ -792,10 +905,11 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
           </div>
         )}
 
-        {/* #6: Messages — overscroll-behavior:contain prevents body scroll */}
+        {/* #6/#74: Messages — overscroll-behavior:contain prevents body scroll.
+            #74: When in peek state, disable scrolling entirely. */}
         <div
           ref={messagesContainerRef}
-          className={styles.messages}
+          className={`${styles.messages} ${!isExpanded ? styles.messagesPeek : ''}`}
           onScroll={checkNearBottom}
         >
           {messages.length === 0 && (
@@ -846,7 +960,7 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
           <p className={styles.photoError}>{photoError}</p>
         )}
 
-        {/* Composer — #3: safe-area padding, #4: 16px font-size on mobile */}
+        {/* Composer — #3/#61: safe-area padding, #4: 16px font-size on mobile */}
         <div className={styles.composer}>
           {/* Photo attach button */}
           <button
@@ -940,6 +1054,15 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
         <BarcodeScanner
           onDetected={handleBarcodeDetected}
           onClose={() => setBarcodeOpen(false)}
+        />
+      )}
+
+      {/* #70: Confirm before clearing chat */}
+      {showClearConfirm && (
+        <ConfirmModal
+          message="Clear today's chat? This cannot be undone."
+          onConfirm={executeClearChat}
+          onCancel={() => setShowClearConfirm(false)}
         />
       )}
     </>


### PR DESCRIPTION
## Summary

- **#61** Add `env(safe-area-inset-bottom)` to the sheet so the composer row clears the iPhone home indicator.
- **#64** Add `touch-action: none` + `overscroll-behavior: none` on the drag handle and header to prevent page scroll from being triggered when touching the sheet header.
- **#65** Make the entire header area (not just the thin pill) a drag target by wiring the existing `handleDragPointerDown/Move/Up` handlers onto both the pill strip and the header `<div>`.
- **#66** Animate reasoning open/close using the same `max-height` + `opacity` transition pattern as `ToolCallCard`'s `AnimatedBody`.
- **#70** Wrap `handleClearChat` with the existing `ConfirmModal` component — tapping trash shows "Clear today's chat? This cannot be undone." before proceeding.
- **#71** The confirmed-proposal line now reads `"Logged: <name>"` instead of `"Entry logged!"` using `rawArgs.name` stored in `confirmedProposals` map.
- **#74** Apply `.messagesPeek` class (`overflow-y: hidden; pointer-events: none`) on the messages container when the sheet is in peek state.
- **#76** `mergeReasoningParts()` collapses consecutive `reasoning` parts in a single message into one combined `ReasoningBubble` before rendering.
- **#77** `ReasoningBubble` collapsed state now matches `ToolCallCard` styling: same compact muted line, rotating chevron, no visible border when collapsed, pulsing dot while streaming.

Closes #61
Closes #64
Closes #65
Closes #66
Closes #70
Closes #71
Closes #74
Closes #76
Closes #77

## Test plan

- [ ] On iPhone (or DevTools device simulator with safe-area): open chat sheet, verify composer + icons are fully visible above the home indicator bar.
- [ ] Tap the sheet header / drag handle area in expanded state; verify dragging down collapses the sheet without causing the page behind it to scroll.
- [ ] Touch the full header row (not just the pill) and drag — sheet should follow finger.
- [ ] In collapsed (peek) state, try scrolling in the message area — nothing should move.
- [ ] Send a message that triggers reasoning. Verify the reasoning block animates open/close smoothly (no jump cut).
- [ ] Send a message with multiple consecutive reasoning parts — only one combined reasoning block should appear.
- [ ] Collapsed reasoning block should look like a ToolCallCard: small chevron, muted text, no box border.
- [ ] Confirm a proposal — the confirmation line should say e.g. "Logged: Banana" not "Entry logged!".
- [ ] Click the trash icon and verify a confirmation dialog appears; cancelling leaves the chat intact; confirming clears it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)