### PR TITLE
Workouts ⋮ menu fixes + section animation + nutrition stat row

### DIFF
--- a/client/src/components/Section.jsx
+++ b/client/src/components/Section.jsx
@@ -196,16 +196,18 @@ function Section({ setSections, section }) {
           </div>
         </div>
       </div>
-      <ul className={styles.movements} style={{ display: section.showItems ? 'block' : 'none' }}>
-        {movements.map((m) => (
-          <Movement
-            key={m.id ?? uuid()}
-            movement={m}
-            setMovements={setMovements}
-            sectionId={section.id}
-          />
-        ))}
-      </ul>
+      <div className={`${styles.movementsWrap} ${section.showItems ? styles.movementsWrapOpen : ''}`}>
+        <ul className={styles.movements}>
+          {movements.map((m) => (
+            <Movement
+              key={m.id ?? uuid()}
+              movement={m}
+              setMovements={setMovements}
+              sectionId={section.id}
+            />
+          ))}
+        </ul>
+      </div>
     </section>
   );
 }

--- a/client/src/features/nutrition/NutritionTracker.module.scss
+++ b/client/src/features/nutrition/NutritionTracker.module.scss
@@ -187,6 +187,44 @@
   letter-spacing: $sarabun-spacing;
 }
 
+// ---- Stat row: calories + macros on one row ----
+.statRow {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(72px, 1fr));
+  gap: 12px;
+  align-items: start;
+}
+
+.statCard {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  min-width: 0;
+}
+
+.statLabel {
+  font-family: $sarabun;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: $sarabun-spacing;
+  color: rgba($text, 0.6);
+  text-transform: uppercase;
+}
+
+.statValue {
+  font-family: $sarabun;
+  font-size: 20px;
+  font-weight: 700;
+  color: $text;
+  line-height: 1.1;
+}
+
+.statGoal {
+  font-size: 13px;
+  font-weight: 400;
+  color: rgba($text, 0.45);
+}
+
 // ---- Progress bar (shared) ----
 .progressTrack {
   width: 100%;

--- a/client/src/features/nutrition/NutritionTracker.tsx
+++ b/client/src/features/nutrition/NutritionTracker.tsx
@@ -309,63 +309,54 @@ export default function NutritionTracker() {
 
       {/* Totals card */}
       <div className={styles.totalsCard}>
-        <div className={styles.caloriesRow}>
-          <span className={styles.caloriesBig}>
-            {totals ? Math.round(totals.calories) : 0}
-          </span>
-          <span className={styles.caloriesUnit}>kcal</span>
-          {goals.calories != null && (
-            <span className={styles.caloriesGoal}>
-              / {goals.calories} goal
+        {/* Calories + macros on a single row (each a compact stat card) */}
+        <div className={styles.statRow}>
+          <div className={styles.statCard}>
+            <span className={styles.statLabel}>Calories</span>
+            <span className={styles.statValue}>
+              {totals ? Math.round(totals.calories) : 0}
+              {goals.calories != null && (
+                <span className={styles.statGoal}> / {goals.calories}</span>
+              )}
             </span>
-          )}
-        </div>
-
-        {/* Calorie progress bar — only if calorie goal set */}
-        {goals.calories != null && totals && (
-          <ProgressBar value={totals.calories} goal={goals.calories} />
-        )}
-
-        {/* Macro bars — only for macros that have a goal */}
-        {totals && (
-          <div className={styles.macrosRow}>
-            {goals.protein_g != null && (
-              <div className={styles.macroItem}>
-                <div className={styles.macroHeader}>
-                  <span className={styles.macroName}>Protein</span>
-                  <span className={styles.macroValue}>
-                    {Math.round(totals.protein_g)}g / {goals.protein_g}g
-                  </span>
-                </div>
-                <ProgressBar value={totals.protein_g} goal={goals.protein_g} />
-              </div>
-            )}
-
-            {goals.carbs_g != null && (
-              <div className={styles.macroItem}>
-                <div className={styles.macroHeader}>
-                  <span className={styles.macroName}>Carbs</span>
-                  <span className={styles.macroValue}>
-                    {Math.round(totals.carbs_g)}g / {goals.carbs_g}g
-                  </span>
-                </div>
-                <ProgressBar value={totals.carbs_g} goal={goals.carbs_g} />
-              </div>
-            )}
-
-            {goals.fat_g != null && (
-              <div className={styles.macroItem}>
-                <div className={styles.macroHeader}>
-                  <span className={styles.macroName}>Fat</span>
-                  <span className={styles.macroValue}>
-                    {Math.round(totals.fat_g)}g / {goals.fat_g}g
-                  </span>
-                </div>
-                <ProgressBar value={totals.fat_g} goal={goals.fat_g} />
-              </div>
+            {goals.calories != null && totals && (
+              <ProgressBar value={totals.calories} goal={goals.calories} />
             )}
           </div>
-        )}
+
+          {totals && goals.protein_g != null && (
+            <div className={styles.statCard}>
+              <span className={styles.statLabel}>Protein</span>
+              <span className={styles.statValue}>
+                {Math.round(totals.protein_g)}g
+                <span className={styles.statGoal}> / {goals.protein_g}g</span>
+              </span>
+              <ProgressBar value={totals.protein_g} goal={goals.protein_g} />
+            </div>
+          )}
+
+          {totals && goals.carbs_g != null && (
+            <div className={styles.statCard}>
+              <span className={styles.statLabel}>Carbs</span>
+              <span className={styles.statValue}>
+                {Math.round(totals.carbs_g)}g
+                <span className={styles.statGoal}> / {goals.carbs_g}g</span>
+              </span>
+              <ProgressBar value={totals.carbs_g} goal={goals.carbs_g} />
+            </div>
+          )}
+
+          {totals && goals.fat_g != null && (
+            <div className={styles.statCard}>
+              <span className={styles.statLabel}>Fat</span>
+              <span className={styles.statValue}>
+                {Math.round(totals.fat_g)}g
+                <span className={styles.statGoal}> / {goals.fat_g}g</span>
+              </span>
+              <ProgressBar value={totals.fat_g} goal={goals.fat_g} />
+            </div>
+          )}
+        </div>
       </div>
 
       {/* Loading / error */}

--- a/client/src/styles/Movement.module.scss
+++ b/client/src/styles/Movement.module.scss
@@ -2,7 +2,6 @@
 
 .section {
   display: flex;
-  overflow: hidden;
   flex-direction: column;
 
   background-color: $surface;
@@ -145,7 +144,8 @@
   background: transparent;
   border: none;
   border-radius: 8px;
-  color: rgba($text, 0.4);
+  // Match the brightness of other workout icons
+  color: $text;
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -192,6 +192,7 @@
   border-radius: 7px;
   cursor: pointer;
   text-align: left;
+  white-space: nowrap;
   min-height: 44px;
   display: flex;
   align-items: center;

--- a/client/src/styles/Workouts.module.scss
+++ b/client/src/styles/Workouts.module.scss
@@ -152,7 +152,6 @@
 .section {
   display: flex;
   flex-direction: column;
-  overflow: hidden;
   justify-content: space-between;
 
   background-color: $surface;
@@ -178,7 +177,7 @@
 
 .sectionHeader {
   display: flex;
-  margin: 9px 32px 0px;
+  margin: 9px 32px 9px;
   @media (min-width: $mobile-width) {
     min-height: 47px;
   }
@@ -280,7 +279,22 @@
   align-items: center;
 }
 
+// Animated expand/collapse wrapper for a section's movements.
+// grid-template-rows 0fr → 1fr animates auto height smoothly.
+.movementsWrap {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.28s ease;
+}
+
+.movementsWrapOpen {
+  grid-template-rows: 1fr;
+}
+
 .movements {
+  // min-height:0 + overflow:hidden let the grid row collapse to 0 when closed
+  min-height: 0;
+  overflow: hidden;
   padding-bottom: 5px;
   margin: 0;
 
@@ -315,7 +329,8 @@
   background: transparent;
   border: none;
   border-radius: 8px;
-  color: rgba($text, 0.4);
+  // Match the brightness of the adjacent collapse chevron / other workout icons
+  color: $text;
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -362,6 +377,7 @@
   border-radius: 7px;
   cursor: pointer;
   text-align: left;
+  white-space: nowrap;
   min-height: 44px;
   display: flex;
   align-items: center;


### PR DESCRIPTION
Polish reported while testing on iPhone (follow-up to #98 + a nutrition layout tweak).

**Workouts ⋮ menus**
- **Tapping the section ⋮ did nothing** — root cause: `.section { overflow: hidden }` clipped the absolutely-positioned dropdown (the card is only header-height), so the menu opened invisibly. Removed the clip on both Section and Movement `.section`.
- **Color** — dots now use full `$text` to match the adjacent collapse chevron / other workout icons (were `rgba($text,0.4)`, looked washed out).
- **Dropdown text wrapped** — added `white-space: nowrap`.
- **Section bottom padding regression** — `#98` removed the old `.mobileAdd` row that gave the card its bottom spacing; restored via `.sectionHeader` `margin-bottom: 9px`.

**Section expand animation** — replaced the instant `display:none` toggle with an animated `grid-template-rows` 0fr↔1fr wrapper (smooth height transition).

**Nutrition totals** — calories now sits on the **same row** as the macro cards (Calories / Protein / Carbs / Fat as one responsive stat row) instead of a big number on its own row above.

Verified locally with Playwright: section menu opens unclipped (no ancestor `overflow:hidden`), items don't wrap, dots match icon color (`rgb(235,237,233)`), expand animates (`grid-template-rows 0.28s`), stat row keeps all cards on one row at 390px with no overflow. Client build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)