### PR TITLE
Workouts: fold add/delete into three-dots menu, section + exercise (#95)

### DIFF
--- a/client/src/components/Movement.jsx
+++ b/client/src/components/Movement.jsx
@@ -1,21 +1,98 @@
 import Editable from "./Editable";
 import Variation from "./variation/Variation";
 import ConfirmModal from "./ConfirmModal";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import useAuth from '../hooks/useAuth.js';
 import clientApi from "../api/clientApi.js";
 import styles from "../styles/Movement.module.scss";
-import plus from "../assets/plus.svg";
-import X from "../assets/delete.svg";
 import { v4 as uuid } from "uuid";
-import useIsMobile from "../hooks/useIsMobile.js";
+
+// ---- Three-dots exercise menu (#95) ----
+function MovementMenu({ onAddVariation, onDeleteExercise }) {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef(null);
+  const btnRef = useRef(null);
+
+  // Close on outside tap/click
+  useEffect(() => {
+    if (!open) return;
+    function handleOutside(e) {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleOutside);
+    document.addEventListener('touchstart', handleOutside, { passive: true });
+    return () => {
+      document.removeEventListener('mousedown', handleOutside);
+      document.removeEventListener('touchstart', handleOutside);
+    };
+  }, [open]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    function handleKey(e) {
+      if (e.key === 'Escape') {
+        setOpen(false);
+        btnRef.current?.focus();
+      }
+    }
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [open]);
+
+  return (
+    <div className={styles.dotsMenuWrapper} ref={wrapperRef}>
+      <button
+        ref={btnRef}
+        className={styles.dotsBtn}
+        onClick={() => setOpen(v => !v)}
+        aria-label="Exercise options"
+        aria-haspopup="true"
+        aria-expanded={open}
+        type="button"
+      >
+        <svg
+          className={styles.dotsIcon}
+          viewBox="0 0 4 18"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <circle cx="2" cy="2" r="1.6" />
+          <circle cx="2" cy="9" r="1.6" />
+          <circle cx="2" cy="16" r="1.6" />
+        </svg>
+      </button>
+
+      {open && (
+        <div className={styles.dotsDropdown} role="menu">
+          <button
+            className={styles.dotsDropdownItem}
+            role="menuitem"
+            type="button"
+            onClick={() => { setOpen(false); onAddVariation(); }}
+          >
+            Add variation
+          </button>
+          <button
+            className={`${styles.dotsDropdownItem} ${styles.dotsDropdownItemDanger}`}
+            role="menuitem"
+            type="button"
+            onClick={() => { setOpen(false); onDeleteExercise(); }}
+          >
+            Delete exercise
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
 
 function Movement({ movement, setMovements }) {
   const [variations, setVariations] = useState([])
-  const [hovering, setHovering] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
   const { withAuth } = useAuth();
-  const { isMobile } = useIsMobile();
 
   useEffect(() => {
     const fetchMovements = async () => {
@@ -50,8 +127,7 @@ function Movement({ movement, setMovements }) {
     setShowConfirm(false);
   }
 
-  async function handleVariationSubmit(e) {
-    e.preventDefault();
+  async function handleVariationSubmit() {
     const res = await withAuth(() => (
       clientApi.post(`/variations/${movement.id}`, {
         label: "Variation"
@@ -88,36 +164,20 @@ function Movement({ movement, setMovements }) {
           onCancel={handleCancelRemove}
         />
       )}
-      <div className={styles.header} onMouseEnter={() => setHovering(true)} onMouseLeave={() => setHovering(false)}>
+      <div className={styles.header}>
         {/* label */}
         <Editable className={styles.sectionPart} value={movement.label} onSubmit={handleNameEdit} />
 
-        {/* add item button */}
-        {!isMobile && (
-          <div className={`${styles.sectionPart} ${styles.addItem}`} style={{ display: hovering ? 'block' : 'none' }}>
-            <button onClick={handleVariationSubmit}>Add Variation</button>
-            <img src={plus} alt="plus" />
-          </div>
-        )}
-
-        {/* remove item button */}
-        <div className={styles.sectionPart} style={{ display: (hovering || isMobile) ? 'block' : 'none' }}>
-          <button className={styles.icon} onClick={handleRemoveClick}>
-            <img src={X} alt="delete" />
-          </button>
-        </div>
+        {/* three-dots menu */}
+        <MovementMenu
+          onAddVariation={handleVariationSubmit}
+          onDeleteExercise={handleRemoveClick}
+        />
       </div>
 
       {/* variations */}
       <div className={styles.variations}>
         {variations.map(v => <Variation key={v.id} variation={v} setVariations={setVariations} removeAllowed={variations.length > 1}/>)}
-        {/* add item button */}
-        {isMobile && (
-          <div className={styles.addItem}>
-            <button onClick={handleVariationSubmit}>Add Variation</button>
-            <img src={plus} alt="plus" />
-          </div>
-        )}
       </div>
     </li>
   )

--- a/client/src/components/Section.jsx
+++ b/client/src/components/Section.jsx
@@ -1,22 +1,99 @@
 import Movement from "./Movement.jsx";
 import Editable from "./Editable.jsx";
 import ConfirmModal from "./ConfirmModal.jsx";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import styles from "../styles/Workouts.module.scss";
-import plus from "../assets/plus.svg";
 import CollapseButton from "./CollapseButton.jsx";
-import X from "../assets/delete.svg";
 import useAuth from '../hooks/useAuth.js';
 import clientApi from "../api/clientApi.js";
 import { v4 as uuid } from "uuid";
-import useIsMobile from "../hooks/useIsMobile.js";
+
+// ---- Three-dots section menu (#95) ----
+function SectionMenu({ onAddExercise, onDeleteSection }) {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef(null);
+  const btnRef = useRef(null);
+
+  // Close on outside tap/click
+  useEffect(() => {
+    if (!open) return;
+    function handleOutside(e) {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleOutside);
+    document.addEventListener('touchstart', handleOutside, { passive: true });
+    return () => {
+      document.removeEventListener('mousedown', handleOutside);
+      document.removeEventListener('touchstart', handleOutside);
+    };
+  }, [open]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    function handleKey(e) {
+      if (e.key === 'Escape') {
+        setOpen(false);
+        btnRef.current?.focus();
+      }
+    }
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [open]);
+
+  return (
+    <div className={styles.dotsMenuWrapper} ref={wrapperRef}>
+      <button
+        ref={btnRef}
+        className={styles.dotsBtn}
+        onClick={() => setOpen(v => !v)}
+        aria-label="Section options"
+        aria-haspopup="true"
+        aria-expanded={open}
+        type="button"
+      >
+        <svg
+          className={styles.dotsIcon}
+          viewBox="0 0 4 18"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <circle cx="2" cy="2" r="1.6" />
+          <circle cx="2" cy="9" r="1.6" />
+          <circle cx="2" cy="16" r="1.6" />
+        </svg>
+      </button>
+
+      {open && (
+        <div className={styles.dotsDropdown} role="menu">
+          <button
+            className={styles.dotsDropdownItem}
+            role="menuitem"
+            type="button"
+            onClick={() => { setOpen(false); onAddExercise(); }}
+          >
+            Add exercise
+          </button>
+          <button
+            className={`${styles.dotsDropdownItem} ${styles.dotsDropdownItemDanger}`}
+            role="menuitem"
+            type="button"
+            onClick={() => { setOpen(false); onDeleteSection(); }}
+          >
+            Delete section
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
 
 function Section({ setSections, section }) {
-  const [hovering, setHovering] = useState(false);
   const [movements, setMovements] = useState([]);
   const [showConfirm, setShowConfirm] = useState(false);
   const { withAuth } = useAuth();
-  const { isMobile } = useIsMobile();
 
   useEffect(() => {
     const fetchMovements = async () => {
@@ -47,8 +124,7 @@ function Section({ setSections, section }) {
     setShowConfirm(false);
   }
 
-  async function handleMovementSubmit(e) {
-    e.preventDefault();
+  async function handleMovementSubmit() {
     const isFirst = movements.length === 0;
     const res = await withAuth(() => (
       clientApi.post(`/movements/${section.id}`, { label: "Exercise" })
@@ -100,7 +176,7 @@ function Section({ setSections, section }) {
           onCancel={handleCancelRemove}
         />
       )}
-      <div className={styles.section} onMouseEnter={() => setHovering(true)} onMouseLeave={() => setHovering(false)}>
+      <div className={styles.section}>
         <div className={styles.sectionHeader}>
           <div className={styles.sectionPart}>
             <Editable
@@ -108,45 +184,28 @@ function Section({ setSections, section }) {
               value={section.label}
               onSubmit={handleEditSubmit}
             />
-            {(hovering && (section.showItems || movements.length === 0) && !isMobile) && (
-              <div className={styles.addItem} >
-                <button type='button' onClick={handleMovementSubmit}>Add Exercise</button>
-                <img src={plus} alt="plus" />
-              </div>
-            )}
           </div>
           <div className={`${styles.sectionPart} ${styles.remove}`}>
-            {(hovering || isMobile) &&
-              <button type='button' onClick={handleRemoveClick} className={styles.icon}>
-                <img src={X} alt="delete" />
-              </button>
-            }
+            <SectionMenu
+              onAddExercise={handleMovementSubmit}
+              onDeleteSection={handleRemoveClick}
+            />
             {movements.length > 0 &&
               <CollapseButton isOpen={section.showItems} onClick={handleDropdownClick} />
             }
           </div>
         </div>
-        <div className={styles.mobileAdd}>
-          {(section.showItems || movements.length === 0) && isMobile && (
-            <div className={styles.addItem} >
-              <button type='button' onClick={handleMovementSubmit}>Add Exercise</button>
-              <img src={plus} alt="plus" />
-            </div>
-          )}
-        </div>
       </div>
-      {
-        <ul className={styles.movements} style={{ display: section.showItems ? 'block' : 'none' }}>
-          {movements.map((m) => (
-            <Movement
-              key={m.id ?? uuid()}
-              movement={m}
-              setMovements={setMovements}
-              sectionId={section.id}
-            />
-          ))}
-        </ul>
-      }
+      <ul className={styles.movements} style={{ display: section.showItems ? 'block' : 'none' }}>
+        {movements.map((m) => (
+          <Movement
+            key={m.id ?? uuid()}
+            movement={m}
+            setMovements={setMovements}
+            sectionId={section.id}
+          />
+        ))}
+      </ul>
     </section>
   );
 }

--- a/client/src/styles/Movement.module.scss
+++ b/client/src/styles/Movement.module.scss
@@ -131,3 +131,80 @@
     background-color: $primary-translucent;
   }
 }
+
+// ── Three-dots exercise menu (#95) ───────────────────────────────────────────
+.dotsMenuWrapper {
+  position: relative;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+.dotsBtn {
+  min-width: 40px;
+  min-height: 40px;
+  background: transparent;
+  border: none;
+  border-radius: 8px;
+  color: rgba($text, 0.4);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+
+  &:active {
+    background-color: rgba($primary, 0.1);
+    color: $primary;
+  }
+}
+
+.dotsIcon {
+  display: block; // iOS Safari SVG fix
+  width: 4px;
+  height: 16px;
+}
+
+.dotsDropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  background-color: $surface;
+  border: 1px solid $surface-border;
+  border-radius: 10px;
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 130px;
+  z-index: 200;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.45);
+}
+
+.dotsDropdownItem {
+  background: transparent;
+  border: none;
+  color: $text;
+  font-family: $sarabun;
+  font-size: 15px;
+  font-weight: 500;
+  letter-spacing: $sarabun-spacing;
+  padding: 10px 14px;
+  border-radius: 7px;
+  cursor: pointer;
+  text-align: left;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+
+  &:active {
+    background-color: rgba($primary, 0.12);
+    color: $primary;
+  }
+}
+
+.dotsDropdownItemDanger {
+  &:active {
+    background-color: rgba($error, 0.12);
+    color: $error;
+  }
+}

--- a/client/src/styles/Workouts.module.scss
+++ b/client/src/styles/Workouts.module.scss
@@ -302,3 +302,79 @@
   transform: rotate(0deg);
   transition: transform 0.2s ease;
 }
+
+// ── Three-dots section menu (#95) ────────────────────────────────────────────
+.dotsMenuWrapper {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.dotsBtn {
+  min-width: 40px;
+  min-height: 40px;
+  background: transparent;
+  border: none;
+  border-radius: 8px;
+  color: rgba($text, 0.4);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+
+  &:active {
+    background-color: rgba($primary, 0.1);
+    color: $primary;
+  }
+}
+
+.dotsIcon {
+  display: block; // iOS Safari SVG fix
+  width: 4px;
+  height: 16px;
+}
+
+.dotsDropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  background-color: $surface;
+  border: 1px solid $surface-border;
+  border-radius: 10px;
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 130px;
+  z-index: 200;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.45);
+}
+
+.dotsDropdownItem {
+  background: transparent;
+  border: none;
+  color: $text;
+  font-family: $sarabun;
+  font-size: 15px;
+  font-weight: 500;
+  letter-spacing: $sarabun-spacing;
+  padding: 10px 14px;
+  border-radius: 7px;
+  cursor: pointer;
+  text-align: left;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+
+  &:active {
+    background-color: rgba($primary, 0.12);
+    color: $primary;
+  }
+}
+
+.dotsDropdownItemDanger {
+  &:active {
+    background-color: rgba($error, 0.12);
+    color: $error;
+  }
+}


### PR DESCRIPTION
## Summary

- **Section level**: replaces the hover-only "Add Exercise" button and delete (✕) icon on each muscle-group header with a persistent ⋮ button that opens a dropdown with "Add exercise" and "Delete section" items. The existing `ConfirmModal` confirm flow for delete is preserved.
- **Exercise level**: replaces the hover-only "Add Variation" button and delete icon on each exercise row with a ⋮ button dropdown with "Add variation" and "Delete exercise". Same confirm flow preserved.
- Drops the `isMobile` / hover state branches entirely — controls are now always-visible and tappable on both mobile and desktop.
- Mirrors the `EntryMenu` pattern from #72 (NutritionTracker): outside-tap (`mousedown`/`touchstart`) + Escape key dismiss, `aria-haspopup`/`aria-expanded`, 44 px min-height tap targets, danger red on active for destructive items.
- iOS Safari SVG fix: `display: block` on the `dotsIcon` SVG element.

Closes #95

## Test plan

- [ ] Open Workouts tab on mobile (390 px viewport)
- [ ] Tap ⋮ on a section header → dropdown shows "Add exercise" and "Delete section"
- [ ] "Add exercise" adds a new exercise to that section
- [ ] "Delete section" shows the confirm modal then removes the section
- [ ] Tap ⋮ on an exercise row → dropdown shows "Add variation" and "Delete exercise"
- [ ] "Add variation" adds a new variation row
- [ ] "Delete exercise" shows the confirm modal then removes the exercise
- [ ] Tapping outside the open menu closes it
- [ ] Pressing Escape closes it
- [ ] Collapse button still works independently of the ⋮ menu
- [ ] `cd client && npx vite build` — clean (no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)