### PR TITLE
Custom Foods & Meals — Phase C (agent)

### DIFF
--- a/client/src/features/nutrition/MealBuilder.module.scss
+++ b/client/src/features/nutrition/MealBuilder.module.scss
@@ -565,3 +565,21 @@
   color: $error;
   letter-spacing: $sarabun-spacing;
 }
+
+// Proposal mode — inline card in NutritionChat thread (no overlay/backdrop)
+.proposalWrap {
+  // No overlay; renders in-flow in the chat message list
+  display: block;
+}
+
+.proposalSheet {
+  width: 100%;
+  background-color: $surface;
+  border: 1px solid rgba($surface-border, 0.5);
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  max-height: 80dvh;
+  overflow-y: auto;
+}

--- a/client/src/features/nutrition/MealBuilder.tsx
+++ b/client/src/features/nutrition/MealBuilder.tsx
@@ -10,6 +10,11 @@
  * Autosave: debounced PATCH (~600ms) to the single draft custom_food.
  * On open: if a draft for the given kind exists, load it.
  * Save: flip status to 'saved' and close.
+ *
+ * Proposal mode: when `proposalArgs` is provided (from the AI agent's
+ * propose_custom_food tool), the builder is pre-filled with those values and
+ * autosave is suppressed. The Save button calls `onConfirmProposal(payload)`
+ * instead of writing to the DB directly.
  */
 import {
   useState,
@@ -27,6 +32,7 @@ import type {
   IngredientInput,
   IngredientSource,
   Per100g,
+  ProposeCustomFoodArgs,
 } from './types';
 import styles from './MealBuilder.module.scss';
 import { X, Plus, Trash2 } from 'lucide-react';
@@ -351,12 +357,21 @@ export interface MealBuilderProps {
   prefillRows?: BuilderRow[];
   onClose: () => void;
   onSaved?: (saved: CustomFoodRow) => void;
+  /**
+   * Proposal mode: when provided, pre-fill from agent's propose_custom_food args
+   * and suppress autosave. The Save button calls onConfirmProposal(payload) instead
+   * of writing to the DB. Used by NutritionChat inline card.
+   */
+  proposalArgs?: ProposeCustomFoodArgs;
+  onConfirmProposal?: (payload: CustomFoodInput) => void;
+  onDenyProposal?: () => void;
 }
 
 // ---------------------------------------------------------------------------
 // Main MealBuilder component
 // ---------------------------------------------------------------------------
-export default function MealBuilder({ open, kind, initialDraft, prefillRows, onClose, onSaved }: MealBuilderProps) {
+export default function MealBuilder({ open, kind, initialDraft, prefillRows, onClose, onSaved, proposalArgs, onConfirmProposal, onDenyProposal }: MealBuilderProps) {
+  const isProposalMode = proposalArgs !== undefined;
   const [name, setName] = useState('');
   const [notes, setNotes] = useState('');
   const [rows, setRows] = useState<BuilderRow[]>([emptyBuilderRow()]);
@@ -396,6 +411,58 @@ export default function MealBuilder({ open, kind, initialDraft, prefillRows, onC
     setNewServingLabel('');
     setNewServingValue('');
     setNewServingType('grams');
+
+    // Proposal mode: pre-fill from agent args, no draft fetch
+    if (proposalArgs) {
+      setName(proposalArgs.name);
+      setNotes(proposalArgs.notes ?? '');
+      setDraftId(null);
+      if (proposalArgs.servings && proposalArgs.servings.length > 0) {
+        // Agent provides def_type + def_value but not resolved grams — use def_value as grams
+        // for fractions (approximate); server resolves on save.
+        setServings(proposalArgs.servings.map((s, i) => ({
+          label: s.label,
+          def_type: s.def_type,
+          def_value: s.def_value,
+          grams: s.def_type === 'grams' ? s.def_value : s.def_value * 100, // approx; resolved on save
+          sort_order: i,
+        })));
+      }
+      if (kind === 'meal' && proposalArgs.ingredients.length > 0) {
+        setRows(proposalArgs.ingredients.map(ing => ({
+          rowKey: nextKey(),
+          name: ing.name,
+          grams: ing.grams,
+          quantity: ing.quantity ?? ing.grams,
+          unitLabel: ing.unit ?? 'g',
+          unitGrams: ing.unit && ing.unit !== 'g' && ing.quantity && ing.quantity > 0
+            ? ing.grams / ing.quantity
+            : 1,
+          portions: ing.portions ?? [GRAMS_UNIT],
+          source: ing.source as IngredientSource,
+          source_ref: ing.source_ref ?? null,
+          calories: ing.calories,
+          protein_g: ing.protein_g,
+          carbs_g: ing.carbs_g,
+          fat_g: ing.fat_g,
+          fiber_g: ing.fiber_g ?? null,
+          sugar_g: ing.sugar_g ?? null,
+          sodium_mg: ing.sodium_mg ?? null,
+          per100g: null,
+        })));
+      } else if (kind === 'food' && proposalArgs.ingredients.length > 0) {
+        const ing = proposalArgs.ingredients[0];
+        setFoodServingGrams(ing.grams);
+        setFoodCalories(ing.calories);
+        setFoodProtein(ing.protein_g);
+        setFoodCarbs(ing.carbs_g);
+        setFoodFat(ing.fat_g);
+        setFoodFiber(ing.fiber_g != null ? String(ing.fiber_g) : '');
+        setFoodSugar(ing.sugar_g != null ? String(ing.sugar_g) : '');
+        setFoodSodium(ing.sodium_mg != null ? String(ing.sodium_mg) : '');
+      }
+      return;
+    }
 
     if (initialDraft) {
       loadFromRow(initialDraft);
@@ -537,6 +604,8 @@ export default function MealBuilder({ open, kind, initialDraft, prefillRows, onC
 
   useEffect(() => {
     if (!open) return;
+    // Suppress autosave in proposal mode
+    if (isProposalMode) return;
     // Only autosave if there's some content
     if (!name.trim() && rows.every(r => !r.name.trim()) && kind === 'meal') return;
     if (!name.trim() && kind === 'food') return;
@@ -554,7 +623,7 @@ export default function MealBuilder({ open, kind, initialDraft, prefillRows, onC
   }, [debouncedPayloadStr, open]);
 
   // ---------------------------------------------------------------------------
-  // Save (flip to saved)
+  // Save (flip to saved, or confirm proposal)
   // ---------------------------------------------------------------------------
   async function handleSave() {
     if (!name.trim()) {
@@ -562,6 +631,13 @@ export default function MealBuilder({ open, kind, initialDraft, prefillRows, onC
       return;
     }
     setSaveError(null);
+
+    // Proposal mode: hand payload back to caller; no DB write here.
+    if (isProposalMode && onConfirmProposal) {
+      onConfirmProposal(buildPayload('saved'));
+      return;
+    }
+
     setIsSaving(true);
     try {
       const payload = buildPayload('saved');
@@ -660,16 +736,23 @@ export default function MealBuilder({ open, kind, initialDraft, prefillRows, onC
   // ---------------------------------------------------------------------------
   if (!open) return null;
 
-  const title = kind === 'meal'
-    ? (draftId ? 'Edit Meal' : 'New Meal')
-    : (draftId ? 'Edit Food' : 'New Food');
+  const title = isProposalMode
+    ? (kind === 'meal' ? 'Save custom meal' : 'Save custom food')
+    : kind === 'meal'
+      ? (draftId ? 'Edit Meal' : 'New Meal')
+      : (draftId ? 'Edit Food' : 'New Food');
 
   return (
-    <div className={styles.overlay}>
-      <div className={styles.sheet} role="dialog" aria-modal="true" aria-label={title}>
+    <div className={isProposalMode ? styles.proposalWrap : styles.overlay}>
+      <div className={isProposalMode ? styles.proposalSheet : styles.sheet} role="dialog" aria-modal={!isProposalMode} aria-label={title}>
         {/* Header */}
         <div className={styles.sheetHeader}>
-          <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="Close">
+          <button
+            type="button"
+            className={styles.closeBtn}
+            onClick={isProposalMode ? (onDenyProposal ?? onClose) : onClose}
+            aria-label={isProposalMode ? 'Decline' : 'Close'}
+          >
             <X size={16} aria-hidden="true" style={{ display: 'block' }} />
           </button>
           <h2 className={styles.sheetTitle}>{title}</h2>
@@ -679,7 +762,7 @@ export default function MealBuilder({ open, kind, initialDraft, prefillRows, onC
             onClick={handleSave}
             disabled={isSaving || !name.trim()}
           >
-            {isSaving ? 'Saving…' : 'Save'}
+            {isProposalMode ? 'Confirm' : isSaving ? 'Saving…' : 'Save'}
           </button>
         </div>
 

--- a/client/src/features/nutrition/NutritionChat.tsx
+++ b/client/src/features/nutrition/NutritionChat.tsx
@@ -36,13 +36,14 @@ import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport, isToolUIPart, getToolName } from 'ai';
 import type { FileUIPart, UIMessage, ToolUIPart, DynamicToolUIPart } from 'ai';
 import ReactMarkdown from 'react-markdown';
-import { useCreateEntry, fetchTranscript, clearTranscript } from './api';
+import { useCreateEntry, useCreateCustomFood, fetchTranscript, clearTranscript } from './api';
 import type { StoredChatMessage } from './api';
 import EntryEditor from './EntryEditor';
+import MealBuilder from './MealBuilder';
 import BarcodeScanner from './BarcodeScanner';
 import ToolCallCard from './ToolCallCard';
 import ConfirmModal from '../../components/ConfirmModal';
-import type { EntryInput, EntryEditorMode, ProposeEntryArgs } from './types';
+import type { EntryInput, EntryEditorMode, ProposeEntryArgs, ProposeCustomFoodArgs, CustomFoodInput } from './types';
 import styles from './NutritionChat.module.scss';
 import { ChevronDown, Trash2, Camera, ScanBarcode, Square, Send, Images, AlertCircle, ChevronRight, MessageSquare } from 'lucide-react';
 import useIsMobile from '../../hooks/useIsMobile';
@@ -340,6 +341,10 @@ interface MessageProps {
   onProposalDeny: (partKey: string) => void;
   deniedProposals: Set<string>;
   confirmedProposals: Map<string, string>; // partKey → entry name
+  onCustomFoodConfirm: (payload: CustomFoodInput, partKey: string) => void;
+  onCustomFoodDeny: (partKey: string) => void;
+  deniedCustomFoodProposals: Set<string>;
+  confirmedCustomFoodProposals: Map<string, string>; // partKey → food name
 }
 
 function ChatMessage({
@@ -351,6 +356,10 @@ function ChatMessage({
   onProposalDeny,
   deniedProposals,
   confirmedProposals,
+  onCustomFoodConfirm,
+  onCustomFoodDeny,
+  deniedCustomFoodProposals,
+  confirmedCustomFoodProposals,
 }: MessageProps) {
   const isUser = message.role === 'user';
   // #15/#17: interrupted flag from StoredChatMessage cast
@@ -460,6 +469,49 @@ function ChatMessage({
                   onClose={() => onProposalDeny(partKey)}
                   onConfirm={(input) => onProposalConfirm(input, partKey)}
                   onDeny={() => onProposalDeny(partKey)}
+                />
+              </div>
+            );
+          }
+
+          // propose_custom_food: renders as an inline pre-filled MealBuilder card
+          if (toolName === 'propose_custom_food') {
+            const partKey = `${message.id}-${toolCallId}`;
+            const isDenied = deniedCustomFoodProposals.has(partKey);
+            const confirmedName = confirmedCustomFoodProposals.get(partKey);
+            const isConfirmed = confirmedName !== undefined;
+
+            if (isDenied) {
+              return (
+                <div key={idx} className={styles.proposalDenied}>
+                  Proposal declined — please refine your request.
+                </div>
+              );
+            }
+            if (isConfirmed) {
+              return (
+                <div key={idx} className={styles.proposalConfirmed}>
+                  {confirmedName ? `Saved: ${confirmedName}` : 'Custom food saved!'}
+                </div>
+              );
+            }
+            if (part.state !== 'input-available' && part.state !== 'output-available') {
+              return <ToolCallCard key={idx} part={part as ToolUIPart | DynamicToolUIPart} />;
+            }
+
+            const rawArgs = (part.state === 'output-available'
+              ? (part as { output: unknown }).output
+              : part.input) as ProposeCustomFoodArgs;
+
+            return (
+              <div key={idx} className={styles.proposalInlineWrap}>
+                <MealBuilder
+                  open={true}
+                  kind={rawArgs.kind}
+                  proposalArgs={rawArgs}
+                  onClose={() => onCustomFoodDeny(partKey)}
+                  onDenyProposal={() => onCustomFoodDeny(partKey)}
+                  onConfirmProposal={(payload) => onCustomFoodConfirm(payload, partKey)}
                 />
               </div>
             );
@@ -602,10 +654,17 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
   // ---- Entry creation for confirmed proposals ----
   const createEntry = useCreateEntry(selectedDate);
 
+  // ---- Custom food creation for confirmed propose_custom_food proposals ----
+  const createCustomFood = useCreateCustomFood();
+
   // ---- Proposal state tracking ----
   const [deniedProposals, setDeniedProposals] = useState<Set<string>>(new Set());
   // #71: store name alongside confirmation so the message can display it
   const [confirmedProposals, setConfirmedProposals] = useState<Map<string, string>>(new Map());
+
+  // ---- Custom food proposal state tracking ----
+  const [deniedCustomFoodProposals, setDeniedCustomFoodProposals] = useState<Set<string>>(new Set());
+  const [confirmedCustomFoodProposals, setConfirmedCustomFoodProposals] = useState<Map<string, string>>(new Map());
 
   // ---- Composer state ----
   const [text, setText] = useState('');
@@ -819,6 +878,16 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
     setConfirmedProposals(prev => new Map([...prev, [partKey, entryName]]));
   }, [createEntry]);
 
+  // ---- Custom food proposal handlers ----
+  const handleCustomFoodDeny = useCallback((partKey: string) => {
+    setDeniedCustomFoodProposals(prev => new Set([...prev, partKey]));
+  }, []);
+
+  const handleCustomFoodConfirm = useCallback(async (payload: CustomFoodInput, partKey: string) => {
+    const saved = await createCustomFood.mutateAsync(payload);
+    setConfirmedCustomFoodProposals(prev => new Map([...prev, [partKey, saved.name]]));
+  }, [createCustomFood]);
+
   // ---- #7/#70: Clear chat — guarded by ConfirmModal ----
   const executeClearChat = useCallback(async () => {
     setShowClearConfirm(false);
@@ -831,6 +900,8 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
     setMessages([]);
     setDeniedProposals(new Set());
     setConfirmedProposals(new Map());
+    setDeniedCustomFoodProposals(new Set());
+    setConfirmedCustomFoodProposals(new Map());
   }, [selectedDate, setMessages]);
 
   const handleClearChat = useCallback(() => {
@@ -1024,6 +1095,10 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
               onProposalDeny={handleProposalDeny}
               deniedProposals={deniedProposals}
               confirmedProposals={confirmedProposals}
+              onCustomFoodConfirm={handleCustomFoodConfirm}
+              onCustomFoodDeny={handleCustomFoodDeny}
+              deniedCustomFoodProposals={deniedCustomFoodProposals}
+              confirmedCustomFoodProposals={confirmedCustomFoodProposals}
             />
           ))}
 

--- a/client/src/features/nutrition/ToolCallCard.tsx
+++ b/client/src/features/nutrition/ToolCallCard.tsx
@@ -22,8 +22,9 @@ type AnyToolUIPart = ToolUIPart | DynamicToolUIPart;
 
 // ---- Item 8: Human-readable tool name map ----
 const TOOL_LABEL_MAP: Record<string, string> = {
-  search_usda: 'USDA search',
-  search_foods_batch: 'USDA search',
+  search_usda: 'Food search',
+  search_foods: 'Food search',
+  search_foods_batch: 'Food search',
   lookup_barcode: 'Barcode lookup',
   get_portions: 'Serving sizes',
   search_food_history: 'Food history',
@@ -33,6 +34,7 @@ const TOOL_LABEL_MAP: Record<string, string> = {
   web_search: 'Web search',
   web_search_preview: 'Web search',
   propose_entry: 'Propose entry',
+  propose_custom_food: 'Save custom food',
 };
 
 /** Convert snake_case / camelCase to Title Case as a fallback. */

--- a/client/src/features/nutrition/types.ts
+++ b/client/src/features/nutrition/types.ts
@@ -158,6 +158,29 @@ export interface CustomFoodInput {
   servings: CustomServing[];
 }
 
+/** What the agent's propose_custom_food tool emits — full builder payload for
+ * creating a reusable custom food or meal. Rendered as an inline MealBuilder
+ * card in NutritionChat; on confirm the client POSTs to /nutrition/custom-foods. */
+export interface ProposeCustomFoodIngredient extends IngredientInput {
+  quantity?: number | null;
+  unit?: string | null;
+  portions?: FoodPortion[] | null;
+}
+
+export interface ProposeCustomFoodServing {
+  label: string;
+  def_type: 'grams' | 'fraction';
+  def_value: number;
+}
+
+export interface ProposeCustomFoodArgs {
+  kind: 'food' | 'meal';
+  name: string;
+  notes?: string | null;
+  ingredients: ProposeCustomFoodIngredient[];
+  servings: ProposeCustomFoodServing[];
+}
+
 /** A custom food/meal row returned from the server. */
 export interface CustomFoodRow {
   id: number;

--- a/schemas/nutrition.ts
+++ b/schemas/nutrition.ts
@@ -121,6 +121,37 @@ export type FoodSearchResult = z.infer<typeof foodSearchResultSchema>;
 
 // ---- Custom Foods & Meals schemas ----
 
+// What the agent's `propose_custom_food` tool emits — a full builder payload for
+// creating a custom food or meal. Echoed back as output so the client can render
+// an inline proposal card. The user reviews/edits and confirms; the client POSTs
+// to /nutrition/custom-foods on confirm (agent does NOT write to DB).
+//
+// Serving definitions carry def_type + def_value; grams resolution happens on save.
+// The agent may include any field the human builder can set (full parity).
+export const proposeCustomFoodIngredientSchema = ingredientInputSchema.extend({
+  // Optional serving metadata so the builder can pre-select a real household serving
+  quantity: z.number().positive().nullable().optional(),
+  unit: z.string().max(64).nullable().optional(),
+  portions: z.array(foodPortionSchema).nullable().optional(),
+});
+export type ProposeCustomFoodIngredient = z.infer<typeof proposeCustomFoodIngredientSchema>;
+
+export const proposeCustomFoodServingSchema = z.object({
+  label: z.string().min(1).max(64),
+  def_type: z.enum(['grams', 'fraction']),
+  def_value: z.number().positive(),
+});
+export type ProposeCustomFoodServing = z.infer<typeof proposeCustomFoodServingSchema>;
+
+export const proposeCustomFoodArgsSchema = z.object({
+  kind: z.enum(['food', 'meal']),
+  name: z.string().min(1).max(255),
+  notes: z.string().max(1000).nullable().optional(),
+  ingredients: z.array(proposeCustomFoodIngredientSchema),
+  servings: z.array(proposeCustomFoodServingSchema),
+});
+export type ProposeCustomFoodArgs = z.infer<typeof proposeCustomFoodArgsSchema>;
+
 /** One custom serving definition stored alongside a custom food/meal. */
 export const customServingSchema = z.object({
   label: z.string().min(1).max(64),

--- a/services/nutrition/agent.ts
+++ b/services/nutrition/agent.ts
@@ -4,7 +4,7 @@
 import { streamText, tool, stepCountIs, convertToModelMessages } from 'ai';
 import { openai } from '@ai-sdk/openai';
 import { z } from 'zod';
-import { proposeEntryArgsSchema } from '../../schemas/nutrition';
+import { proposeEntryArgsSchema, proposeCustomFoodArgsSchema } from '../../schemas/nutrition';
 import * as store from './store';
 import * as providers from './providers';
 import { recordUsage } from './usage';
@@ -68,9 +68,10 @@ TODAY'S DATE: ${selectedDate}
 
 ## Your job
 Help the user identify, quantify, and log what they ate. When the user describes food:
-1. Search for it with \`search_usda\` (or \`lookup_barcode\` for barcodes) to get accurate per-100g macros — NEVER invent or estimate calories without grounding them in a tool result.
-   - For a **multi-item meal** (two or more distinct foods in one message), use ONE \`search_foods_batch\` call with all queries at once instead of multiple \`search_usda\` calls. Use \`search_usda\` only for single-item lookups.
-   - Both \`search_usda\` and \`search_foods_batch\` automatically attach portion sizes to the top result, so you often do NOT need a separate \`get_portions\` call.
+1. Search for it with \`search_foods\` (or \`lookup_barcode\` for barcodes) to get accurate per-100g macros — NEVER invent or estimate calories without grounding them in a tool result.
+   - For a **multi-item meal** (two or more distinct foods in one message), use ONE \`search_foods_batch\` call with all queries at once instead of multiple \`search_foods\` calls. Use \`search_foods\` only for single-item lookups.
+   - Both \`search_foods\` and \`search_foods_batch\` automatically attach portion sizes to the top result, so you often do NOT need a separate \`get_portions\` call.
+   - Results may include the user's own saved custom foods/meals (source: 'custom'). **Prefer custom results when they match what the user is describing** — they already carry the user's preferred portions and notes. Logging a saved custom meal is identical to logging any other food: use the normal \`propose_entry\` flow with the custom item's ingredients.
 2. Check \`search_food_history\` first for foods the user has logged before — prefer reusing those if the food matches, including the same serving they used last time.
 3. Estimate the portion in **grams**. When the user gives a weight in non-gram units (lbs, oz, kg, mg, etc.), call \`convert_to_grams\` — do NOT do the arithmetic yourself. Ask one brief clarifying question if the portion or food identity is genuinely ambiguous (e.g. "Was that a small, medium, or large banana?"). Do not ask multiple questions at once.
 4. When you are confident about identity + portion, call **\`propose_entry\`** with the fully structured entry. The user will review and confirm in the UI — you do NOT write to the database.
@@ -103,7 +104,7 @@ When building a multi-ingredient entry (recipe, dish, or meal), do NOT add ingre
 Only include such ingredients if the user **explicitly asks** to log them (e.g. "include the salt" or "log all spices too").
 
 ## Web-search fallback
-- Only use \`web_search\` when \`search_usda\`, \`search_foods_batch\`, and \`lookup_barcode\` all return nothing useful (e.g. a local restaurant item, branded boba, or a food not in USDA/OFF). **NEVER use \`web_search\` for arithmetic or calculation — use the \`calculator\` tool instead.**
+- Only use \`web_search\` when \`search_foods\`, \`search_foods_batch\`, and \`lookup_barcode\` all return nothing useful (e.g. a local restaurant item, branded boba, or a food not in the food database). **NEVER use \`web_search\` for arithmetic or calculation — use the \`calculator\` tool instead.**
 - Prefer official brand or restaurant nutrition pages. Extract per-serving or per-100g macros.
 - **Always cite the source URL** in your reply when using web-search data.
 - Use ingredient \`source: 'manual'\` for any web-derived items.
@@ -129,6 +130,16 @@ DO NOT populate \`notes\` when the proposal is straightforward (e.g. "200g chick
 
 ## Arithmetic and the calculator tool
 Use the \`calculator\` tool for **any non-trivial arithmetic** — gram conversions, macro scaling (per100g × grams/100), portion multiplications, totalling macros across ingredients, etc. Pass a standard math expression string (e.g. \`"0.28 * 210"\`). Do NOT perform multi-step arithmetic in your head; call \`calculator\` instead. NEVER use \`web_search\` for math.
+
+## Saving a reusable custom food or meal
+When the user asks to save something for future reuse (e.g. "save this as my usual X", "add this meal to my library", "make a custom food for this"), call **\`propose_custom_food\`** to propose creating it. The user will review and confirm in the UI — you do NOT write to the database. You have full parity with the human builder:
+- Set \`kind\`: \`'meal'\` for multi-ingredient bundles; \`'food'\` for single items with directly entered macros.
+- Set \`name\` (required): a short, recognisable name the user will see in their library.
+- Set \`notes\` (optional): any useful detail about the food or meal (preparation notes, source, etc.).
+- Set \`ingredients\`: the full list of ingredients with grams + macros. Use the same macro-derivation rules as \`propose_entry\` (per100g × grams/100).
+- Set \`servings\` (optional): custom serving definitions. Use \`def_type: 'grams'\` with a gram weight, or \`def_type: 'fraction'\` with a decimal fraction of the full batch (e.g. 0.25 for ¼ batch). The grams field is resolved on save.
+
+Do NOT call \`propose_custom_food\` just because the user logged something once — only when they explicitly ask to save it for reuse. Also offer it proactively when you notice the user has logged the same composite meal multiple times and they haven't saved it yet.
 
 ## Other rules
 - Ground all macros in tool results. If a search returns no results, say so and ask the user for more info.
@@ -175,21 +186,21 @@ ${summariseEntries(recent)}
       });
     },
     tools: {
-      /** Full-text food search against USDA FoodData Central (+ OFF fallback).
+      /** Source-agnostic food search: user's custom foods/meals first, then USDA/OFF.
        *  Returns per-100g macros + portions attached to the top result. */
-      search_usda: tool({
+      search_foods: tool({
         description:
-          'Search for a SINGLE food in USDA FoodData Central and Open Food Facts. Returns up to 5 candidates with per-100g macros, and portions (household serving sizes) attached to the top result. Use search_foods_batch instead when the user describes two or more foods at once.',
+          'Search for a SINGLE food in the food database (USDA, Open Food Facts, and the user\'s saved custom foods/meals). Returns up to 5 candidates with per-100g macros, and portions (household serving sizes) attached to the top result. Results may include custom items (source: \'custom\') — prefer those when they match what the user describes. Use search_foods_batch instead when the user describes two or more foods at once.',
         inputSchema: z.object({
           query: z.string().describe('Food name or description to search for, e.g. "banana" or "chicken breast raw"'),
         }),
-        execute: async ({ query }) => providers.searchFoodsWithPortions(query),
+        execute: async ({ query }) => providers.searchAllFoodsWithPortions(userUuid, query),
       }),
 
-      /** Batched USDA search — one call for multi-item meals. Portions on top result per query. */
+      /** Batched food search — one call for multi-item meals. Portions on top result per query. */
       search_foods_batch: tool({
         description:
-          'Search for multiple foods in one call. Use this when the user describes two or more distinct foods in a single message (e.g. "rice, chicken, and broccoli"). Runs all searches in parallel and returns results grouped per query, with portions attached to the top result of each query.',
+          'Search for multiple foods in one call. Use this when the user describes two or more distinct foods in a single message (e.g. "rice, chicken, and broccoli"). Searches the food database (USDA, Open Food Facts, and the user\'s saved custom foods/meals). Runs all searches in parallel and returns results grouped per query, with portions attached to the top result of each query.',
         inputSchema: z.object({
           queries: z
             .array(z.string())
@@ -200,7 +211,7 @@ ${summariseEntries(recent)}
           const results = await Promise.all(
             queries.map(async (query) => ({
               query,
-              results: await providers.searchFoodsWithPortions(query),
+              results: await providers.searchAllFoodsWithPortions(userUuid, query),
             })),
           );
           return results;
@@ -217,13 +228,13 @@ ${summariseEntries(recent)}
         execute: async ({ code }) => providers.lookupBarcode(code),
       }),
 
-      /** USDA FDC household serving sizes for a food. */
+      /** Household serving sizes for a food (USDA FDC or OFF). */
       get_portions: tool({
         description:
-          'Fetch household serving sizes (e.g. "1 medium", "1 cup") for a food from USDA FDC or OFF. Call this after search_usda to help convert a described portion to grams. Not needed if portions are already attached to the search result.',
+          'Fetch household serving sizes (e.g. "1 medium", "1 cup") for a food from USDA FDC or OFF. Call this after search_foods to help convert a described portion to grams. Not needed if portions are already attached to the search result.',
         inputSchema: z.object({
           source: z.enum(['usda', 'off']).describe('Data source the food came from'),
-          ref: z.string().describe('source_ref from search_usda or lookup_barcode result'),
+          ref: z.string().describe('source_ref from search_foods or lookup_barcode result'),
         }),
         execute: async ({ source, ref }) => providers.getPortions(source, ref),
       }),
@@ -249,7 +260,7 @@ ${summariseEntries(recent)}
       /** Search the user's own food log history. */
       search_food_history: tool({
         description:
-          "Search the user's past food log entries by name. Useful to reuse a previous entry's ingredient breakdown (including the serving size) instead of re-searching USDA.",
+          "Search the user's past food log entries by name. Useful to reuse a previous entry's ingredient breakdown (including the serving size) instead of re-searching the food database.",
         inputSchema: z.object({
           query: z.string().describe('Food name or keyword to search for in past entries'),
         }),
@@ -418,9 +429,9 @@ ${summariseEntries(recent)}
       }),
 
       /**
-       * Web search — fallback for foods USDA/OFF don't have (e.g. local restaurant items,
-       * branded boba). Only use after search_usda / search_foods_batch / lookup_barcode
-       * all return nothing useful. Always cite the source URL in your reply.
+       * Web search — fallback for foods not in the food database (e.g. local restaurant
+       * items, branded boba). Only use after search_foods / search_foods_batch /
+       * lookup_barcode all return nothing useful. Always cite the source URL in your reply.
        * Use ingredient source: 'manual' for web-derived items.
        */
       web_search: openai.tools.webSearch(),
@@ -435,6 +446,19 @@ ${summariseEntries(recent)}
         description:
           'Propose a structured food entry for the user to review and confirm. Call this once you are confident about food identity and portion. Each ingredient must include quantity, unit (a real household serving label), portions list, and grams = quantity × unit_grams. The user will see an editor pre-filled with these values and can adjust before saving.',
         inputSchema: proposeEntryArgsSchema,
+        execute: async (args) => JSON.parse(JSON.stringify(args)),
+      }),
+
+      /**
+       * propose_custom_food: echoes its validated args as output so the stream
+       * terminates cleanly. The client renders an inline MealBuilder pre-filled with
+       * these values; on confirm it POSTs to /nutrition/custom-foods itself.
+       * The agent does NOT write to the DB — this is a proposal-and-confirm flow.
+       */
+      propose_custom_food: tool({
+        description:
+          'Propose creating a reusable custom food or meal for the user\'s library. Call this when the user explicitly asks to save something for future reuse (e.g. "save this as my usual X", "add this to my library"). Set kind (food/meal), name, optional notes, ingredients with macros, and optional custom servings. The user will review the pre-filled form and can edit before confirming. Do NOT call this just because the user logged something once.',
+        inputSchema: proposeCustomFoodArgsSchema,
         execute: async (args) => JSON.parse(JSON.stringify(args)),
       }),
     },


### PR DESCRIPTION
## Summary

- **Source-agnostic rename**: `search_usda` → `search_foods` in `agent.ts` (tool key, description, and every reference inside the system-prompt template literal with backticks preserved). Both `search_foods` and `search_foods_batch` now call `providers.searchAllFoodsWithPortions(userUuid, …)` so custom items (`source:'custom'`) surface alongside USDA/OFF results. `TOOL_LABEL_MAP` updated: `search_usda` and `search_foods` → "Food search"; `propose_custom_food` added → "Save custom food".
- **System prompt updated**: removed USDA-specific language where source-agnostic wording fits better; added guidance that custom results should be preferred when they match what the user describes; added `propose_custom_food` usage instructions (when to call it, all builder fields, proposal-only/no silent writes).
- **New `propose_custom_food` tool**: added `proposeCustomFoodArgsSchema` (with `proposeCustomFoodIngredientSchema` and `proposeCustomFoodServingSchema`) in `schemas/nutrition.ts` and mirrored `ProposeCustomFoodArgs`/`ProposeCustomFoodIngredient`/`ProposeCustomFoodServing` in `client/src/features/nutrition/types.ts`. The tool echoes validated args via `JSON.parse(JSON.stringify(args))` to end the stream — identical pattern to `propose_entry`.
- **`MealBuilder` proposal mode**: added `proposalArgs`, `onConfirmProposal`, and `onDenyProposal` props. When `proposalArgs` is provided, the builder is pre-filled from agent args, autosave is suppressed, the Save button label changes to "Confirm" and calls `onConfirmProposal(payload)` instead of posting to the DB, and the close button calls `onDenyProposal`. Renders in-flow using new `proposalWrap`/`proposalSheet` CSS classes (no full-screen overlay). All existing MealBuilder usages unchanged.
- **`NutritionChat.tsx` inline card**: added `propose_custom_food` branch after the `propose_entry` block. Extracts args from tool output/input, renders inline `MealBuilder` in proposal mode. On confirm, calls `useCreateCustomFood().mutateAsync(payload)` and shows "Saved: {name}". On deny, shows declined state. Tracks confirmed/denied by partKey, same pattern as `propose_entry`. Clear-chat resets both proposal maps.

## Type-check results

- `npx tsc --noEmit` (repo root): ✅ clean
- `cd client && npx tsc --noEmit`: ✅ clean

## System-prompt backtick verification

All backtick tool-name references inside the `agent.ts` template literal remain properly escaped (e.g. `` \`search_foods\` ``, `` \`propose_custom_food\` ``). Verified by visual inspection — `tsc` would fail to parse the file if any were broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)