### PR TITLE
Fix migration 011 deploy failure (semicolon in comment)

### DIFF
--- a/migrations/011_habits_registry.sql
+++ b/migrations/011_habits_registry.sql
@@ -1,6 +1,6 @@
 -- Adds a per-user habits registry table so habits have an identity beyond
 -- just a tally key.  Existing tallies are unaffected: habit_tallies continues
--- to store rows keyed by habit_name; this table simply gives users a named
+-- to store rows keyed by habit_name. This table simply gives users a named
 -- list they can manage (create / rename / delete / reorder).
 --
 -- Seeding: any user who already has tallies for 'nail-biting' gets that habit


### PR DESCRIPTION
Migration `011_habits_registry.sql` (from #86) would **fail on the Heroku release-phase deploy**.

`scripts/migrate.js` splits each migration file on `;` and runs the chunks via prepared-statement `execute()`. Line 2 of 011 had a semicolon *inside a comment* (`...keyed by habit_name; this table...`), which split the comment into invalid SQL and broke the migration. Verified locally against Docker MySQL: it failed before this change and applies cleanly after.

Fix: reword the comment to drop the inline semicolon (the convention migrations 007–010 already follow).

Note: the underlying `migrate.js` splitter is fragile (naive `split(';')` + `execute()` chokes on comment-only chunks). Worth hardening separately, but this surgical fix unblocks the habits deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)