### PR TITLE
fix: tag provenance when logging a custom food/meal from search

### DIFF
--- a/client/src/features/nutrition/EntryEditor.tsx
+++ b/client/src/features/nutrition/EntryEditor.tsx
@@ -807,11 +807,21 @@ export default function EntryEditor({
       fat_g: r.fat_g,
     }));
 
+    // Detect provenance: if any ingredient row was filled from a custom food/meal,
+    // tag the entry with source='custom' and from_custom_food_id so that the
+    // recently-used list (which joins on from_custom_food_id) can bootstrap.
+    const customRow = rows.find(
+      r => r.source === 'custom' && r.source_ref != null && !isNaN(Number(r.source_ref)),
+    );
+    const entrySource: EntryInput['source'] = customRow ? 'custom' : 'manual';
+    const fromCustomFoodId = customRow ? Number(customRow.source_ref) : undefined;
+
     const input: EntryInput = {
       localDate: date,
       meal,
       name: effectiveName,
-      source: 'manual',
+      source: entrySource,
+      ...(fromCustomFoodId != null ? { from_custom_food_id: fromCustomFoodId } : {}),
       ingredients,
     };
 


### PR DESCRIPTION
## Summary

- **The bug**: Selecting a custom food/meal from the EntryEditor search dropdown and saving wrote `source='manual'` and `from_custom_food_id=NULL`, so the Recently Used list could never bootstrap — its backing query joins on `food_entries.from_custom_food_id`, which was always `NULL` for search-selected custom items.
- **The only path that previously set `from_custom_food_id`** was the quick-re-log handler, which only appears for items already in the recently-used list — a chicken-and-egg deadlock.
- **The fix** (client-only, one path): in `handleSave` inside `EntryEditor.tsx`, detect whether any ingredient row carries `source === 'custom'` with a numeric `source_ref`. If so, set the `EntryInput`'s `source: 'custom'` and `from_custom_food_id` to that id. Otherwise preserve the existing `source: 'manual'` behavior. Proposal-mode (`handleConfirm`) is untouched.
- No backend, schema, or migration changes needed — `store.createEntry` already persists both fields, `EntryInput` already carries `from_custom_food_id?`, and `ENTRY_SOURCES` already includes `'custom'`.

## Test plan
- [ ] In Add Food Entry, type a custom food/meal name, select it from the dropdown, and save.
- [ ] Confirm the resulting `food_entry` row in the DB has `source='custom'` and `from_custom_food_id` set to the custom food's id.
- [ ] The entry should now appear in Recently Used on next load.
- [ ] Logging a non-custom (USDA / OFF / manual) food still produces `source='manual'` with no `from_custom_food_id`.
- [ ] `cd client && npx tsc --noEmit` — clean.
- [ ] Root `npx tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)