### PR TITLE
Auto-open section on add exercise + right-align entry macros (#100 #101)

### DIFF
--- a/client/src/components/Section.jsx
+++ b/client/src/components/Section.jsx
@@ -117,7 +117,7 @@ function Section({ setSections, section }) {
   }
 
   async function handleMovementSubmit() {
-    const isFirst = movements.length === 0;
+    const wasClosed = !section.showItems;
     const res = await withAuth(() => (
       clientApi.post(`/movements/${section.id}`, { label: "Exercise" })
     ));
@@ -125,7 +125,7 @@ function Section({ setSections, section }) {
     setMovements(prevMovements => (
       [...prevMovements, { id: key, label: 'Exercise' }]
     ))
-    if (isFirst) {
+    if (wasClosed) {
       setSections(prevSections => (
         prevSections.map(s => s.id === section.id ? { ...s, showItems: true } : s)
       ));

--- a/client/src/features/nutrition/NutritionTracker.module.scss
+++ b/client/src/features/nutrition/NutritionTracker.module.scss
@@ -387,11 +387,20 @@
   flex-shrink: 0;
 }
 
+// #101: kcal on left, P/C/F chips pushed right
 .macroChips {
   display: flex;
-  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 5px;
+}
+
+// Sub-container for the three macro chips so they stay grouped on the right
+.macroChipsGroup {
+  display: flex;
   align-items: center;
   gap: 5px;
+  flex-shrink: 0;
 }
 
 .chip {

--- a/client/src/features/nutrition/NutritionTracker.tsx
+++ b/client/src/features/nutrition/NutritionTracker.tsx
@@ -352,12 +352,14 @@ export default function NutritionTracker() {
                 />
               </div>
 
-              {/* kcal + macros on one row */}
+              {/* kcal left, macro chips right (#101) */}
               <div className={styles.macroChips}>
                 <span className={styles.entryCalories}>{Math.round(entry.calories)} kcal</span>
-                <span className={styles.chip}>{Math.round(entry.protein_g)}g P</span>
-                <span className={styles.chip}>{Math.round(entry.carbs_g)}g C</span>
-                <span className={styles.chip}>{Math.round(entry.fat_g)}g F</span>
+                <div className={styles.macroChipsGroup}>
+                  <span className={styles.chip}>{Math.round(entry.protein_g)}g P</span>
+                  <span className={styles.chip}>{Math.round(entry.carbs_g)}g C</span>
+                  <span className={styles.chip}>{Math.round(entry.fat_g)}g F</span>
+                </div>
               </div>
             </div>
           ))}


### PR DESCRIPTION
## Summary

- **#100** `Section.jsx` — `handleMovementSubmit` now opens the section whenever it is closed (`wasClosed = !section.showItems`), not only on the first exercise. Uses the same optimistic `setSections` + `PATCH /sections/:id` pattern as before.
- **#101** `NutritionTracker.tsx` / `.module.scss` — kcal stays on the left; the three macro chips (P/C/F) are wrapped in a `.macroChipsGroup` sub-container and pushed to the right via `justify-content: space-between` on `.macroChips`. One row at all mobile widths (375 px+).

Closes #100
Closes #101

## Test plan

- [ ] Workouts: collapse a section that already has exercises, then tap "Add exercise" → section expands automatically
- [ ] Workouts: add first exercise to an empty section → section still expands (was always `wasClosed = true`)
- [ ] Nutrition: log a food entry → kcal label is left-aligned, P/C/F chips are right-aligned on the same row
- [ ] Nutrition: verify single-row layout holds on 375 px viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)