### PR TITLE
fix: weight/reps icons match number height

### DIFF
--- a/client/src/styles/Variation.module.scss
+++ b/client/src/styles/Variation.module.scss
@@ -87,6 +87,15 @@
   flex-shrink: 0;
 }
 
+// #124: the weight/reps icons sit inline next to the numbers (22px) but render
+// at the standard 16px, looking tiny. Scale just those (direct children of
+// .part) to match the adjacent number height. Graph/delete icons live inside
+// buttons, so they're unaffected.
+.part > .icon {
+  width: 1em;
+  height: 1em;
+}
+
 .graphBtn {
   display: flex;
   width: 40px;


### PR DESCRIPTION
Closes #124

The inline weight/reps icons rendered at 16px next to 22px numbers, looking tiny. Scopes `width/height: 1em` to `.part > .icon` so only those two inline icons scale to the number height; graph/delete icons (inside buttons) are unaffected.

Build verified (`vite build` clean). Scoped CSS; not runtime-validated locally (login friction on the dev box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)