### PR TITLE
Fix backend build break + habits increment bug (found in validation)

### DIFF
--- a/client/src/components/HabitTracker.jsx
+++ b/client/src/components/HabitTracker.jsx
@@ -546,6 +546,14 @@ function HabitTracker() {
     if (!activeHabit) return;
     const row = displayRows.find(r => r.date === date);
     if (!row) return;
+    // If no tally row is persisted yet for this date (e.g. today's synthetic
+    // row on a freshly created habit), create it via the upsert tally endpoint.
+    // PATCHing a non-existent row 404s, which silently rolled the count back.
+    const serverRow = rows.find(r => r.date === date);
+    if (!serverRow) {
+      addTallyMutation.mutate({ localDate: date, localTime: getNowLocalTime() });
+      return;
+    }
     const newCount = row.count + 1;
     // Optimistic update
     queryClient.setQueryData(['habits', activeHabit.name], (prev) => {

--- a/services/nutrition/agent.ts
+++ b/services/nutrition/agent.ts
@@ -89,13 +89,13 @@ When proposing an entry with \`propose_entry\`, for EACH ingredient:
 6. Sum ingredient macros to produce the entry's total macros. Do NOT use a different total than this sum.
 7. If a food was previously logged (from \`search_food_history\`), prefer the same serving and grams unless the user specifies otherwise.
 
-## The `notes` field in propose_entry (OPTIONAL — use sparingly)
-The `notes` field on a proposal is OPTIONAL and should only be populated when you need to explain a confusing or non-obvious choice to the user — for example:
+## The \`notes\` field in propose_entry (OPTIONAL — use sparingly)
+The \`notes\` field on a proposal is OPTIONAL and should only be populated when you need to explain a confusing or non-obvious choice to the user — for example:
 - Why an odd decimal gram weight was chosen (e.g. "1 medium egg from USDA is 49.6 g per the database serving size")
 - Why a less-obvious food database entry was selected over an alternative
 - Why a specific portion size was picked when the user's description was ambiguous
 
-DO NOT populate `notes` when the proposal is straightforward (e.g. "200g chicken breast"). Do NOT use `notes` as an always-present summary of what you logged — your chat reply already serves that purpose. Leave `notes` null/absent in the vast majority of proposals.
+DO NOT populate \`notes\` when the proposal is straightforward (e.g. "200g chicken breast"). Do NOT use \`notes\` as an always-present summary of what you logged — your chat reply already serves that purpose. Leave \`notes\` null/absent in the vast majority of proposals.
 
 ## Other rules
 - Ground all macros in tool results. If a search returns no results, say so and ask the user for more info.


### PR DESCRIPTION
Two defects in the merged feedback-fix work, surfaced by the post-Wave-2 Playwright validation pass.

## 1. Backend won't compile (CRITICAL — deploy blocker)
The #67 "notes" guidance (PR #83) was added to the `agent.ts` system-prompt **template literal** using **unescaped backticks**, which terminates the literal:

```
services/nutrition/agent.ts(98,109): error TS1443: Module declaration names may only use ' or " quoted strings.
```

Result: backend `tsc` fails → the server crashes on boot and `heroku-postbuild` (which runs `tsc`) would fail the deploy. Fixed by escaping the backticks (`\`notes\``), matching the rest of the prompt.

## 2. Habit increment 404s on a fresh day (#78 follow-up)
Incrementing a habit on a day with no persisted tally row yet (e.g. today's synthetic row on a freshly created habit) PATCHed a row that doesn't exist → `404 No tally found`, silently rolling the optimistic count back to 0. The marquee new-habit flow felt broken. Now `handleIncrement` routes through the upsert `/tally` endpoint when no server row exists.

## Verification
- Backend `tsc --noEmit`: clean
- Client `vite build`: clean
- Increment fix confirmed live: fresh habit, click "+", count 0→1, tally rendered, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)