### PR TITLE
Chat: hide calc card, mobile no-send-on-Enter, photo library, error surfacing (#104 #105 #106 #107)

### DIFF
--- a/client/src/features/nutrition/NutritionChat.module.scss
+++ b/client/src/features/nutrition/NutritionChat.module.scss
@@ -795,6 +795,76 @@
   height: 16px;
 }
 
+// ---- #107: Error bubble ----
+.errorBubble {
+  max-width: min(80%, 500px);
+  min-width: 0;
+  box-sizing: border-box;
+  border-radius: 10px;
+  background-color: rgba($error, 0.06);
+  border: 1px solid rgba($error, 0.25);
+  overflow: hidden;
+}
+
+.errorBubbleToggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 8px 12px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  min-height: 36px;
+  box-sizing: border-box;
+}
+
+.errorBubbleIcon {
+  display: block; // iOS Safari SVG fix
+  flex-shrink: 0;
+  color: rgba($error, 0.8);
+  width: 16px;
+  height: 16px;
+}
+
+.errorBubbleLabel {
+  flex: 1;
+  font-family: $sarabun;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: $sarabun-spacing;
+  color: rgba($error, 0.85);
+}
+
+.errorBubbleChevron {
+  display: block; // iOS Safari SVG fix
+  flex-shrink: 0;
+  color: rgba($error, 0.5);
+  width: 16px;
+  height: 16px;
+  transition: transform 0.2s ease;
+}
+
+.errorBubbleChevronOpen {
+  transform: rotate(90deg);
+}
+
+.errorBubbleDetail {
+  margin: 0;
+  padding: 6px 12px 10px;
+  border-top: 1px solid rgba($error, 0.15);
+  font-family: "SFMono-Regular", "Consolas", "Liberation Mono", monospace;
+  font-size: 11px;
+  line-height: 1.5;
+  color: rgba($error, 0.7);
+  white-space: pre-wrap;
+  word-break: break-all;
+  overflow-x: auto;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
 // ---- Animations ----
 @keyframes fadeIn {
   from { opacity: 0; }

--- a/client/src/features/nutrition/NutritionChat.tsx
+++ b/client/src/features/nutrition/NutritionChat.tsx
@@ -44,7 +44,8 @@ import ToolCallCard from './ToolCallCard';
 import ConfirmModal from '../../components/ConfirmModal';
 import type { EntryInput, EntryEditorMode, ProposeEntryArgs } from './types';
 import styles from './NutritionChat.module.scss';
-import { ChevronDown, Trash2, Camera, ScanBarcode, Square, Send } from 'lucide-react';
+import { ChevronDown, Trash2, Camera, ScanBarcode, Square, Send, Images, AlertCircle, ChevronRight } from 'lucide-react';
+import useIsMobile from '../../hooks/useIsMobile';
 
 // ---------------------------------------------------------------------------
 // Auth helper — mirrors clientApi.js interceptor logic
@@ -243,6 +244,49 @@ function ReasoningBubble({ text, streaming }: ReasoningBubbleProps) {
 }
 
 // ---------------------------------------------------------------------------
+// #107: Error bubble — shown in the chat thread when useChat surfaces an error
+// ---------------------------------------------------------------------------
+interface ErrorBubbleProps {
+  error: Error;
+}
+
+function ErrorBubble({ error }: ErrorBubbleProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const detail = (() => {
+    try {
+      // Try to parse as JSON for richer display
+      const parsed = JSON.parse(error.message);
+      return JSON.stringify(parsed, null, 2);
+    } catch {
+      return error.message || String(error);
+    }
+  })();
+
+  return (
+    <div className={styles.errorBubble}>
+      <button
+        type="button"
+        className={styles.errorBubbleToggle}
+        onClick={() => setExpanded(p => !p)}
+        aria-expanded={expanded}
+      >
+        <AlertCircle className={styles.errorBubbleIcon} size={16} aria-hidden="true" />
+        <span className={styles.errorBubbleLabel}>Something went wrong</span>
+        <ChevronRight
+          className={`${styles.errorBubbleChevron} ${expanded ? styles.errorBubbleChevronOpen : ''}`}
+          size={16}
+          aria-hidden="true"
+        />
+      </button>
+      {expanded && (
+        <pre className={styles.errorBubbleDetail}>{detail}</pre>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // #76: Merge adjacent reasoning parts in a message into a single combined block
 // ---------------------------------------------------------------------------
 type MergedPart =
@@ -421,6 +465,9 @@ function ChatMessage({
             );
           }
 
+          // #104: hide the calculator tool card — it's an implementation detail
+          if (toolName === 'calculator') return null;
+
           return <ToolCallCard key={idx} part={part as ToolUIPart | DynamicToolUIPart} />;
         }
 
@@ -459,7 +506,7 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
   const loadedDateRef = useRef(selectedDate);
 
   // ---- useChat setup ----
-  const { messages, setMessages, sendMessage, status, stop } = useChat({
+  const { messages, setMessages, sendMessage, status, stop, error: chatError } = useChat({
     transport: new DefaultChatTransport({
       api: `${VITE_API_URL}/nutrition/chat`,
       credentials: 'include',
@@ -525,6 +572,9 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
     };
   }, [selectedDate, fetchAndApplyTranscript]);
 
+  // #105: detect mobile to suppress Enter-to-send
+  const { isMobile } = useIsMobile();
+
   // ---- Sheet expand/collapse state ----
   const [expanded, setExpanded] = useState(false);
 
@@ -569,6 +619,8 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
 
   // ---- Refs ----
   const fileInputRef = useRef<HTMLInputElement>(null);
+  // #106: separate hidden input for photo library (no capture attribute)
+  const libraryInputRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
@@ -641,6 +693,14 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
     if (fileInputRef.current) fileInputRef.current.value = '';
   }, [handlePhotoFiles]);
 
+  // #106: handler for the photo library input
+  const handleLibraryInputChange = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files.length > 0) {
+      await handlePhotoFiles(e.target.files);
+    }
+    if (libraryInputRef.current) libraryInputRef.current.value = '';
+  }, [handlePhotoFiles]);
+
   const removePhoto = useCallback((previewUrl: string) => {
     setPendingPhotos(prev => {
       const photo = prev.find(p => p.previewUrl === previewUrl);
@@ -690,13 +750,14 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
     stop();
   }, [stop]);
 
-  // Enter to send, Shift+Enter for newline
+  // #105: Enter to send on desktop only; on mobile Enter inserts newline.
+  // Shift+Enter always inserts a newline regardless of platform.
   const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (e.key === 'Enter' && !e.shiftKey && !isMobile) {
       e.preventDefault();
       handleSend();
     }
-  }, [handleSend]);
+  }, [handleSend, isMobile]);
 
   // ---- Proposal handlers ----
   const handleProposalDeny = useCallback((partKey: string) => {
@@ -922,6 +983,13 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
             />
           ))}
 
+          {/* #107: Error bubble — shown when the chat stream/API call fails */}
+          {chatError && (
+            <div className={styles.messageGroup}>
+              <ErrorBubble error={chatError} />
+            </div>
+          )}
+
           {/* #12: Scroll anchor — scrollIntoView targets this */}
           <div ref={messagesEndRef} />
         </div>
@@ -977,8 +1045,20 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
             >
               <ScanBarcode className={styles.composerCircleBtnIcon} size={16} aria-hidden="true" />
             </button>
+
+            {/* #106: Photo library button — opens file picker without capture */}
+            <button
+              type="button"
+              className={styles.composerCircleBtn}
+              onClick={() => libraryInputRef.current?.click()}
+              aria-label="Attach from photo library"
+              title="Attach from photo library"
+            >
+              <Images className={styles.composerCircleBtnIcon} size={16} aria-hidden="true" />
+            </button>
           </div>
 
+          {/* Camera capture input — opens direct camera on iOS */}
           <input
             ref={fileInputRef}
             type="file"
@@ -987,6 +1067,18 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
             multiple
             className={styles.hiddenFileInput}
             onChange={handleFileInputChange}
+            aria-hidden="true"
+            tabIndex={-1}
+          />
+
+          {/* #106: Photo library input — no capture attribute so iOS shows the file picker */}
+          <input
+            ref={libraryInputRef}
+            type="file"
+            accept="image/*"
+            multiple
+            className={styles.hiddenFileInput}
+            onChange={handleLibraryInputChange}
             aria-hidden="true"
             tabIndex={-1}
           />

--- a/routes/nutrition.ts
+++ b/routes/nutrition.ts
@@ -320,6 +320,10 @@ router.post('/chat', async (req, res): Promise<any> => {
     });
   } catch (error) {
     // Only reached if streamText itself throws before streaming begins
+    // #107: log detailed error info so it shows up in Heroku logs
+    const err = error as Error;
+    console.error('[nutrition/chat] Stream error:', err?.message ?? String(error));
+    if (err?.stack) console.error('[nutrition/chat] Stack:', err.stack);
     return handleSqlError(error, res);
   }
 });


### PR DESCRIPTION
## Summary

- **#104** Hide `calculator` tool-call card from the chat thread — detect tool name via `getToolName` and return `null` before rendering `ToolCallCard`.
- **#105** On mobile, `Enter` no longer sends a message (inserts a newline instead); send is via the button only. Uses the existing `useIsMobile` hook. Desktop keeps Enter-to-send.
- **#106** Added a third circular button (photo library / `Images` icon) next to the camera + barcode buttons. It opens a separate hidden `<input type="file" accept="image/*">` with **no** `capture` attribute so iOS presents the photo library / file picker. Reuses `handlePhotoFiles` pipeline.
- **#107** Wires `error` from `useChat` to a new `ErrorBubble` component rendered inside the message thread — shows "Something went wrong" with an expandable detail panel. Also adds `console.error` logging of error message and stack in `routes/nutrition.ts` chat endpoint.

Closes #105
Closes #106
Closes #107
Contributes to #104

## Test plan

- [ ] Send a message that triggers the `calculator` tool — verify no tool card appears in the thread
- [ ] On a mobile viewport: press Enter in the textarea — confirm it inserts a newline, not sends
- [ ] On desktop: press Enter — confirm it sends the message
- [ ] Tap the new `Images` button — iOS should present the photo library (not the camera). Pick a photo and confirm it appears as a pending thumbnail
- [ ] Force a network error (kill the backend) — confirm "Something went wrong" bubble appears in thread, expandable with detail
- [ ] Check Heroku logs after a backend error — confirm `[nutrition/chat] Stream error:` appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)