### PR TITLE
feat: sticky header, habits ignore-empty-days toggle

### DIFF
--- a/client/src/components/HabitTracker.jsx
+++ b/client/src/components/HabitTracker.jsx
@@ -292,7 +292,7 @@ function NewHabitInput({ onSave, onCancel }) {
 }
 
 // ─── Habit list item (inside dropdown) ─────────────────────────────────────────
-function HabitListItem({ habit, isActive, onSelect, onRename, onDelete }) {
+function HabitListItem({ habit, isActive, onSelect, onRename, onDelete, onToggleIgnoreEmpty }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [renaming, setRenaming] = useState(false);
   const menuRef = useRef(null);
@@ -321,6 +321,8 @@ function HabitListItem({ habit, isActive, onSelect, onRename, onDelete }) {
     );
   }
 
+  const ignoreEmptyDays = !!habit.ignore_empty_days;
+
   return (
     <div className={`${styles.habitItem} ${isActive ? styles.habitItemActive : ''}`}>
       <button
@@ -342,6 +344,21 @@ function HabitListItem({ habit, isActive, onSelect, onRename, onDelete }) {
         </button>
         {menuOpen && (
           <div className={styles.habitMenu} role="menu">
+            <label
+              className={`${styles.habitMenuItem} ${styles.habitMenuItemToggle}`}
+              role="menuitem"
+              onClick={e => e.stopPropagation()}
+            >
+              <input
+                type="checkbox"
+                className={styles.habitMenuToggleInput}
+                checked={ignoreEmptyDays}
+                onChange={e => {
+                  onToggleIgnoreEmpty(habit.id, e.target.checked);
+                }}
+              />
+              <span>Skip days with no tallys</span>
+            </label>
             <button
               className={styles.habitMenuItem}
               role="menuitem"
@@ -408,14 +425,14 @@ function HabitTracker() {
 
   const habits = habitsQuery.data ?? [];
 
-  // Auto-select the first habit when registry loads; keep active in sync on rename
+  // Auto-select the first habit when registry loads; keep active in sync on rename/setting changes
   useEffect(() => {
     if (activeHabit === null && habits.length > 0) {
       setActiveHabit(habits[0]);
     }
     if (activeHabit !== null) {
       const fresh = habits.find(h => h.id === activeHabit.id);
-      if (fresh && fresh.name !== activeHabit.name) {
+      if (fresh && (fresh.name !== activeHabit.name || fresh.ignore_empty_days !== activeHabit.ignore_empty_days)) {
         setActiveHabit(fresh);
       }
     }
@@ -466,6 +483,35 @@ function HabitTracker() {
         // Remove old tallies cache key; will refetch under new name
         queryClient.removeQueries({ queryKey: ['habits', activeHabit.name] });
         setActiveHabit(prev => ({ ...prev, name: updated.name }));
+      }
+    },
+  });
+
+  const patchHabitSettingsMutation = useMutation({
+    mutationFn: async ({ id, ignore_empty_days }) => {
+      await clientApi.patch(`/habits/${id}`, { ignore_empty_days });
+      return { id, ignore_empty_days };
+    },
+    onMutate: async ({ id, ignore_empty_days }) => {
+      // Optimistic update: update registry cache
+      const prevRegistry = queryClient.getQueryData(['habits-registry']);
+      queryClient.setQueryData(['habits-registry'], (prev) =>
+        (prev ?? []).map(h => h.id === id ? { ...h, ignore_empty_days } : h)
+      );
+      // Also update activeHabit local state optimistically
+      if (activeHabit?.id === id) {
+        setActiveHabit(prev => ({ ...prev, ignore_empty_days }));
+      }
+      return { prevRegistry };
+    },
+    onError: (_err, { id }, context) => {
+      // Roll back on error
+      if (context?.prevRegistry) {
+        queryClient.setQueryData(['habits-registry'], context.prevRegistry);
+      }
+      if (activeHabit?.id === id) {
+        const rolled = (context?.prevRegistry ?? []).find(h => h.id === id);
+        if (rolled) setActiveHabit(prev => ({ ...prev, ignore_empty_days: rolled.ignore_empty_days }));
       }
     },
   });
@@ -521,9 +567,39 @@ function HabitTracker() {
   // ── Ensure today row is always present ────────────────────────────────────
   const today = getTodayLocalDate();
   const todayExists = rows.some(r => r.date === today);
-  const displayRows = todayExists
+  const rowsWithToday = todayExists
     ? rows
     : [{ date: today, count: 0, range_start: null, range_end: null }, ...rows];
+
+  // ── Fill zeros when ignore_empty_days is false ─────────────────────────────
+  // When showing all days: iterate every calendar day from the earliest tally
+  // date to today, inserting count=0 rows for missing days.
+  const ignoreEmptyDays = activeHabit ? !!activeHabit.ignore_empty_days : true;
+  let displayRows;
+  if (ignoreEmptyDays || rowsWithToday.length === 0) {
+    displayRows = rowsWithToday;
+  } else {
+    // Find the oldest date in the data
+    const dates = rowsWithToday.map(r => r.date).sort();
+    const minDate = dates[0];
+    const dateMap = {};
+    for (const r of rowsWithToday) dateMap[r.date] = r;
+
+    const filled = [];
+    // Walk from today back to minDate
+    const [minY, minM, minD] = minDate.split('-').map(Number);
+    const cursor = new Date(new Date(today + 'T00:00:00').getTime());
+    const stopDate = new Date(minY, minM - 1, minD);
+    while (cursor >= stopDate) {
+      const cy = cursor.getFullYear();
+      const cm = String(cursor.getMonth() + 1).padStart(2, '0');
+      const cd = String(cursor.getDate()).padStart(2, '0');
+      const key = `${cy}-${cm}-${cd}`;
+      filled.push(dateMap[key] ?? { date: key, count: 0, range_start: null, range_end: null });
+      cursor.setDate(cursor.getDate() - 1);
+    }
+    displayRows = filled;
+  }
 
   // ── Handlers ───────────────────────────────────────────────────────────────
   async function handleAddTally() {
@@ -626,6 +702,7 @@ function HabitTracker() {
                 onSelect={(h) => { setActiveHabit(h); setHabitsOpen(false); }}
                 onRename={(id, newName) => renameHabitMutation.mutate({ id, name: newName })}
                 onDelete={(h) => setHabitToDelete(h)}
+                onToggleIgnoreEmpty={(id, value) => patchHabitSettingsMutation.mutate({ id, ignore_empty_days: value })}
               />
             ))}
             {showNewHabit ? (

--- a/client/src/styles/HabitTracker.module.scss
+++ b/client/src/styles/HabitTracker.module.scss
@@ -420,6 +420,24 @@
   color: $error;
 }
 
+.habitMenuItemToggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.habitMenuToggleInput {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  accent-color: $primary;
+  cursor: pointer;
+  // Ensure 44px tap target is met via the parent label
+  margin: 0;
+}
+
 // ── Rename input ───────────────────────────────────────────────────────────────
 .renameRow {
   flex: 1;

--- a/client/src/styles/Header.module.scss
+++ b/client/src/styles/Header.module.scss
@@ -9,6 +9,9 @@
   height: 8vh;
   padding: 2rem 2.5rem;
   border-bottom: 5px solid $primary-border;
+  position: sticky;
+  top: 0;
+  z-index: 50;
 
   > a {
     text-decoration: none;

--- a/migrations/012_habits_ignore_empty_days.sql
+++ b/migrations/012_habits_ignore_empty_days.sql
@@ -1,0 +1,2 @@
+ALTER TABLE habits
+ADD COLUMN ignore_empty_days TINYINT(1) NOT NULL DEFAULT 1;

--- a/routes/habits.ts
+++ b/routes/habits.ts
@@ -17,7 +17,7 @@ router.get('/', async (req, res): Promise<any> => {
     let data: RowDataPacket[];
     try {
         [data] = await pool.query<RowDataPacket[]>(`
-            SELECT id, name, ordering, created_at
+            SELECT id, name, ordering, ignore_empty_days, created_at
             FROM habits
             WHERE user_uuid = UUID_TO_BIN(?)
             ORDER BY ordering ASC, created_at ASC
@@ -71,13 +71,37 @@ router.post('/', async (req, res): Promise<any> => {
     });
 });
 
-// PATCH /habits/:id — rename a habit (also renames its tallies)
+// PATCH /habits/:id — update a habit (rename or toggle ignore_empty_days)
 router.patch('/:id', async (req, res): Promise<any> => {
     const { uuid }: User = res.locals.user;
     const id = parseInt(req.params.id, 10);
     if (isNaN(id)) return res.status(400).json({ message: 'Invalid habit id' });
 
-    const { name } = req.body as { name?: string };
+    const { name, ignore_empty_days } = req.body as { name?: string; ignore_empty_days?: boolean };
+
+    // ── Branch: update ignore_empty_days ──────────────────────────────────────
+    if (ignore_empty_days !== undefined) {
+        if (typeof ignore_empty_days !== 'boolean') {
+            return res.status(400).json({ message: 'ignore_empty_days must be a boolean' });
+        }
+
+        let result: ResultSetHeader;
+        try {
+            [result] = await pool.query<ResultSetHeader>(`
+                UPDATE habits SET ignore_empty_days = ?
+                WHERE id = ? AND user_uuid = UUID_TO_BIN(?)
+            `, [ignore_empty_days ? 1 : 0, id, uuid]);
+        } catch (error) {
+            return handleSqlError(error, res);
+        }
+
+        if (result.affectedRows === 0) {
+            return res.status(404).json({ message: `Habit ${id} not found` });
+        }
+        return res.status(200).json({ message: 'Updated' });
+    }
+
+    // ── Branch: rename ─────────────────────────────────────────────────────────
     if (!name || typeof name !== 'string' || !name.trim()) {
         return res.status(400).json({ message: 'name is required' });
     }


### PR DESCRIPTION
## Summary
- Sticky header on scroll: adds `position: sticky; top: 0; z-index: 50` to `.header` in `Header.module.scss`
- Migration `012_habits_ignore_empty_days.sql`: adds `ignore_empty_days TINYINT(1) NOT NULL DEFAULT 1` column to `habits` table
- Backend (`routes/habits.ts`): GET /habits now returns `ignore_empty_days`; PATCH /habits/:id handles `ignore_empty_days` boolean update alongside the existing rename logic
- Frontend (`HabitTracker.jsx`): per-habit "Skip days with no tallys" toggle in the three-dot menu, with optimistic update/rollback; when off, fills in zero-count rows for every calendar day from first tally to today

Closes #117
Closes #119