### PR TITLE
Habits: full CRUD with registry table (#78)

### DIFF
--- a/client/src/components/HabitTracker.jsx
+++ b/client/src/components/HabitTracker.jsx
@@ -1,11 +1,9 @@
-import { useEffect, useState, useCallback } from 'react';
-import { format, parseISO } from 'date-fns';
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { format } from 'date-fns';
 import clientApi from '../api/clientApi.js';
 import useAuth from '../hooks/useAuth.js';
 import styles from '../styles/HabitTracker.module.scss';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-
-const HABIT_NAME = 'nail-biting';
 
 // Returns today's local date as YYYY-MM-DD
 function getTodayLocalDate() {
@@ -110,6 +108,7 @@ function formatTime(timeStr) {
   return to12h(timeStr);
 }
 
+// ─── Tally row ──────────────────────────────────────────────────────────────────
 function HabitRow({ row, isToday, onIncrement, onDecrement, onRangeChange }) {
   const [rangeStart, setRangeStart] = useState(formatTime(row.range_start) || '');
   const [rangeEnd, setRangeEnd] = useState(formatTime(row.range_end) || '');
@@ -211,34 +210,302 @@ function HabitRow({ row, isToday, onIncrement, onDecrement, onRangeChange }) {
   );
 }
 
+// ─── Inline rename input ────────────────────────────────────────────────────────
+function RenameInput({ initialValue, onSave, onCancel }) {
+  const [value, setValue] = useState(initialValue);
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  function handleKeyDown(e) {
+    if (e.key === 'Enter') handleSave();
+    if (e.key === 'Escape') onCancel();
+  }
+
+  function handleSave() {
+    const trimmed = value.trim();
+    if (!trimmed || trimmed === initialValue) {
+      onCancel();
+      return;
+    }
+    onSave(trimmed);
+  }
+
+  return (
+    <div className={styles.renameRow}>
+      <input
+        ref={inputRef}
+        className={styles.renameInput}
+        value={value}
+        onChange={e => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={handleSave}
+        maxLength={100}
+        aria-label="Rename habit"
+      />
+    </div>
+  );
+}
+
+// ─── New habit input ────────────────────────────────────────────────────────────
+function NewHabitInput({ onSave, onCancel }) {
+  const [value, setValue] = useState('');
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  function handleKeyDown(e) {
+    if (e.key === 'Enter') handleSave();
+    if (e.key === 'Escape') onCancel();
+  }
+
+  function handleSave() {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      onCancel();
+      return;
+    }
+    onSave(trimmed);
+  }
+
+  return (
+    <div className={styles.newHabitRow}>
+      <input
+        ref={inputRef}
+        className={styles.newHabitInput}
+        value={value}
+        onChange={e => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="Habit name…"
+        maxLength={100}
+        aria-label="New habit name"
+      />
+      <button className={styles.newHabitSaveBtn} onClick={handleSave} type="button">
+        Add
+      </button>
+      <button className={styles.newHabitCancelBtn} onClick={onCancel} type="button" aria-label="Cancel">
+        <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <line x1="3" y1="3" x2="13" y2="13" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+          <line x1="13" y1="3" x2="3" y2="13" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
+// ─── Habit list item (inside dropdown) ─────────────────────────────────────────
+function HabitListItem({ habit, isActive, onSelect, onRename, onDelete }) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [renaming, setRenaming] = useState(false);
+  const menuRef = useRef(null);
+
+  // Close menu on outside tap/click
+  useEffect(() => {
+    if (!menuOpen) return;
+    function handleOutside(e) {
+      if (menuRef.current && !menuRef.current.contains(e.target)) {
+        setMenuOpen(false);
+      }
+    }
+    document.addEventListener('pointerdown', handleOutside);
+    return () => document.removeEventListener('pointerdown', handleOutside);
+  }, [menuOpen]);
+
+  if (renaming) {
+    return (
+      <div className={`${styles.habitItem} ${isActive ? styles.habitItemActive : ''}`}>
+        <RenameInput
+          initialValue={habit.name}
+          onSave={(newName) => { setRenaming(false); onRename(habit.id, newName); }}
+          onCancel={() => setRenaming(false)}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className={`${styles.habitItem} ${isActive ? styles.habitItemActive : ''}`}>
+      <button
+        className={styles.habitSelectBtn}
+        onClick={() => onSelect(habit)}
+        type="button"
+      >
+        {habit.name}
+      </button>
+      <div className={styles.habitMenuWrap} ref={menuRef}>
+        <button
+          className={styles.habitMenuBtn}
+          onClick={() => setMenuOpen(o => !o)}
+          type="button"
+          aria-label={`Options for ${habit.name}`}
+          aria-expanded={menuOpen}
+        >
+          <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <circle cx="8" cy="3" r="1.5" fill="currentColor" />
+            <circle cx="8" cy="8" r="1.5" fill="currentColor" />
+            <circle cx="8" cy="13" r="1.5" fill="currentColor" />
+          </svg>
+        </button>
+        {menuOpen && (
+          <div className={styles.habitMenu} role="menu">
+            <button
+              className={styles.habitMenuItem}
+              role="menuitem"
+              onClick={() => { setMenuOpen(false); setRenaming(true); }}
+              type="button"
+            >
+              Rename
+            </button>
+            <button
+              className={`${styles.habitMenuItem} ${styles.habitMenuItemDanger}`}
+              role="menuitem"
+              onClick={() => { setMenuOpen(false); onDelete(habit); }}
+              type="button"
+            >
+              Delete
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Confirm delete dialog ──────────────────────────────────────────────────────
+function ConfirmDeleteDialog({ habit, onConfirm, onCancel }) {
+  return (
+    <div className={styles.confirmOverlay} role="dialog" aria-modal="true" aria-label="Confirm delete">
+      <div className={styles.confirmBox}>
+        <p className={styles.confirmText}>
+          Delete <strong>{habit.name}</strong>? This will remove all its tallies and cannot be undone.
+        </p>
+        <div className={styles.confirmBtns}>
+          <button className={styles.confirmCancel} onClick={onCancel} type="button">
+            Cancel
+          </button>
+          <button className={styles.confirmDelete} onClick={onConfirm} type="button">
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Main component ─────────────────────────────────────────────────────────────
 function HabitTracker() {
   const { user } = useAuth();
   const queryClient = useQueryClient();
 
-  const talliesQuery = useQuery({
-    queryKey: ['habits', HABIT_NAME],
+  const [activeHabit, setActiveHabit] = useState(null);
+  const [showNewHabit, setShowNewHabit] = useState(false);
+  const [habitToDelete, setHabitToDelete] = useState(null);
+  const [habitsOpen, setHabitsOpen] = useState(false);
+
+  // ── Habits registry query ──────────────────────────────────────────────────
+  const habitsQuery = useQuery({
+    queryKey: ['habits-registry'],
     queryFn: async () => {
-      const res = await clientApi.get(`/habits/${HABIT_NAME}`);
-      // mysql2 DATE columns serialize to ISO strings through JSON (e.g. "2026-06-17T00:00:00.000Z")
-      // slice(0,10) normalizes both bare "YYYY-MM-DD" and ISO datetime strings to "YYYY-MM-DD"
+      const res = await clientApi.get('/habits');
+      return res.data.data;
+    },
+    enabled: user !== undefined && user !== null,
+  });
+
+  const habits = habitsQuery.data ?? [];
+
+  // Auto-select the first habit when registry loads; keep active in sync on rename
+  useEffect(() => {
+    if (activeHabit === null && habits.length > 0) {
+      setActiveHabit(habits[0]);
+    }
+    if (activeHabit !== null) {
+      const fresh = habits.find(h => h.id === activeHabit.id);
+      if (fresh && fresh.name !== activeHabit.name) {
+        setActiveHabit(fresh);
+      }
+    }
+  }, [habits]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── Tallies query (depends on selected habit) ──────────────────────────────
+  const talliesQuery = useQuery({
+    queryKey: ['habits', activeHabit?.name],
+    queryFn: async () => {
+      const res = await clientApi.get(`/habits/${activeHabit.name}`);
+      // mysql2 DATE columns serialize to ISO strings through JSON
+      // slice(0,10) normalizes both bare "YYYY-MM-DD" and ISO datetime strings
       return res.data.data.map(row => ({
         ...row,
         date: String(row.date).slice(0, 10),
       }));
     },
-    enabled: user !== undefined && user !== null,
+    enabled: user !== undefined && user !== null && activeHabit !== null,
   });
 
   const rows = talliesQuery.data ?? [];
-  const loading = talliesQuery.isLoading;
+  const talliesLoading = talliesQuery.isLoading;
 
-  const addTallyMutation = useMutation({
-    mutationFn: async ({ localDate, localTime }) => {
-      const res = await clientApi.post(`/habits/${HABIT_NAME}/tally`, { localDate, localTime });
+  // ── Habit CRUD mutations ───────────────────────────────────────────────────
+  const createHabitMutation = useMutation({
+    mutationFn: async (name) => {
+      const res = await clientApi.post('/habits', { name });
+      return res.data.data;
+    },
+    onSuccess: (newHabit) => {
+      queryClient.setQueryData(['habits-registry'], (prev) => [...(prev ?? []), newHabit]);
+      setActiveHabit(newHabit);
+      setShowNewHabit(false);
+      setHabitsOpen(false);
+    },
+  });
+
+  const renameHabitMutation = useMutation({
+    mutationFn: async ({ id, name }) => {
+      const res = await clientApi.patch(`/habits/${id}`, { name });
       return res.data.data;
     },
     onSuccess: (updated) => {
-      queryClient.setQueryData(['habits', HABIT_NAME], (prev) => {
+      queryClient.setQueryData(['habits-registry'], (prev) =>
+        (prev ?? []).map(h => h.id === updated.id ? { ...h, name: updated.name } : h)
+      );
+      if (activeHabit?.id === updated.id) {
+        // Remove old tallies cache key; will refetch under new name
+        queryClient.removeQueries({ queryKey: ['habits', activeHabit.name] });
+        setActiveHabit(prev => ({ ...prev, name: updated.name }));
+      }
+    },
+  });
+
+  const deleteHabitMutation = useMutation({
+    mutationFn: async (id) => {
+      await clientApi.delete(`/habits/${id}`);
+      return id;
+    },
+    onSuccess: (id) => {
+      queryClient.setQueryData(['habits-registry'], (prev) => {
+        const next = (prev ?? []).filter(h => h.id !== id);
+        if (activeHabit?.id === id) {
+          setActiveHabit(next.length > 0 ? next[0] : null);
+        }
+        return next;
+      });
+      setHabitToDelete(null);
+    },
+  });
+
+  // ── Tally mutations ────────────────────────────────────────────────────────
+  const addTallyMutation = useMutation({
+    mutationFn: async ({ localDate, localTime }) => {
+      const res = await clientApi.post(`/habits/${activeHabit.name}/tally`, { localDate, localTime });
+      return res.data.data;
+    },
+    onSuccess: (updated) => {
+      queryClient.setQueryData(['habits', activeHabit.name], (prev) => {
         const list = prev ?? [];
         const existing = list.find(r => r.date === updated.date);
         if (existing) {
@@ -252,67 +519,65 @@ function HabitTracker() {
 
   const patchTallyMutation = useMutation({
     mutationFn: async ({ date, fields }) => {
-      await clientApi.patch(`/habits/${HABIT_NAME}/${date}`, fields);
+      await clientApi.patch(`/habits/${activeHabit.name}/${date}`, fields);
       return { date, fields };
     },
     onSuccess: ({ date, fields }) => {
-      queryClient.setQueryData(['habits', HABIT_NAME], (prev) =>
+      queryClient.setQueryData(['habits', activeHabit.name], (prev) =>
         (prev ?? []).map(r => r.date === date ? { ...r, ...fields } : r)
       );
     },
   });
 
-  // Ensure today's row is always present in local state
+  // ── Ensure today row is always present ────────────────────────────────────
   const today = getTodayLocalDate();
   const todayExists = rows.some(r => r.date === today);
   const displayRows = todayExists
     ? rows
     : [{ date: today, count: 0, range_start: null, range_end: null }, ...rows];
 
+  // ── Handlers ───────────────────────────────────────────────────────────────
   async function handleAddTally() {
-    if (addTallyMutation.isPending) return;
-    const localDate = getTodayLocalDate();
-    const localTime = getNowLocalTime();
-    addTallyMutation.mutate({ localDate, localTime });
+    if (!activeHabit || addTallyMutation.isPending) return;
+    addTallyMutation.mutate({ localDate: getTodayLocalDate(), localTime: getNowLocalTime() });
   }
 
   async function handleIncrement(date) {
+    if (!activeHabit) return;
     const row = displayRows.find(r => r.date === date);
     if (!row) return;
     const newCount = row.count + 1;
     // Optimistic update
-    queryClient.setQueryData(['habits', HABIT_NAME], (prev) => {
+    queryClient.setQueryData(['habits', activeHabit.name], (prev) => {
       const list = prev ?? [];
       const existing = list.find(r => r.date === date);
-      if (existing) {
-        return list.map(r => r.date === date ? { ...r, count: newCount } : r);
-      } else {
-        return [{ date, count: newCount, range_start: null, range_end: null }, ...list];
-      }
+      if (existing) return list.map(r => r.date === date ? { ...r, count: newCount } : r);
+      return [{ date, count: newCount, range_start: null, range_end: null }, ...list];
     });
     try {
-      await clientApi.patch(`/habits/${HABIT_NAME}/${date}`, { count: newCount });
+      await clientApi.patch(`/habits/${activeHabit.name}/${date}`, { count: newCount });
     } catch {
       // Roll back on failure
-      queryClient.setQueryData(['habits', HABIT_NAME], (prev) =>
+      queryClient.setQueryData(['habits', activeHabit.name], (prev) =>
         (prev ?? []).map(r => r.date === date ? { ...r, count: row.count } : r)
       );
     }
   }
 
   async function handleDecrement(date) {
+    if (!activeHabit) return;
     const row = displayRows.find(r => r.date === date);
     if (!row || row.count === 0) return;
     const newCount = row.count - 1;
     // Optimistic update
-    queryClient.setQueryData(['habits', HABIT_NAME], (prev) =>
+    queryClient.setQueryData(['habits', activeHabit.name], (prev) =>
       (prev ?? []).map(r => r.date === date ? { ...r, count: newCount } : r)
     );
     try {
-      await clientApi.patch(`/habits/${HABIT_NAME}/${date}`, { count: newCount });
+      await clientApi.patch(`/habits/${activeHabit.name}/${date}`, { count: newCount });
     } catch {
       // Roll back on failure
-      queryClient.setQueryData(['habits', HABIT_NAME], (prev) =>
+      queryClient.setQueryData(['habits', activeHabit.name], (prev) =>
         (prev ?? []).map(r => r.date === date ? { ...r, count: row.count } : r)
       );
     }
@@ -322,17 +587,91 @@ function HabitTracker() {
     patchTallyMutation.mutate({ date, fields });
   }, [patchTallyMutation]);
 
+  // ── Render ─────────────────────────────────────────────────────────────────
+  const habitsLoading = habitsQuery.isLoading;
+
   return (
     <section className={styles.container}>
+
+      {/* ── Habit selector ──────────────────────────────────────────────── */}
+      <div className={styles.habitSelectorWrap}>
+        <button
+          className={styles.habitSelectorBtn}
+          onClick={() => setHabitsOpen(o => !o)}
+          type="button"
+          aria-expanded={habitsOpen}
+          aria-label="Select habit"
+          disabled={habitsLoading}
+        >
+          <span className={styles.habitSelectorName}>
+            {habitsLoading
+              ? 'Loading…'
+              : activeHabit
+              ? activeHabit.name
+              : habits.length === 0
+              ? 'No habits yet'
+              : 'Select a habit'}
+          </span>
+          <svg
+            className={`${styles.habitSelectorChevron} ${habitsOpen ? styles.habitSelectorChevronOpen : ''}`}
+            viewBox="0 0 16 16"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+          >
+            <polyline points="4,6 8,10 12,6" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </button>
+
+        {habitsOpen && (
+          <div className={styles.habitDropdown}>
+            {habits.map(habit => (
+              <HabitListItem
+                key={habit.id}
+                habit={habit}
+                isActive={activeHabit?.id === habit.id}
+                onSelect={(h) => { setActiveHabit(h); setHabitsOpen(false); }}
+                onRename={(id, newName) => renameHabitMutation.mutate({ id, name: newName })}
+                onDelete={(h) => setHabitToDelete(h)}
+              />
+            ))}
+            {showNewHabit ? (
+              <NewHabitInput
+                onSave={(name) => createHabitMutation.mutate(name)}
+                onCancel={() => setShowNewHabit(false)}
+              />
+            ) : (
+              <button
+                className={styles.addHabitBtn}
+                onClick={() => setShowNewHabit(true)}
+                type="button"
+                disabled={createHabitMutation.isPending}
+              >
+                <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                  <line x1="8" y1="2" x2="8" y2="14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                  <line x1="2" y1="8" x2="14" y2="8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                </svg>
+                New habit
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* ── Add tally button ─────────────────────────────────────────────── */}
       <button
         className={styles.addTallyBtn}
         onClick={handleAddTally}
-        disabled={addTallyMutation.isPending}
+        disabled={addTallyMutation.isPending || !activeHabit}
       >
         <span className={styles.addTallyPlus}>+</span> Add Tally
       </button>
 
-      {loading ? (
+      {/* ── Tally rows ───────────────────────────────────────────────────── */}
+      {!activeHabit ? (
+        <p className={styles.empty}>
+          {habits.length === 0 ? 'Create a habit above to get started.' : 'Select a habit to view tallies.'}
+        </p>
+      ) : talliesLoading ? (
         <p className={styles.empty}>Loading…</p>
       ) : (
         <div className={styles.list}>
@@ -347,6 +686,15 @@ function HabitTracker() {
             />
           ))}
         </div>
+      )}
+
+      {/* ── Confirm delete dialog ────────────────────────────────────────── */}
+      {habitToDelete && (
+        <ConfirmDeleteDialog
+          habit={habitToDelete}
+          onConfirm={() => deleteHabitMutation.mutate(habitToDelete.id)}
+          onCancel={() => setHabitToDelete(null)}
+        />
       )}
     </section>
   );

--- a/client/src/styles/HabitTracker.module.scss
+++ b/client/src/styles/HabitTracker.module.scss
@@ -241,3 +241,409 @@
   letter-spacing: $sarabun-spacing;
   opacity: 0.7;
 }
+
+// ── Habit selector ─────────────────────────────────────────────────────────────
+.habitSelectorWrap {
+  position: relative;
+}
+
+.habitSelectorBtn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 12px 16px;
+  background-color: $surface;
+  border: 2px solid $surface-border;
+  border-radius: $border-radius;
+  color: $text;
+  font-family: $sarabun;
+  font-size: 17px;
+  font-weight: 600;
+  letter-spacing: $sarabun-spacing;
+  cursor: pointer;
+  text-align: left;
+  -webkit-tap-highlight-color: transparent;
+  transition: border-color 0.12s ease;
+
+  &:active {
+    border-color: $primary-border;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  @media (max-width: $mobile-width) {
+    font-size: 15px;
+    padding: 11px 14px;
+  }
+}
+
+.habitSelectorName {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.habitSelectorChevron {
+  display: block;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  color: rgba($text, 0.6);
+  transition: transform 0.15s ease;
+}
+
+.habitSelectorChevronOpen {
+  transform: rotate(180deg);
+}
+
+// ── Habit dropdown ─────────────────────────────────────────────────────────────
+.habitDropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  z-index: 20;
+  background-color: $surface;
+  border: 2px solid $surface-border;
+  border-radius: $border-radius;
+  overflow: hidden;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+// ── Habit list item ────────────────────────────────────────────────────────────
+.habitItem {
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid rgba($surface-border, 0.5);
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.habitItemActive {
+  background-color: $primary-translucent;
+}
+
+.habitSelectBtn {
+  flex: 1;
+  min-width: 0;
+  padding: 13px 14px;
+  background: none;
+  border: none;
+  color: $text;
+  font-family: $sarabun;
+  font-size: 16px;
+  letter-spacing: $sarabun-spacing;
+  text-align: left;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  @media (max-width: $mobile-width) {
+    font-size: 15px;
+    padding: 14px 12px;
+  }
+}
+
+// ── Habit three-dots menu ──────────────────────────────────────────────────────
+.habitMenuWrap {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.habitMenuBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 44px;
+  background: none;
+  border: none;
+  color: rgba($text, 0.55);
+  cursor: pointer;
+  padding: 0;
+  -webkit-tap-highlight-color: transparent;
+
+  svg {
+    display: block;
+    width: 16px;
+    height: 16px;
+  }
+
+  &:active {
+    color: $primary;
+  }
+}
+
+.habitMenu {
+  position: absolute;
+  right: 4px;
+  top: calc(100% + 2px);
+  z-index: 30;
+  background-color: $surface;
+  border: 1.5px solid $surface-border;
+  border-radius: 10px;
+  overflow: hidden;
+  min-width: 110px;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.5);
+}
+
+.habitMenuItem {
+  display: block;
+  width: 100%;
+  padding: 11px 14px;
+  background: none;
+  border: none;
+  color: $text;
+  font-family: $sarabun;
+  font-size: 15px;
+  letter-spacing: $sarabun-spacing;
+  text-align: left;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+
+  & + & {
+    border-top: 1px solid rgba($surface-border, 0.5);
+  }
+
+  &:active {
+    background-color: $primary-translucent;
+  }
+}
+
+.habitMenuItemDanger {
+  color: $error;
+}
+
+// ── Rename input ───────────────────────────────────────────────────────────────
+.renameRow {
+  flex: 1;
+  padding: 6px 12px;
+}
+
+.renameInput {
+  width: 100%;
+  background-color: transparent;
+  border: none;
+  border-bottom: 2px solid $primary-border;
+  color: $text;
+  font-family: $sarabun;
+  font-size: 16px;
+  letter-spacing: $sarabun-spacing;
+  padding: 4px 0;
+  outline: none;
+
+  // Prevent iOS zoom: ensure font-size >= 16px
+  @media (max-width: $mobile-width) {
+    font-size: 16px;
+  }
+}
+
+// ── New habit input ────────────────────────────────────────────────────────────
+.newHabitRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px;
+  border-top: 1px solid rgba($surface-border, 0.5);
+}
+
+.newHabitInput {
+  flex: 1;
+  min-width: 0;
+  background-color: transparent;
+  border: none;
+  border-bottom: 2px solid $surface-border;
+  color: $text;
+  font-family: $sarabun;
+  font-size: 16px;
+  letter-spacing: $sarabun-spacing;
+  padding: 4px 0;
+  outline: none;
+
+  &:focus {
+    border-bottom-color: $primary-border;
+  }
+
+  &::placeholder {
+    color: rgba($text, 0.4);
+  }
+
+  // Prevent iOS zoom
+  @media (max-width: $mobile-width) {
+    font-size: 16px;
+  }
+}
+
+.newHabitSaveBtn {
+  flex-shrink: 0;
+  padding: 6px 12px;
+  background-color: $primary;
+  color: $background;
+  border: none;
+  border-radius: 8px;
+  font-family: $sarabun;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: $sarabun-spacing;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+
+  &:active {
+    background-color: $primary-dark;
+  }
+}
+
+.newHabitCancelBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: rgba($text, 0.5);
+  cursor: pointer;
+  padding: 0;
+  -webkit-tap-highlight-color: transparent;
+
+  svg {
+    display: block;
+    width: 14px;
+    height: 14px;
+  }
+
+  &:active {
+    color: $text;
+  }
+}
+
+// ── Add habit button ───────────────────────────────────────────────────────────
+.addHabitBtn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 12px 14px;
+  background: none;
+  border: none;
+  border-top: 1px solid rgba($surface-border, 0.5);
+  color: $primary;
+  font-family: $sarabun;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: $sarabun-spacing;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+
+  svg {
+    display: block;
+    width: 15px;
+    height: 15px;
+    flex-shrink: 0;
+  }
+
+  &:active {
+    background-color: $primary-translucent;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  @media (max-width: $mobile-width) {
+    padding: 14px;
+  }
+}
+
+// ── Confirm delete dialog ──────────────────────────────────────────────────────
+.confirmOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  background-color: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.confirmBox {
+  background-color: $surface;
+  border: 2px solid $surface-border;
+  border-radius: $border-radius;
+  padding: 24px 20px 20px;
+  max-width: 340px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.confirmText {
+  margin: 0;
+  color: $text;
+  font-family: $sarabun;
+  font-size: 16px;
+  letter-spacing: $sarabun-spacing;
+  line-height: 1.5;
+
+  strong {
+    color: $primary;
+    font-weight: 700;
+  }
+}
+
+.confirmBtns {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.confirmCancel {
+  padding: 10px 18px;
+  background: none;
+  border: 2px solid $surface-border;
+  border-radius: 10px;
+  color: $text;
+  font-family: $sarabun;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: $sarabun-spacing;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+
+  &:active {
+    background-color: $primary-translucent;
+    border-color: $primary-border;
+  }
+}
+
+.confirmDelete {
+  padding: 10px 18px;
+  background-color: $error;
+  border: 2px solid $error;
+  border-radius: 10px;
+  color: $text;
+  font-family: $sarabun;
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: $sarabun-spacing;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+
+  &:active {
+    opacity: 0.8;
+  }
+}

--- a/migrations/011_habits_registry.sql
+++ b/migrations/011_habits_registry.sql
@@ -1,0 +1,34 @@
+-- Adds a per-user habits registry table so habits have an identity beyond
+-- just a tally key.  Existing tallies are unaffected: habit_tallies continues
+-- to store rows keyed by habit_name; this table simply gives users a named
+-- list they can manage (create / rename / delete / reorder).
+--
+-- Seeding: any user who already has tallies for 'nail-biting' gets that habit
+-- inserted automatically so their existing data keeps working after deploy.
+--
+-- Deploy ordering:
+--   1. Run this migration BEFORE deploying new backend code.
+--   2. The new CRUD endpoints (/habits registry routes) depend on this table.
+--   3. Existing tally endpoints are unaffected and continue to work even if
+--      this migration runs first on a fresh DB with no prior tallies.
+--
+-- Idempotency: CREATE TABLE IF NOT EXISTS is safe on re-runs.
+-- scripts/migrate.js tracks applied files in schema_migrations so this file
+-- is only ever executed once per DB.
+
+CREATE TABLE IF NOT EXISTS habits (
+  id          INT AUTO_INCREMENT PRIMARY KEY,
+  user_uuid   BINARY(16)    NOT NULL,
+  name        VARCHAR(100)  NOT NULL,
+  ordering    INT           NOT NULL DEFAULT 0,
+  created_at  DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE KEY unique_user_habit_name (user_uuid, name),
+  FOREIGN KEY (user_uuid) REFERENCES users(user_uuid) ON DELETE CASCADE
+);
+
+-- Seed: for every user who already has nail-biting tallies, insert the habit
+-- into the registry (if it does not already exist).
+INSERT IGNORE INTO habits (user_uuid, name, ordering, created_at)
+SELECT DISTINCT user_uuid, 'nail-biting', 0, NOW()
+FROM habit_tallies
+WHERE habit_name = 'nail-biting';

--- a/routes/habits.ts
+++ b/routes/habits.ts
@@ -8,6 +8,172 @@ import { User } from '../types';
 const router = Router();
 router.use(authenticateToken);
 
+// ─── Habits registry CRUD ──────────────────────────────────────────────────────
+
+// GET /habits — list all habits for the user (ordered by ordering, then created_at)
+router.get('/', async (req, res): Promise<any> => {
+    const { uuid }: User = res.locals.user;
+
+    let data: RowDataPacket[];
+    try {
+        [data] = await pool.query<RowDataPacket[]>(`
+            SELECT id, name, ordering, created_at
+            FROM habits
+            WHERE user_uuid = UUID_TO_BIN(?)
+            ORDER BY ordering ASC, created_at ASC
+        `, [uuid]);
+    } catch (error) {
+        return handleSqlError(error, res);
+    }
+
+    res.status(200).json({ data, message: 'Successfully retrieved habits' });
+});
+
+// POST /habits — create a new habit
+router.post('/', async (req, res): Promise<any> => {
+    const { uuid }: User = res.locals.user;
+    const { name } = req.body as { name?: string };
+
+    if (!name || typeof name !== 'string' || !name.trim()) {
+        return res.status(400).json({ message: 'name is required' });
+    }
+    const trimmed = name.trim().slice(0, 100);
+
+    // Determine next ordering value
+    let maxRow: RowDataPacket[];
+    try {
+        [maxRow] = await pool.query<RowDataPacket[]>(`
+            SELECT COALESCE(MAX(ordering), -1) AS maxOrd
+            FROM habits
+            WHERE user_uuid = UUID_TO_BIN(?)
+        `, [uuid]);
+    } catch (error) {
+        return handleSqlError(error, res);
+    }
+    const nextOrd = ((maxRow[0]?.maxOrd as number) ?? -1) + 1;
+
+    let result: ResultSetHeader;
+    try {
+        [result] = await pool.query<ResultSetHeader>(`
+            INSERT INTO habits (user_uuid, name, ordering)
+            VALUES (UUID_TO_BIN(?), ?, ?)
+        `, [uuid, trimmed, nextOrd]);
+    } catch (error: any) {
+        if (error?.code === 'ER_DUP_ENTRY') {
+            return res.status(409).json({ message: `Habit "${trimmed}" already exists` });
+        }
+        return handleSqlError(error, res);
+    }
+
+    res.status(201).json({
+        data: { id: result.insertId, name: trimmed, ordering: nextOrd },
+        message: `Habit "${trimmed}" created`
+    });
+});
+
+// PATCH /habits/:id — rename a habit (also renames its tallies)
+router.patch('/:id', async (req, res): Promise<any> => {
+    const { uuid }: User = res.locals.user;
+    const id = parseInt(req.params.id, 10);
+    if (isNaN(id)) return res.status(400).json({ message: 'Invalid habit id' });
+
+    const { name } = req.body as { name?: string };
+    if (!name || typeof name !== 'string' || !name.trim()) {
+        return res.status(400).json({ message: 'name is required' });
+    }
+    const newName = name.trim().slice(0, 100);
+
+    // Look up the old name so we can rename tallies
+    let rows: RowDataPacket[];
+    try {
+        [rows] = await pool.query<RowDataPacket[]>(`
+            SELECT name FROM habits
+            WHERE id = ? AND user_uuid = UUID_TO_BIN(?)
+        `, [id, uuid]);
+    } catch (error) {
+        return handleSqlError(error, res);
+    }
+    if (rows.length === 0) {
+        return res.status(404).json({ message: 'Habit not found' });
+    }
+    const oldName: string = rows[0].name;
+
+    // Rename in registry
+    let result: ResultSetHeader;
+    try {
+        [result] = await pool.query<ResultSetHeader>(`
+            UPDATE habits SET name = ?
+            WHERE id = ? AND user_uuid = UUID_TO_BIN(?)
+        `, [newName, id, uuid]);
+    } catch (error: any) {
+        if (error?.code === 'ER_DUP_ENTRY') {
+            return res.status(409).json({ message: `Habit "${newName}" already exists` });
+        }
+        return handleSqlError(error, res);
+    }
+    if (result.affectedRows === 0) {
+        return res.status(404).json({ message: 'Habit not found' });
+    }
+
+    // Rename all tallies for this user+old-name to the new name
+    try {
+        await pool.query<ResultSetHeader>(`
+            UPDATE habit_tallies SET habit_name = ?
+            WHERE user_uuid = UUID_TO_BIN(?) AND habit_name = ?
+        `, [newName, uuid, oldName]);
+    } catch (error) {
+        console.error('Failed to rename habit tallies:', error);
+    }
+
+    res.status(200).json({ data: { id, name: newName }, message: `Habit renamed to "${newName}"` });
+});
+
+// DELETE /habits/:id — delete a habit and all its tallies
+router.delete('/:id', async (req, res): Promise<any> => {
+    const { uuid }: User = res.locals.user;
+    const id = parseInt(req.params.id, 10);
+    if (isNaN(id)) return res.status(400).json({ message: 'Invalid habit id' });
+
+    // Look up name so we can delete tallies
+    let rows: RowDataPacket[];
+    try {
+        [rows] = await pool.query<RowDataPacket[]>(`
+            SELECT name FROM habits
+            WHERE id = ? AND user_uuid = UUID_TO_BIN(?)
+        `, [id, uuid]);
+    } catch (error) {
+        return handleSqlError(error, res);
+    }
+    if (rows.length === 0) {
+        return res.status(404).json({ message: 'Habit not found' });
+    }
+    const habitName: string = rows[0].name;
+
+    // Delete tallies first
+    try {
+        await pool.query<ResultSetHeader>(`
+            DELETE FROM habit_tallies
+            WHERE user_uuid = UUID_TO_BIN(?) AND habit_name = ?
+        `, [uuid, habitName]);
+    } catch (error) {
+        return handleSqlError(error, res);
+    }
+
+    // Delete from registry
+    try {
+        await pool.query<ResultSetHeader>(`
+            DELETE FROM habits
+            WHERE id = ? AND user_uuid = UUID_TO_BIN(?)
+        `, [id, uuid]);
+    } catch (error) {
+        return handleSqlError(error, res);
+    }
+
+    res.status(200).json({ message: `Habit "${habitName}" and its tallies deleted` });
+});
+
+// ─── Tally endpoints (keyed by habit name — unchanged) ─────────────────────────
+
 // GET all rows for a habit (sorted descending by date)
 router.get('/:habitName', async (req, res): Promise<any> => {
     const { uuid }: User = res.locals.user;


### PR DESCRIPTION
## Summary

- Adds a `habits` registry table (migration `011_habits_registry.sql`) so habits have a named identity independent of their tallies.
- Adds CRUD API endpoints: list, create, rename (with tally rename), delete (with tally cascade).
- Replaces the hardcoded `HABIT_NAME = 'nail-biting'` in `HabitTracker.jsx` with a full habit selector, create/rename/delete UI, and per-habit tally views.

## Migration: `011_habits_registry.sql`

**What it creates:**
- `habits` table: `id INT AUTO_INCREMENT PK`, `user_uuid BINARY(16) FK → users`, `name VARCHAR(100)`, `ordering INT`, `created_at DATETIME`.
- Unique constraint on `(user_uuid, name)` prevents duplicate habit names per user.
- FK to `users` with `ON DELETE CASCADE` (if a user is deleted, their habits are removed automatically).

**How it seeds:**
```sql
INSERT IGNORE INTO habits (user_uuid, name, ordering, created_at)
SELECT DISTINCT user_uuid, 'nail-biting', 0, NOW()
FROM habit_tallies
WHERE habit_name = 'nail-biting';
```
Any user who already has `nail-biting` tallies gets the habit created in the registry automatically. `INSERT IGNORE` makes this safe on re-runs.

**Deploy ordering:**
1. Run `scripts/migrate.js` (Heroku release phase does this automatically) **before** deploying the new backend code.
2. Existing tally endpoints continue to work even on the old code — the migration is additive.
3. New CRUD endpoints require the `habits` table, so they must not be reached before the migration runs (Heroku release phase ensures this ordering).

**Idempotency:** `CREATE TABLE IF NOT EXISTS` + `INSERT IGNORE` make this safe to re-run.

## API changes (`routes/habits.ts`)

New endpoints before the existing tally routes:

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/habits` | List all habits for the user (ordered by `ordering`, then `created_at`) |
| `POST` | `/habits` | Create a habit (`{ name }`) |
| `PATCH` | `/habits/:id` | Rename a habit — also renames all matching `habit_tallies.habit_name` rows |
| `DELETE` | `/habits/:id` | Delete a habit and all its tallies |

Existing tally endpoints (`GET /:habitName`, `POST /:habitName/tally`, `PATCH /:habitName/:date`) are unchanged.

## Frontend changes (`HabitTracker.jsx` + `HabitTracker.module.scss`)

- **Habit selector:** Dropdown button showing the active habit name with a chevron. Tapping opens a list of all habits.
- **Switching habits:** Tapping a habit in the list selects it and closes the dropdown; the tally view updates immediately.
- **Create:** "New habit" button at the bottom of the dropdown opens an inline input. Enter or "Add" saves; Escape cancels.
- **Rename:** Three-dots menu on each habit item → Rename replaces the row with an inline input; saving calls `PATCH /habits/:id` and invalidates the old tally cache key so tallies refetch under the new name.
- **Delete:** Three-dots menu → Delete shows a confirmation dialog before calling `DELETE /habits/:id`.
- **Tally UI:** Unchanged — Add Tally, increment/decrement, and time-range inputs all operate on the selected habit.
- All SVG elements inside flex containers use `display: block` (iOS Safari fix).
- All text inputs use `font-size: 16px` on mobile to prevent iOS Safari zoom.

## Local DB test

Docker MySQL (DB_PORT=3307) was not available in this environment; the migration SQL was manually reviewed. The `CREATE TABLE IF NOT EXISTS` and `INSERT IGNORE` statements follow conventions from migrations 005–010 and are compatible with the `scripts/migrate.js` runner.

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)