### PR TITLE
Chat composer: floating attach buttons, placeholder centering, standalone safe-area (#92 #93 #94)

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#000000" />
   <meta name="description" content="An app to help you track you personal records in the gym" />
   <link rel="apple-touch-icon" href="/logo192.png" />

--- a/client/src/features/nutrition/NutritionChat.module.scss
+++ b/client/src/features/nutrition/NutritionChat.module.scss
@@ -35,10 +35,11 @@
   &:focus { outline: none; }
 }
 
-// Peek: just the drag handle + composer visible
-// #61: height now uses max() to account for safe-area on iPhone
+// Peek: drag handle + floating attach buttons + composer row
+// #61: height uses calc() to account for safe-area on iPhone
+// #93: attach row added ≈ 52px → bump peek from 96→136px
 .sheetPeek {
-  height: calc(96px + env(safe-area-inset-bottom));
+  height: calc(136px + env(safe-area-inset-bottom));
 }
 
 // Expanded: full chat
@@ -619,19 +620,66 @@
   letter-spacing: $sarabun-spacing;
 }
 
-// ---- Composer row ----
+// ---- Composer area ----
+// #93: The camera + barcode buttons float ABOVE the textarea as small circles,
+//      left-aligned. The composer row itself holds only the textarea + send button.
 // #3/#61: safe-area for iOS home indicator.
 // The sheet has padding-bottom: env(safe-area-inset-bottom) so the composer
 // only needs a consistent inner padding — the sheet's padding handles the gap.
+.composerWrap {
+  flex-shrink: 0;
+  border-top: 1px solid rgba($surface-border, 0.3);
+}
+
+// #93: Row of floating circular buttons above the textarea, left-aligned.
+// They sit outside the flex row so the textarea gets full width.
+.composerAttachRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px 4px;
+}
+
+// #93: Small circular attach button (camera, barcode).
+// min-width/height 36px → tappable on mobile (Apple HIG ≥ 44 pt; 36px still works
+// for secondary UI when spaced well — matches clearBtn sizing).
+.composerCircleBtn {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  background: rgba($background, 0.5);
+  border: 1px solid rgba($surface-border, 0.6);
+  border-radius: 50%;
+  color: rgba($text, 0.55);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+
+  &:active {
+    color: $primary;
+    border-color: $primary-border;
+    background-color: rgba($primary, 0.08);
+  }
+}
+
+.composerCircleBtnIcon {
+  display: block; // iOS Safari SVG fix
+  width: 16px;
+  height: 16px;
+}
+
+// #93: Bottom row — textarea + send, full width
 .composer {
   display: flex;
   align-items: flex-end;
   gap: 6px;
-  padding: 8px 12px 10px;
-  border-top: 1px solid rgba($surface-border, 0.3);
-  flex-shrink: 0;
+  padding: 4px 12px 10px;
 }
 
+// Keep .composerBtn for backwards-compat (not rendered any more but avoids
+// a "unused class" warning if some other branch references it).
 .composerBtn {
   flex-shrink: 0;
   min-width: 40px;
@@ -664,21 +712,27 @@
   display: none;
 }
 
-// #4: textarea — 16px on mobile prevents iOS from zooming on focus.
-// Desktop keeps 15px for visual density.
+// #4/#92: textarea — 16px on mobile prevents iOS from zooming on focus.
+// #92: Placeholder vertical centering: use line-height equal to (min-height - 2*padding)
+//      so a single text line sits in the center of the 40px box.
+//      With min-height:40px and padding-top/bottom:8px that leaves 24px for text.
+//      line-height:24px centers a single line; multi-line growth via useAutoGrow is unaffected.
 .composerInput {
   flex: 1;
   background-color: rgba($background, 0.4);
   color: $text;
   border: 1px solid rgba($surface-border, 0.6);
   border-radius: 12px;
-  padding: 10px 12px;
+  // #92: vertical centering: padding 8px top/bottom, line-height 24px.
+  //      Total single-line height = 8 + 24 + 8 + 2(border) = 42px ≈ 40px min-height.
+  padding: 8px 12px;
   font-family: $sarabun;
   // #4: 16px on mobile (≤$mobile-width) to suppress iOS auto-zoom on focus
   font-size: 16px;
   letter-spacing: $sarabun-spacing;
   resize: none;
-  line-height: 1.4;
+  // #92: line-height matches the content area so one line of text is vertically centered
+  line-height: 1.5;
   min-height: 40px;
   max-height: 180px;
   overflow-y: hidden; // JS sets to auto when at max

--- a/client/src/features/nutrition/NutritionChat.tsx
+++ b/client/src/features/nutrition/NutritionChat.tsx
@@ -455,7 +455,9 @@ interface NutritionChatProps {
 }
 
 // Sheet height constants
-const PEEK_HEIGHT = 96;     // px — drag handle + composer
+// #93: Peek height now includes the floating attach-button row above the composer.
+// dragHandleBtn≈18 + composerAttachRow≈52 (8+36+8) + composer≈54 (4+40+10) ≈ 124px.
+const PEEK_HEIGHT = 136;    // px — drag handle + attach row + composer row (+ a little breathing room)
 const EXPANDED_HEIGHT_VH = 88; // dvh
 
 export default function NutritionChat({ open, onClose, selectedDate }: NutritionChatProps) {
@@ -960,22 +962,44 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
           <p className={styles.photoError}>{photoError}</p>
         )}
 
-        {/* Composer — #3/#61: safe-area padding, #4: 16px font-size on mobile */}
-        <div className={styles.composer}>
-          {/* Photo attach button */}
-          <button
-            type="button"
-            className={styles.composerBtn}
-            onClick={() => fileInputRef.current?.click()}
-            aria-label="Attach photo"
-            title="Attach photo"
-          >
-            <svg className={styles.composerBtnIcon} viewBox="0 0 22 22" fill="none" aria-hidden="true">
-              <rect x="2" y="5" width="18" height="13" rx="2.5" stroke="currentColor" strokeWidth="1.8" />
-              <circle cx="11" cy="12" r="3.5" stroke="currentColor" strokeWidth="1.8" />
-              <path d="M8 5l1.5-2h3L14 5" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round" />
-            </svg>
-          </button>
+        {/* Composer — #3/#61: safe-area padding, #4: 16px font-size on mobile
+            #93: camera + barcode moved above textarea as floating circles (left-aligned).
+            #92: textarea now spans full width; placeholder centering fixed via CSS. */}
+        <div className={styles.composerWrap}>
+          {/* #93: Floating circular attach buttons — above the textarea, left-aligned */}
+          <div className={styles.composerAttachRow}>
+            {/* Photo attach button */}
+            <button
+              type="button"
+              className={styles.composerCircleBtn}
+              onClick={() => fileInputRef.current?.click()}
+              aria-label="Attach photo"
+              title="Attach photo"
+            >
+              <svg className={styles.composerCircleBtnIcon} viewBox="0 0 22 22" fill="none" aria-hidden="true">
+                <rect x="2" y="5" width="18" height="13" rx="2.5" stroke="currentColor" strokeWidth="1.8" />
+                <circle cx="11" cy="12" r="3.5" stroke="currentColor" strokeWidth="1.8" />
+                <path d="M8 5l1.5-2h3L14 5" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round" />
+              </svg>
+            </button>
+
+            {/* Barcode button */}
+            <button
+              type="button"
+              className={styles.composerCircleBtn}
+              onClick={() => setBarcodeOpen(true)}
+              aria-label="Scan barcode"
+              title="Scan barcode"
+            >
+              <svg className={styles.composerCircleBtnIcon} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <rect x="2" y="4" width="3" height="16" rx="0.5" fill="currentColor" stroke="none" />
+                <rect x="7" y="4" width="1.5" height="16" rx="0.5" fill="currentColor" stroke="none" />
+                <rect x="10.5" y="4" width="2.5" height="16" rx="0.5" fill="currentColor" stroke="none" />
+                <rect x="15" y="4" width="1.5" height="16" rx="0.5" fill="currentColor" stroke="none" />
+                <rect x="18.5" y="4" width="3.5" height="16" rx="0.5" fill="currentColor" stroke="none" />
+              </svg>
+            </button>
+          </div>
 
           <input
             ref={fileInputRef}
@@ -989,63 +1013,49 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
             tabIndex={-1}
           />
 
-          {/* Barcode button */}
-          <button
-            type="button"
-            className={styles.composerBtn}
-            onClick={() => setBarcodeOpen(true)}
-            aria-label="Scan barcode"
-            title="Scan barcode"
-          >
-            <svg className={styles.composerBtnIcon} viewBox="0 0 24 24" fill="none" aria-hidden="true">
-              <rect x="2" y="4" width="3" height="16" rx="0.5" fill="currentColor" stroke="none" />
-              <rect x="7" y="4" width="1.5" height="16" rx="0.5" fill="currentColor" stroke="none" />
-              <rect x="10.5" y="4" width="2.5" height="16" rx="0.5" fill="currentColor" stroke="none" />
-              <rect x="15" y="4" width="1.5" height="16" rx="0.5" fill="currentColor" stroke="none" />
-              <rect x="18.5" y="4" width="3.5" height="16" rx="0.5" fill="currentColor" stroke="none" />
-            </svg>
-          </button>
+          {/* #93: Bottom row — textarea spans full width + send button at right */}
+          <div className={styles.composer}>
+            {/* #4/#92: 16px font-size (no iOS zoom); placeholder vertically centered via CSS */}
+            <textarea
+              ref={textareaRef}
+              className={styles.composerInput}
+              placeholder="Describe what you ate…"
+              value={text}
+              onChange={e => setText(e.target.value)}
+              onKeyDown={handleKeyDown}
+              onFocus={() => {
+                setExpanded(true);
+              }}
+              rows={1}
+              aria-label="Chat message"
+            />
 
-          {/* #4: 16px font-size set via CSS class to prevent iOS zoom */}
-          <textarea
-            ref={textareaRef}
-            className={styles.composerInput}
-            placeholder="Describe what you ate…"
-            value={text}
-            onChange={e => setText(e.target.value)}
-            onKeyDown={handleKeyDown}
-            onFocus={() => {
-              setExpanded(true);
-            }}
-            rows={1}
-            aria-label="Chat message"
-          />
-
-          {/* #14: Send/Stop button — shows Stop icon while streaming */}
-          {isStreaming ? (
-            <button
-              type="button"
-              className={`${styles.sendBtn} ${styles.stopBtn}`}
-              onClick={handleStop}
-              aria-label="Stop generation"
-            >
-              <svg className={styles.sendIcon} viewBox="0 0 20 20" fill="none" aria-hidden="true">
-                <rect x="5" y="5" width="10" height="10" rx="2" fill="currentColor" />
-              </svg>
-            </button>
-          ) : (
-            <button
-              type="button"
-              className={styles.sendBtn}
-              onClick={handleSend}
-              disabled={!canSend}
-              aria-label="Send"
-            >
-              <svg className={styles.sendIcon} viewBox="0 0 20 20" fill="none" aria-hidden="true">
-                <path d="M2 10l16-8-8 16V10H2z" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round" />
-              </svg>
-            </button>
-          )}
+            {/* #14: Send/Stop button — shows Stop icon while streaming */}
+            {isStreaming ? (
+              <button
+                type="button"
+                className={`${styles.sendBtn} ${styles.stopBtn}`}
+                onClick={handleStop}
+                aria-label="Stop generation"
+              >
+                <svg className={styles.sendIcon} viewBox="0 0 20 20" fill="none" aria-hidden="true">
+                  <rect x="5" y="5" width="10" height="10" rx="2" fill="currentColor" />
+                </svg>
+              </button>
+            ) : (
+              <button
+                type="button"
+                className={styles.sendBtn}
+                onClick={handleSend}
+                disabled={!canSend}
+                aria-label="Send"
+              >
+                <svg className={styles.sendIcon} viewBox="0 0 20 20" fill="none" aria-hidden="true">
+                  <path d="M2 10l16-8-8 16V10H2z" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round" />
+                </svg>
+              </button>
+            )}
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

- **#92** Fix textarea placeholder/text vertical centering — adjusted padding to 8px top/bottom and line-height to 1.5 so a single line sits centered in the 40px min-height input box; useAutoGrow multi-line growth is unaffected.
- **#93** Move camera + barcode buttons above the textarea as small circular buttons (36px, border-radius 50%), left-aligned in their own row (`composerAttachRow`). The textarea now spans the full composer width with the send button at the right. `PEEK_HEIGHT` bumped 96 → 136px and `.sheetPeek` height updated to match so both the attach row and composer row are visible when the sheet is collapsed.
- **#94** Add `viewport-fit=cover` to the `index.html` viewport meta so `env(safe-area-inset-bottom)` resolves to the real home-indicator inset in iOS standalone (PWA) mode. The sheet already applied `padding-bottom: env(safe-area-inset-bottom)` (from fix #61); enabling `viewport-fit=cover` is what makes that env value non-zero in standalone mode.

## Files changed

- `client/index.html` — viewport meta: `viewport-fit=cover` added
- `client/src/features/nutrition/NutritionChat.tsx` — composer layout restructured; new `composerWrap` / `composerAttachRow` / circle buttons; `PEEK_HEIGHT` updated
- `client/src/features/nutrition/NutritionChat.module.scss` — new `.composerWrap`, `.composerAttachRow`, `.composerCircleBtn`, `.composerCircleBtnIcon` classes; `.sheetPeek` height updated; `.composerInput` padding/line-height adjusted for centering

Closes #92
Closes #93
Closes #94

## Test plan

- [ ] Textarea placeholder text is vertically centered (single line sits in the middle of the 40px box)
- [ ] Camera and barcode buttons appear as circles above the textarea when the sheet is in peek or expanded state
- [ ] Textarea spans full width of the composer row (only the send button shares the row)
- [ ] Both circular buttons are tappable on mobile; no hover-only interactions
- [ ] Collapsed sheet (peek state) shows the full attach row + composer row without clipping
- [ ] `env(safe-area-inset-bottom)` safe area verified on real iOS device in standalone mode (add to home screen) — controls should clear the home indicator
- [ ] Multi-line textarea growth via useAutoGrow still works normally
- [ ] Send, Stop, barcode scan, photo attach all continue to function
- [ ] `npx vite build` passes clean (verified locally)

> Note: #94 safe-area behavior in standalone mode is only testable on a real iPhone added to the home screen; cannot be fully validated on desktop or in Safari browser mode (env() evaluates to 0 unless `viewport-fit=cover` is active in a real standalone context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)