### PR TITLE
Custom Foods & Meals — Phase A (backend)

### DIFF
--- a/migrations/013_custom_foods.sql
+++ b/migrations/013_custom_foods.sql
@@ -1,0 +1,58 @@
+-- Custom Foods & Meals (issue #109). Follows conventions from 007_nutrition.sql:
+-- INT AUTO_INCREMENT PK, BINARY(16) user_uuid, no FK, FULLTEXT on name.
+-- migrate.js tolerates errno 1050 (table exists) and 1060 (column exists),
+-- so CREATE TABLE IF NOT EXISTS and ADD COLUMN re-runs are safe.
+-- ALTER ... MODIFY is naturally idempotent (widening an ENUM is accepted on
+-- repeated runs without error).
+
+CREATE TABLE IF NOT EXISTS custom_foods (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_uuid BINARY(16) NOT NULL,
+  kind ENUM('food','meal') NOT NULL,
+  status ENUM('draft','saved') NOT NULL DEFAULT 'saved',
+  name VARCHAR(255) NOT NULL,
+  notes VARCHAR(1000) NULL,
+  total_grams FLOAT NOT NULL DEFAULT 0,
+  calories FLOAT NOT NULL DEFAULT 0,
+  protein_g FLOAT NOT NULL DEFAULT 0,
+  carbs_g FLOAT NOT NULL DEFAULT 0,
+  fat_g FLOAT NOT NULL DEFAULT 0,
+  fiber_g FLOAT NULL, sugar_g FLOAT NULL, sodium_mg FLOAT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  KEY idx_user_status (user_uuid, status),
+  FULLTEXT KEY ft_name (name)
+);
+
+CREATE TABLE IF NOT EXISTS custom_food_ingredients (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  custom_food_id INT NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  grams FLOAT NOT NULL,
+  source ENUM('usda','off','manual','custom') NOT NULL,
+  source_ref VARCHAR(64) NULL,
+  calories FLOAT NOT NULL DEFAULT 0,
+  protein_g FLOAT NOT NULL DEFAULT 0,
+  carbs_g FLOAT NOT NULL DEFAULT 0,
+  fat_g FLOAT NOT NULL DEFAULT 0,
+  fiber_g FLOAT NULL, sugar_g FLOAT NULL, sodium_mg FLOAT NULL,
+  KEY idx_parent (custom_food_id)
+);
+
+CREATE TABLE IF NOT EXISTS custom_food_servings (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  custom_food_id INT NOT NULL,
+  label VARCHAR(64) NOT NULL,
+  def_type ENUM('grams','fraction') NOT NULL,
+  def_value FLOAT NOT NULL,
+  grams FLOAT NOT NULL,
+  sort_order INT NOT NULL DEFAULT 0,
+  KEY idx_parent (custom_food_id)
+);
+
+ALTER TABLE food_entry_ingredients MODIFY source ENUM('usda','off','manual','custom') NOT NULL;
+ALTER TABLE food_entry_ingredients ADD COLUMN fiber_g FLOAT NULL;
+ALTER TABLE food_entry_ingredients ADD COLUMN sugar_g FLOAT NULL;
+ALTER TABLE food_entry_ingredients ADD COLUMN sodium_mg FLOAT NULL;
+ALTER TABLE food_entries MODIFY source ENUM('manual','text','photo','barcode','mixed','custom') NOT NULL;
+ALTER TABLE food_entries ADD COLUMN from_custom_food_id INT NULL;

--- a/routes/nutrition.ts
+++ b/routes/nutrition.ts
@@ -4,9 +4,9 @@ import { authenticateToken } from './auth';
 import { validateId } from '../utils/validation';
 import handleSqlError from '../utils/handleSqlError';
 import { User } from '../types';
-import { entryInputSchema, goalsSchema } from '../schemas/nutrition';
+import { entryInputSchema, goalsSchema, customFoodInputSchema } from '../schemas/nutrition';
 import * as store from '../services/nutrition/store';
-import { searchFoods, lookupBarcode, getPortions } from '../services/nutrition/providers';
+import { searchAllFoodsWithPortions, lookupBarcode, getPortions } from '../services/nutrition/providers';
 import { streamNutritionChat } from '../services/nutrition/agent';
 import { getUserUsageTotals, getAllUsersUsage, getUserEmail } from '../services/nutrition/usage';
 import {
@@ -102,15 +102,127 @@ router.delete('/entries/:id', async (req, res): Promise<any> => {
   }
 });
 
+// GET /custom-foods/recent — most-recently-logged custom items (must be BEFORE /:id)
+router.get('/custom-foods/recent', async (req, res): Promise<any> => {
+  const { uuid }: User = res.locals.user;
+  const limit = Math.min(Number(req.query.limit ?? 5), 20);
+
+  try {
+    const data = await store.recentCustomFoods(uuid, limit);
+    return res.status(200).json({ data, message: `Found ${data.length} recent custom food(s)` });
+  } catch (error) {
+    return handleSqlError(error, res);
+  }
+});
+
+// GET /custom-foods — list custom foods/meals (optional ?status=draft|saved)
+router.get('/custom-foods', async (req, res): Promise<any> => {
+  const { uuid }: User = res.locals.user;
+  const statusParam = req.query.status as string | undefined;
+
+  if (statusParam && statusParam !== 'draft' && statusParam !== 'saved') {
+    return res.status(400).json({ message: 'status must be "draft" or "saved"' });
+  }
+
+  try {
+    const data = await store.listCustomFoods(uuid, statusParam as 'draft' | 'saved' | undefined);
+    return res.status(200).json({ data, message: `Found ${data.length} custom food(s)` });
+  } catch (error) {
+    return handleSqlError(error, res);
+  }
+});
+
+// POST /custom-foods — create a custom food/meal
+router.post('/custom-foods', async (req, res): Promise<any> => {
+  const { uuid }: User = res.locals.user;
+  const parsed = customFoodInputSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ message: parsed.error.issues[0]?.message ?? 'Invalid request body' });
+  }
+
+  try {
+    const data = await store.createCustomFood(uuid, parsed.data);
+    return res.status(201).json({ data, message: 'Custom food created' });
+  } catch (error) {
+    return handleSqlError(error, res);
+  }
+});
+
+// GET /custom-foods/:id — single custom food/meal
+router.get('/custom-foods/:id', async (req, res): Promise<any> => {
+  const { uuid }: User = res.locals.user;
+  if (!validateId(req.params.id, res)) return;
+  const id = Number(req.params.id);
+
+  try {
+    const data = await store.getCustomFood(uuid, id);
+    if (!data) return res.status(404).json({ message: `Custom food ${id} not found` });
+    return res.status(200).json({ data, message: `Successfully retrieved custom food ${id}` });
+  } catch (error) {
+    return handleSqlError(error, res);
+  }
+});
+
+// PATCH /custom-foods/:id — update / draft autosave
+router.patch('/custom-foods/:id', async (req, res): Promise<any> => {
+  const { uuid }: User = res.locals.user;
+  if (!validateId(req.params.id, res)) return;
+  const id = Number(req.params.id);
+
+  const parsed = customFoodInputSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ message: parsed.error.issues[0]?.message ?? 'Invalid request body' });
+  }
+
+  try {
+    const data = await store.updateCustomFood(uuid, id, parsed.data);
+    if (!data) return res.status(404).json({ message: `Custom food ${id} not found` });
+    return res.status(200).json({ data, message: `Custom food ${id} updated` });
+  } catch (error) {
+    return handleSqlError(error, res);
+  }
+});
+
+// DELETE /custom-foods/:id
+router.delete('/custom-foods/:id', async (req, res): Promise<any> => {
+  const { uuid }: User = res.locals.user;
+  if (!validateId(req.params.id, res)) return;
+  const id = Number(req.params.id);
+
+  try {
+    const deleted = await store.deleteCustomFood(uuid, id);
+    if (!deleted) return res.status(404).json({ message: `Custom food ${id} not found` });
+    return res.status(200).json({ message: `Custom food ${id} deleted` });
+  } catch (error) {
+    return handleSqlError(error, res);
+  }
+});
+
+// POST /custom-foods/:id/duplicate — clone a saved item into a new draft
+router.post('/custom-foods/:id/duplicate', async (req, res): Promise<any> => {
+  const { uuid }: User = res.locals.user;
+  if (!validateId(req.params.id, res)) return;
+  const id = Number(req.params.id);
+
+  try {
+    const data = await store.duplicateCustomFood(uuid, id);
+    if (!data) return res.status(404).json({ message: `Custom food ${id} not found` });
+    return res.status(201).json({ data, message: `Custom food ${id} duplicated` });
+  } catch (error) {
+    return handleSqlError(error, res);
+  }
+});
+
 // GET /foods/search?q=...
 router.get('/foods/search', async (req, res): Promise<any> => {
+  const { uuid }: User = res.locals.user;
   const q = (req.query.q ?? '') as string;
   if (!q.trim()) {
     return res.status(400).json({ message: 'Query parameter q is required' });
   }
 
   try {
-    const data = await searchFoods(q.trim());
+    const data = await searchAllFoodsWithPortions(uuid, q.trim());
     return res.status(200).json({ data, message: `Found ${data.length} result(s)` });
   } catch (error) {
     return handleSqlError(error, res);

--- a/schemas/nutrition.ts
+++ b/schemas/nutrition.ts
@@ -5,8 +5,8 @@
 import { z } from 'zod';
 
 export const MEALS = ['breakfast', 'lunch', 'dinner', 'snack'] as const;
-export const ENTRY_SOURCES = ['manual', 'text', 'photo', 'barcode', 'mixed'] as const;
-export const INGREDIENT_SOURCES = ['usda', 'off', 'manual'] as const;
+export const ENTRY_SOURCES = ['manual', 'text', 'photo', 'barcode', 'mixed', 'custom'] as const;
+export const INGREDIENT_SOURCES = ['usda', 'off', 'manual', 'custom'] as const;
 
 // Per-100g nutrient profile returned by food search / barcode lookup.
 export const per100gSchema = z.object({
@@ -30,6 +30,10 @@ export const ingredientInputSchema = z.object({
   protein_g: z.number().nonnegative(),
   carbs_g: z.number().nonnegative(),
   fat_g: z.number().nonnegative(),
+  // Optional micros — carried so meal snapshots and entry totals can sum them.
+  fiber_g: z.number().nonnegative().nullable().optional(),
+  sugar_g: z.number().nonnegative().nullable().optional(),
+  sodium_mg: z.number().nonnegative().nullable().optional(),
 });
 
 // Create/replace an entry (POST /entries, PATCH /entries/:id share this shape).
@@ -53,7 +57,7 @@ export const goalsSchema = z.object({
 
 export const foodSearchResultSchema = z.object({
   name: z.string(),
-  source: z.enum(['usda', 'off']),
+  source: z.enum(['usda', 'off', 'custom']),
   source_ref: z.string(),
   per100g: per100gSchema,
   serving_grams: z.number().positive().nullable().optional(),
@@ -114,6 +118,51 @@ export const proposeEntryArgsSchema = entryInputSchema
   });
 export type ProposeEntryArgs = z.infer<typeof proposeEntryArgsSchema>;
 export type FoodSearchResult = z.infer<typeof foodSearchResultSchema>;
+
+// ---- Custom Foods & Meals schemas ----
+
+/** One custom serving definition stored alongside a custom food/meal. */
+export const customServingSchema = z.object({
+  label: z.string().min(1).max(64),
+  def_type: z.enum(['grams', 'fraction']),
+  def_value: z.number().positive(),
+  grams: z.number().positive(),
+});
+export type CustomServing = z.infer<typeof customServingSchema>;
+
+/** Input payload for creating or updating a custom food/meal. */
+export const customFoodInputSchema = z.object({
+  kind: z.enum(['food', 'meal']),
+  name: z.string().min(1).max(255),
+  notes: z.string().max(1000).nullable().optional(),
+  status: z.enum(['draft', 'saved']),
+  ingredients: z.array(ingredientInputSchema),
+  servings: z.array(customServingSchema),
+});
+export type CustomFoodInput = z.infer<typeof customFoodInputSchema>;
+
+/** The persisted custom food/meal row returned to the client. */
+export const customFoodRowSchema = z.object({
+  id: z.number().int().positive(),
+  kind: z.enum(['food', 'meal']),
+  status: z.enum(['draft', 'saved']),
+  name: z.string(),
+  notes: z.string().nullable(),
+  total_grams: z.number().nonnegative(),
+  calories: z.number().nonnegative(),
+  protein_g: z.number().nonnegative(),
+  carbs_g: z.number().nonnegative(),
+  fat_g: z.number().nonnegative(),
+  fiber_g: z.number().nullable(),
+  sugar_g: z.number().nullable(),
+  sodium_mg: z.number().nullable(),
+  per100g: per100gSchema,
+  ingredients: z.array(ingredientInputSchema.extend({ id: z.number() })),
+  servings: z.array(customServingSchema.extend({ id: z.number(), sort_order: z.number() })),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+export type CustomFoodRow = z.infer<typeof customFoodRowSchema>;
 
 // ---- DB row / response shapes returned to the client ----
 export interface IngredientRow extends IngredientInput {

--- a/services/nutrition/providers.ts
+++ b/services/nutrition/providers.ts
@@ -12,6 +12,7 @@
 //   - lookupBarcode: GET https://world.openfoodfacts.org/api/v2/product/<code>.json
 //     (send a descriptive User-Agent). Return null when status:0 (not found).
 import { FoodSearchResult, FoodPortion } from '../../schemas/nutrition';
+import { searchCustomFoods } from './store';
 
 const USER_AGENT = 'WorkoutLogApp/1.0 (nutrition tracker; contact: admin@example.com)';
 
@@ -310,9 +311,12 @@ export async function searchFoodsWithPortions(query: string): Promise<FoodSearch
 
   // Fetch portions for the top result in parallel with nothing else to keep it simple
   const top = results[0];
-  const portions = await getPortions(top.source, top.source_ref);
-  // Mutate in-place so the result remains the same FoodSearchResult reference type.
-  (results[0] as FoodSearchResult).portions = portions;
+  // Only USDA/OFF results have external portions; custom items already carry their own.
+  if (top.source === 'usda' || top.source === 'off') {
+    const portions = await getPortions(top.source, top.source_ref);
+    // Mutate in-place so the result remains the same FoodSearchResult reference type.
+    (results[0] as FoodSearchResult).portions = portions;
+  }
 
   return results;
 }
@@ -331,6 +335,42 @@ export async function getPortionsBatch(
       portions: await getPortions(source, ref),
     })),
   );
+  return results;
+}
+
+/**
+ * Source-agnostic food search: custom items first, then USDA/OFF.
+ * Duplicate suppression: skip external results whose name exactly matches a custom
+ * result name (case-insensitive). Non-trivial fuzzy suppression is left for Phase B/C.
+ */
+export async function searchAllFoods(userUuid: string, query: string): Promise<FoodSearchResult[]> {
+  const [custom, external] = await Promise.all([
+    searchCustomFoods(userUuid, query),
+    searchFoods(query),
+  ]);
+
+  // Suppress external hits that exactly match a custom food name (case-insensitive).
+  const customNames = new Set(custom.map((c) => c.name.toLowerCase()));
+  const filtered = external.filter((e) => !customNames.has(e.name.toLowerCase()));
+
+  return [...custom, ...filtered];
+}
+
+/**
+ * Like searchAllFoods but also fetches portions for the top non-custom result (USDA only).
+ * Custom items already carry their portions; external top result still gets getPortions.
+ */
+export async function searchAllFoodsWithPortions(userUuid: string, query: string): Promise<FoodSearchResult[]> {
+  const results = await searchAllFoods(userUuid, query);
+  if (results.length === 0) return results;
+
+  // Find first non-custom result and fetch its portions
+  const firstExternal = results.find((r) => r.source === 'usda' || r.source === 'off');
+  if (firstExternal && (firstExternal.source === 'usda' || firstExternal.source === 'off')) {
+    const portions = await getPortions(firstExternal.source, firstExternal.source_ref);
+    firstExternal.portions = portions;
+  }
+
   return results;
 }
 

--- a/services/nutrition/store.ts
+++ b/services/nutrition/store.ts
@@ -9,9 +9,21 @@
 //     ingredient rows (do not trust a client-sent entry total).
 //   - Normalize DATE columns to 'YYYY-MM-DD' before returning.
 import { RowDataPacket, ResultSetHeader } from 'mysql2';
+import { PoolConnection } from 'mysql2/promise';
 import pool from '../../database';
 import withTransaction from '../../utils/withTransaction';
-import { EntryInput, EntryRow, DayResponse, Goals, IngredientRow } from '../../schemas/nutrition';
+import {
+  EntryInput,
+  EntryRow,
+  DayResponse,
+  Goals,
+  IngredientRow,
+  CustomFoodInput,
+  CustomFoodRow,
+  CustomServing,
+  IngredientInput as IngredientInputSchema,
+} from '../../schemas/nutrition';
+import { FoodSearchResult } from '../../schemas/nutrition';
 
 /** Sum ingredient macros to produce entry-level totals. */
 function sumIngredients(ingredients: IngredientInput[]): {
@@ -28,7 +40,41 @@ function sumIngredients(ingredients: IngredientInput[]): {
   );
 }
 
+/** Sum ingredient macros INCLUDING micros (for custom foods/meals). */
+function sumIngredientsFull(ingredients: IngredientInputFull[]): {
+  calories: number; protein_g: number; carbs_g: number; fat_g: number;
+  fiber_g: number | null; sugar_g: number | null; sodium_mg: number | null;
+  total_grams: number;
+} {
+  let calories = 0, protein_g = 0, carbs_g = 0, fat_g = 0;
+  let fiber_g = 0, sugar_g = 0, sodium_mg = 0;
+  let hasFiber = false, hasSugar = false, hasSodium = false;
+  let total_grams = 0;
+
+  for (const ing of ingredients) {
+    calories += ing.calories;
+    protein_g += ing.protein_g;
+    carbs_g += ing.carbs_g;
+    fat_g += ing.fat_g;
+    total_grams += ing.grams;
+    if (ing.fiber_g != null) { fiber_g += ing.fiber_g; hasFiber = true; }
+    if (ing.sugar_g != null) { sugar_g += ing.sugar_g; hasSugar = true; }
+    if (ing.sodium_mg != null) { sodium_mg += ing.sodium_mg; hasSodium = true; }
+  }
+
+  return {
+    calories, protein_g, carbs_g, fat_g, total_grams,
+    fiber_g: hasFiber ? fiber_g : null,
+    sugar_g: hasSugar ? sugar_g : null,
+    sodium_mg: hasSodium ? sodium_mg : null,
+  };
+}
+
 type IngredientInput = { calories: number; protein_g: number; carbs_g: number; fat_g: number };
+type IngredientInputFull = {
+  calories: number; protein_g: number; carbs_g: number; fat_g: number; grams: number;
+  fiber_g?: number | null; sugar_g?: number | null; sodium_mg?: number | null;
+};
 
 /** Fetch ingredients for a given entry id using the provided connection or pool. */
 async function fetchIngredients(entryId: number): Promise<IngredientRow[]> {
@@ -352,4 +398,484 @@ export async function searchFoodHistory(userUuid: string, query: string): Promis
     });
   }
   return entries;
+}
+
+// ---- Custom Foods & Meals ----
+
+/** Derive per100g from total batch macros + total_grams. Guards against zero total_grams. */
+function derivePer100g(
+  calories: number, protein_g: number, carbs_g: number, fat_g: number,
+  fiber_g: number | null, sugar_g: number | null, sodium_mg: number | null,
+  total_grams: number,
+) {
+  const scale = total_grams > 0 ? 100 / total_grams : 0;
+  return {
+    calories: calories * scale,
+    protein_g: protein_g * scale,
+    carbs_g: carbs_g * scale,
+    fat_g: fat_g * scale,
+    fiber_g: fiber_g != null ? fiber_g * scale : null,
+    sugar_g: sugar_g != null ? sugar_g * scale : null,
+    sodium_mg: sodium_mg != null ? sodium_mg * scale : null,
+  };
+}
+
+/** Re-resolve fractional servings' grams from the updated total_grams. */
+function resolveServingGrams(
+  servings: CustomFoodInput['servings'],
+  total_grams: number,
+): CustomFoodInput['servings'] {
+  return servings.map((s) => ({
+    ...s,
+    grams: s.def_type === 'fraction' ? s.def_value * total_grams : s.def_value,
+  }));
+}
+
+/** Fetch custom_food_ingredients for a given custom_food_id. */
+async function fetchCustomIngredients(customFoodId: number): Promise<Array<IngredientInputSchema & { id: number }>> {
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `SELECT id, name, grams, source, source_ref, calories, protein_g, carbs_g, fat_g,
+            fiber_g, sugar_g, sodium_mg
+     FROM custom_food_ingredients
+     WHERE custom_food_id = ?
+     ORDER BY id ASC`,
+    [customFoodId],
+  );
+  return rows as Array<IngredientInputSchema & { id: number }>;
+}
+
+/** Fetch custom_food_servings for a given custom_food_id. */
+async function fetchCustomServings(customFoodId: number): Promise<Array<CustomServing & { id: number; sort_order: number }>> {
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `SELECT id, label, def_type, def_value, grams, sort_order
+     FROM custom_food_servings
+     WHERE custom_food_id = ?
+     ORDER BY sort_order ASC, id ASC`,
+    [customFoodId],
+  );
+  return rows as Array<CustomServing & { id: number; sort_order: number }>;
+}
+
+/** Assemble a full CustomFoodRow from a raw DB row + its children. */
+async function buildCustomFoodRow(row: RowDataPacket): Promise<CustomFoodRow> {
+  const id = row.id as number;
+  const ingredients = await fetchCustomIngredients(id);
+  const servings = await fetchCustomServings(id);
+
+  const total_grams = row.total_grams as number;
+  const calories = row.calories as number;
+  const protein_g = row.protein_g as number;
+  const carbs_g = row.carbs_g as number;
+  const fat_g = row.fat_g as number;
+  const fiber_g = row.fiber_g as number | null;
+  const sugar_g = row.sugar_g as number | null;
+  const sodium_mg = row.sodium_mg as number | null;
+
+  const per100g = derivePer100g(calories, protein_g, carbs_g, fat_g, fiber_g, sugar_g, sodium_mg, total_grams);
+
+  return {
+    id,
+    kind: row.kind as 'food' | 'meal',
+    status: row.status as 'draft' | 'saved',
+    name: row.name as string,
+    notes: (row.notes as string | null) ?? null,
+    total_grams,
+    calories,
+    protein_g,
+    carbs_g,
+    fat_g,
+    fiber_g,
+    sugar_g,
+    sodium_mg,
+    per100g,
+    ingredients,
+    servings,
+    created_at: String(row.created_at),
+    updated_at: String(row.updated_at),
+  };
+}
+
+/**
+ * Delete empty drafts (name blank AND no ingredients) for a user.
+ * Called as best-effort cleanup — errors are silently swallowed.
+ */
+async function cleanupEmptyDrafts(userUuid: string): Promise<void> {
+  try {
+    const [drafts] = await pool.query<RowDataPacket[]>(
+      `SELECT cf.id FROM custom_foods cf
+       WHERE cf.user_uuid = UUID_TO_BIN(?)
+         AND cf.status = 'draft'
+         AND (cf.name = '' OR cf.name IS NULL)
+         AND NOT EXISTS (
+           SELECT 1 FROM custom_food_ingredients cfi WHERE cfi.custom_food_id = cf.id
+         )`,
+      [userUuid],
+    );
+    for (const draft of drafts) {
+      const draftId = draft.id as number;
+      await pool.query(`DELETE FROM custom_food_servings WHERE custom_food_id = ?`, [draftId]);
+      await pool.query(`DELETE FROM custom_food_ingredients WHERE custom_food_id = ?`, [draftId]);
+      await pool.query(`DELETE FROM custom_foods WHERE id = ?`, [draftId]);
+    }
+  } catch {
+    // best-effort; don't break the caller
+  }
+}
+
+/**
+ * Compute batch totals for a custom food input, depending on kind.
+ * - meal: sums ingredient rows (including micros).
+ * - food: uses macro values from the single ingredient row (if present).
+ */
+function computeBatchTotals(input: CustomFoodInput): {
+  total_grams: number; calories: number; protein_g: number; carbs_g: number; fat_g: number;
+  fiber_g: number | null; sugar_g: number | null; sodium_mg: number | null;
+} {
+  if (input.kind === 'meal') {
+    return sumIngredientsFull(input.ingredients);
+  }
+  // food mode: macro values come from the single ingredient row (if present)
+  if (input.ingredients.length > 0) {
+    const ing = input.ingredients[0];
+    return {
+      total_grams: ing.grams,
+      calories: ing.calories,
+      protein_g: ing.protein_g,
+      carbs_g: ing.carbs_g,
+      fat_g: ing.fat_g,
+      fiber_g: ing.fiber_g ?? null,
+      sugar_g: ing.sugar_g ?? null,
+      sodium_mg: ing.sodium_mg ?? null,
+    };
+  }
+  return { total_grams: 0, calories: 0, protein_g: 0, carbs_g: 0, fat_g: 0, fiber_g: null, sugar_g: null, sodium_mg: null };
+}
+
+/** Insert ingredient and serving child rows inside an open transaction connection. */
+async function upsertChildren(
+  conn: PoolConnection,
+  customFoodId: number,
+  input: CustomFoodInput,
+  resolvedServings: CustomFoodInput['servings'],
+): Promise<void> {
+  await conn.query(`DELETE FROM custom_food_ingredients WHERE custom_food_id = ?`, [customFoodId]);
+  if (input.ingredients.length > 0) {
+    const placeholders = input.ingredients.map(() => '(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)').join(', ');
+    const values: unknown[] = [];
+    for (const ing of input.ingredients) {
+      values.push(
+        customFoodId, ing.name, ing.grams, ing.source, ing.source_ref ?? null,
+        ing.calories, ing.protein_g, ing.carbs_g, ing.fat_g,
+        ing.fiber_g ?? null, ing.sugar_g ?? null, ing.sodium_mg ?? null,
+      );
+    }
+    await conn.query(
+      `INSERT INTO custom_food_ingredients
+         (custom_food_id, name, grams, source, source_ref, calories, protein_g, carbs_g, fat_g, fiber_g, sugar_g, sodium_mg)
+       VALUES ${placeholders}`,
+      values,
+    );
+  }
+
+  await conn.query(`DELETE FROM custom_food_servings WHERE custom_food_id = ?`, [customFoodId]);
+  if (resolvedServings.length > 0) {
+    const placeholders = resolvedServings.map(() => '(?, ?, ?, ?, ?, ?)').join(', ');
+    const values: unknown[] = [];
+    for (let i = 0; i < resolvedServings.length; i++) {
+      const s = resolvedServings[i];
+      values.push(customFoodId, s.label, s.def_type, s.def_value, s.grams, i);
+    }
+    await conn.query(
+      `INSERT INTO custom_food_servings (custom_food_id, label, def_type, def_value, grams, sort_order)
+       VALUES ${placeholders}`,
+      values,
+    );
+  }
+}
+
+/**
+ * Create a custom food/meal.
+ * If status='draft', upserts a single draft per (user, kind) to avoid duplicates.
+ */
+export async function createCustomFood(userUuid: string, input: CustomFoodInput): Promise<CustomFoodRow> {
+  const totals = computeBatchTotals(input);
+  const resolvedServings = resolveServingGrams(input.servings, totals.total_grams);
+
+  if (input.status === 'draft') {
+    const [existingRows] = await pool.query<RowDataPacket[]>(
+      `SELECT id FROM custom_foods
+       WHERE user_uuid = UUID_TO_BIN(?) AND status = 'draft' AND kind = ?
+       ORDER BY id ASC LIMIT 1`,
+      [userUuid, input.kind],
+    );
+
+    if (existingRows.length > 0) {
+      const id = existingRows[0].id as number;
+      await withTransaction(async (conn) => {
+        await conn.query(
+          `UPDATE custom_foods
+           SET name = ?, notes = ?, total_grams = ?, calories = ?, protein_g = ?,
+               carbs_g = ?, fat_g = ?, fiber_g = ?, sugar_g = ?, sodium_mg = ?
+           WHERE id = ?`,
+          [
+            input.name, input.notes ?? null,
+            totals.total_grams, totals.calories, totals.protein_g,
+            totals.carbs_g, totals.fat_g, totals.fiber_g ?? null,
+            totals.sugar_g ?? null, totals.sodium_mg ?? null,
+            id,
+          ],
+        );
+        await upsertChildren(conn, id, input, resolvedServings);
+      });
+      return (await getCustomFood(userUuid, id))!;
+    }
+  }
+
+  const id = await withTransaction(async (conn) => {
+    const [result] = await conn.query<ResultSetHeader>(
+      `INSERT INTO custom_foods
+         (user_uuid, kind, status, name, notes, total_grams, calories, protein_g, carbs_g, fat_g, fiber_g, sugar_g, sodium_mg)
+       VALUES (UUID_TO_BIN(?), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        userUuid, input.kind, input.status, input.name, input.notes ?? null,
+        totals.total_grams, totals.calories, totals.protein_g,
+        totals.carbs_g, totals.fat_g, totals.fiber_g ?? null,
+        totals.sugar_g ?? null, totals.sodium_mg ?? null,
+      ],
+    );
+    const newId = result.insertId;
+    await upsertChildren(conn, newId, input, resolvedServings);
+    return newId;
+  });
+
+  return (await getCustomFood(userUuid, id))!;
+}
+
+/** Fetch a single custom food/meal by id, scoped to the user. Returns null if not found. */
+export async function getCustomFood(userUuid: string, id: number): Promise<CustomFoodRow | null> {
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `SELECT id, kind, status, name, notes, total_grams, calories, protein_g, carbs_g, fat_g,
+            fiber_g, sugar_g, sodium_mg, created_at, updated_at
+     FROM custom_foods
+     WHERE id = ? AND user_uuid = UUID_TO_BIN(?)`,
+    [id, userUuid],
+  );
+  if (rows.length === 0) return null;
+  return buildCustomFoodRow(rows[0]);
+}
+
+/** List all custom foods/meals for a user, optionally filtered by status. */
+export async function listCustomFoods(userUuid: string, status?: 'draft' | 'saved'): Promise<CustomFoodRow[]> {
+  await cleanupEmptyDrafts(userUuid);
+
+  const params: unknown[] = [userUuid];
+  let where = 'WHERE user_uuid = UUID_TO_BIN(?)';
+  if (status) {
+    where += ' AND status = ?';
+    params.push(status);
+  }
+
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `SELECT id, kind, status, name, notes, total_grams, calories, protein_g, carbs_g, fat_g,
+            fiber_g, sugar_g, sodium_mg, created_at, updated_at
+     FROM custom_foods
+     ${where}
+     ORDER BY updated_at DESC`,
+    params,
+  );
+
+  const results: CustomFoodRow[] = [];
+  for (const row of rows) {
+    results.push(await buildCustomFoodRow(row));
+  }
+  return results;
+}
+
+/** Update a custom food/meal. Returns null if not found / not owned. */
+export async function updateCustomFood(
+  userUuid: string,
+  id: number,
+  input: CustomFoodInput,
+): Promise<CustomFoodRow | null> {
+  const totals = computeBatchTotals(input);
+  const resolvedServings = resolveServingGrams(input.servings, totals.total_grams);
+
+  const updated = await withTransaction(async (conn) => {
+    const [check] = await conn.query<ResultSetHeader>(
+      `UPDATE custom_foods
+       SET kind = ?, status = ?, name = ?, notes = ?, total_grams = ?,
+           calories = ?, protein_g = ?, carbs_g = ?, fat_g = ?,
+           fiber_g = ?, sugar_g = ?, sodium_mg = ?
+       WHERE id = ? AND user_uuid = UUID_TO_BIN(?)`,
+      [
+        input.kind, input.status, input.name, input.notes ?? null,
+        totals.total_grams, totals.calories, totals.protein_g,
+        totals.carbs_g, totals.fat_g, totals.fiber_g ?? null,
+        totals.sugar_g ?? null, totals.sodium_mg ?? null,
+        id, userUuid,
+      ],
+    );
+    if (check.affectedRows === 0) return false;
+    await upsertChildren(conn, id, input, resolvedServings);
+    return true;
+  });
+
+  if (!updated) return null;
+  return getCustomFood(userUuid, id);
+}
+
+/** Hard delete a custom food/meal + its children. Returns false if not found. */
+export async function deleteCustomFood(userUuid: string, id: number): Promise<boolean> {
+  return withTransaction(async (conn) => {
+    const [check] = await conn.query<RowDataPacket[]>(
+      `SELECT id FROM custom_foods WHERE id = ? AND user_uuid = UUID_TO_BIN(?)`,
+      [id, userUuid],
+    );
+    if (check.length === 0) return false;
+
+    await conn.query(`DELETE FROM custom_food_ingredients WHERE custom_food_id = ?`, [id]);
+    await conn.query(`DELETE FROM custom_food_servings WHERE custom_food_id = ?`, [id]);
+    const [result] = await conn.query<ResultSetHeader>(
+      `DELETE FROM custom_foods WHERE id = ? AND user_uuid = UUID_TO_BIN(?)`,
+      [id, userUuid],
+    );
+    return result.affectedRows > 0;
+  });
+}
+
+/**
+ * Clone a saved custom food/meal into a new draft row (duplicate-as-template).
+ * Always inserts a fresh row (does not merge into any existing draft).
+ * Returns null if the source is not found / not owned.
+ */
+export async function duplicateCustomFood(userUuid: string, id: number): Promise<CustomFoodRow | null> {
+  const source = await getCustomFood(userUuid, id);
+  if (!source) return null;
+
+  const input: CustomFoodInput = {
+    kind: source.kind,
+    name: source.name,
+    notes: source.notes,
+    status: 'draft',
+    ingredients: source.ingredients,
+    servings: source.servings,
+  };
+
+  const totals = computeBatchTotals(input);
+  const resolvedServings = resolveServingGrams(input.servings, totals.total_grams);
+
+  const newId = await withTransaction(async (conn) => {
+    const [result] = await conn.query<ResultSetHeader>(
+      `INSERT INTO custom_foods
+         (user_uuid, kind, status, name, notes, total_grams, calories, protein_g, carbs_g, fat_g, fiber_g, sugar_g, sodium_mg)
+       VALUES (UUID_TO_BIN(?), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        userUuid, input.kind, 'draft', input.name, input.notes ?? null,
+        totals.total_grams, totals.calories, totals.protein_g,
+        totals.carbs_g, totals.fat_g, totals.fiber_g ?? null,
+        totals.sugar_g ?? null, totals.sodium_mg ?? null,
+      ],
+    );
+    const insertedId = result.insertId;
+    await upsertChildren(conn, insertedId, input, resolvedServings);
+    return insertedId;
+  });
+
+  return getCustomFood(userUuid, newId);
+}
+
+/**
+ * FULLTEXT/LIKE search over saved custom foods/meals.
+ * Returns FoodSearchResult-shaped objects (source='custom') with portions attached.
+ */
+export async function searchCustomFoods(userUuid: string, query: string): Promise<FoodSearchResult[]> {
+  const likePattern = `%${query.replace(/[%_\\]/g, '\\$&')}%`;
+
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `SELECT id, kind, name, total_grams, calories, protein_g, carbs_g, fat_g,
+            fiber_g, sugar_g, sodium_mg
+     FROM custom_foods
+     WHERE user_uuid = UUID_TO_BIN(?)
+       AND status = 'saved'
+       AND name LIKE ?
+     ORDER BY updated_at DESC
+     LIMIT 10`,
+    [userUuid, likePattern],
+  );
+
+  const results: FoodSearchResult[] = [];
+  for (const row of rows) {
+    const id = row.id as number;
+    const total_grams = row.total_grams as number;
+    const per100g = derivePer100g(
+      row.calories as number, row.protein_g as number, row.carbs_g as number, row.fat_g as number,
+      row.fiber_g as number | null, row.sugar_g as number | null, row.sodium_mg as number | null,
+      total_grams,
+    );
+    const servings = await fetchCustomServings(id);
+
+    const portions: FoodSearchResult['portions'] = [
+      { label: 'full batch', grams: total_grams > 0 ? total_grams : 1 },
+      ...servings.map((s) => ({ label: s.label, grams: s.grams })),
+    ];
+
+    results.push({
+      name: row.name as string,
+      source: 'custom',
+      source_ref: String(id),
+      per100g,
+      portions,
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Most recently logged custom items by joining food_entries.from_custom_food_id.
+ * Returns FoodSearchResult-shaped objects for the "Recently used" row in the UI.
+ */
+export async function recentCustomFoods(userUuid: string, limit = 5): Promise<FoodSearchResult[]> {
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `SELECT cf.id, cf.kind, cf.name, cf.total_grams, cf.calories, cf.protein_g, cf.carbs_g,
+            cf.fat_g, cf.fiber_g, cf.sugar_g, cf.sodium_mg,
+            MAX(fe.logged_at) as last_logged
+     FROM food_entries fe
+     INNER JOIN custom_foods cf ON cf.id = fe.from_custom_food_id
+     WHERE fe.user_uuid = UUID_TO_BIN(?)
+       AND cf.user_uuid = UUID_TO_BIN(?)
+       AND cf.status = 'saved'
+     GROUP BY cf.id, cf.kind, cf.name, cf.total_grams, cf.calories, cf.protein_g,
+              cf.carbs_g, cf.fat_g, cf.fiber_g, cf.sugar_g, cf.sodium_mg
+     ORDER BY last_logged DESC
+     LIMIT ?`,
+    [userUuid, userUuid, limit],
+  );
+
+  const results: FoodSearchResult[] = [];
+  for (const row of rows) {
+    const id = row.id as number;
+    const total_grams = row.total_grams as number;
+    const per100g = derivePer100g(
+      row.calories as number, row.protein_g as number, row.carbs_g as number, row.fat_g as number,
+      row.fiber_g as number | null, row.sugar_g as number | null, row.sodium_mg as number | null,
+      total_grams,
+    );
+    const servings = await fetchCustomServings(id);
+
+    const portions: FoodSearchResult['portions'] = [
+      { label: 'full batch', grams: total_grams > 0 ? total_grams : 1 },
+      ...servings.map((s) => ({ label: s.label, grams: s.grams })),
+    ];
+
+    results.push({
+      name: row.name as string,
+      source: 'custom',
+      source_ref: String(id),
+      per100g,
+      portions,
+    });
+  }
+
+  return results;
 }


### PR DESCRIPTION
## Summary

- **`migrations/013_custom_foods.sql`**: Three new tables (`custom_foods`, `custom_food_ingredients`, `custom_food_servings`) plus `ALTER` statements that widen `food_entry_ingredients.source` to include `'custom'`, add `fiber_g`/`sugar_g`/`sodium_mg` micros columns to `food_entry_ingredients`, widen `food_entries.source` to include `'custom'`, and add `from_custom_food_id` to `food_entries` (provenance only, non-authoritative).
- **`schemas/nutrition.ts`**: `'custom'` added to `ENTRY_SOURCES` and `INGREDIENT_SOURCES` constants; optional `fiber_g`/`sugar_g`/`sodium_mg` added to `ingredientInputSchema`; `foodSearchResultSchema.source` now includes `'custom'`; new schemas `customServingSchema`, `customFoodInputSchema`, `customFoodRowSchema` with exported TS types.
- **`services/nutrition/store.ts`**: `sumIngredientsFull` (extends macro sum to include micros); `createCustomFood` (with draft-upsert: one draft per user+kind, reuses existing draft row rather than creating duplicates), `getCustomFood`, `listCustomFoods` (with empty-draft cleanup), `updateCustomFood`, `deleteCustomFood` (hard delete + children), `duplicateCustomFood` (clones into fresh draft row, does not merge into existing draft), `searchCustomFoods` (LIKE search, `status='saved'`, returns `FoodSearchResult`-shaped objects with `source:'custom'` and portions = full batch + custom servings), `recentCustomFoods` (join `food_entries.from_custom_food_id`).
- **`services/nutrition/providers.ts`**: `searchAllFoods(userUuid, query)` — custom results first, then external; suppresses external hits with exact matching name (case-insensitive). `searchAllFoodsWithPortions(userUuid, query)` — like the above but attaches `getPortions` to the first non-custom result (USDA/OFF).
- **`routes/nutrition.ts`**: New endpoints `GET /custom-foods`, `POST /custom-foods`, `GET /custom-foods/recent` (registered **before** `/:id` to avoid param capture), `GET /custom-foods/:id`, `PATCH /custom-foods/:id` (also serves draft autosave), `DELETE /custom-foods/:id`, `POST /custom-foods/:id/duplicate`. `GET /foods/search` now calls `searchAllFoodsWithPortions(uuid, q)` (custom-first, user-scoped) instead of the old unauthenticated-only `searchFoods`.

## Notes / caveats for verification

**Migration numbering**: migrations 008–012 already existed in the repo, so this is `013_custom_foods.sql` (not `008` as in the plan template).

**`migrate.js` ALTER idempotency**: `migrate.js` records each file in `schema_migrations` on first successful run and skips it on subsequent runs — so the `ALTER ... MODIFY` and `ADD COLUMN` statements only ever execute once per DB. On a first-time run: `MODIFY source ENUM(...)` succeeds idempotently (MySQL accepts re-widening without error); `ADD COLUMN fiber_g/sugar_g/sodium_mg/from_custom_food_id` would get errno 1060 (duplicate column) on a pre-migrated DB — tolerated by the runner.

**Duplicate-name suppression**: `searchAllFoods` suppresses external results whose name exactly (case-insensitively) matches a custom food name. Non-trivial fuzzy/token-overlap suppression was skipped as non-trivial (see plan note).

**`tsc` passes cleanly** on the server code (`npm run build` exits 0). No client or `agent.ts` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)