### PR TITLE
fix(client): pin react-is to fix clean-install Vite build

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -22,6 +22,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.80.0",
+        "react-is": "^18.3.1",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.0.2",
         "recharts": "^3.7.0",
@@ -4189,11 +4190,10 @@
       }
     },
     "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "license": "MIT",
-      "peer": true
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -18,6 +18,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.80.0",
+    "react-is": "^18.3.1",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.0.2",
     "recharts": "^3.7.0",


### PR DESCRIPTION
## Problem
`recharts@3` depends on `react-is`, but the client's `package.json` never declared it. It was only present transitively (deduped to `17.0.2` via `react-redux`), so a fresh `npm install` could omit it entirely — breaking `vite build` with an unresolved `react-is` import. This surfaced when a clean worktree install failed to build; master/Heroku happened to have it cached.

## Fix
Pin `react-is@^18.3.1` as a direct client dependency. It matches React 18 and satisfies both `recharts` (`^18`) and `react-redux`. Now `react-is` resolves to `18.3.1` and clean installs — including Heroku's release build — always include it.

## Verification
- `npm install` then `npx vite build` → ✅ builds clean
- `react-is` resolves to 18.3.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)