### PR TITLE
feat: rename snack meal display label to "Snack / Other"

### DIFF
--- a/client/src/features/nutrition/EntryEditor.tsx
+++ b/client/src/features/nutrition/EntryEditor.tsx
@@ -26,7 +26,7 @@ import type {
   Per100g,
   ProposeIngredient,
 } from './types';
-import { MEALS } from './types';
+import { MEALS, MEAL_LABELS } from './types';
 import styles from './EntryEditor.module.scss';
 import { ScanBarcode } from 'lucide-react';
 
@@ -914,7 +914,7 @@ export default function EntryEditor({
             className={`${styles.mealBtn} ${meal === m ? styles.mealBtnActive : ''}`}
             onClick={() => setMeal(m)}
           >
-            {m.charAt(0).toUpperCase() + m.slice(1)}
+            {MEAL_LABELS[m]}
           </button>
         ))}
       </div>

--- a/client/src/features/nutrition/NutritionTracker.tsx
+++ b/client/src/features/nutrition/NutritionTracker.tsx
@@ -7,7 +7,7 @@ import MyFoodsSheet from './MyFoodsSheet';
 import MealBuilder from './MealBuilder';
 import ConfirmModal from '../../components/ConfirmModal.jsx';
 import type { EntryEditorMode, EntryRow, Meal, IngredientInput } from './types';
-import { MEALS } from './types';
+import { MEALS, MEAL_LABELS } from './types';
 import styles from './NutritionTracker.module.scss';
 import { MoreVertical, ChevronLeft, ChevronRight, Target, BookMarked } from 'lucide-react';
 
@@ -322,8 +322,7 @@ export default function NutritionTracker() {
     entries: entries.filter(e => e.meal === meal),
   })).filter(g => g.entries.length > 0);
 
-  const mealLabel = (meal: string) =>
-    meal.charAt(0).toUpperCase() + meal.slice(1);
+  const mealLabel = (meal: Meal) => MEAL_LABELS[meal];
 
   return (
     <section className={styles.container}>

--- a/client/src/features/nutrition/types.ts
+++ b/client/src/features/nutrition/types.ts
@@ -7,6 +7,13 @@ export type IngredientSource = 'usda' | 'off' | 'manual' | 'custom';
 
 export const MEALS: Meal[] = ['breakfast', 'lunch', 'dinner', 'snack'];
 
+export const MEAL_LABELS: Record<Meal, string> = {
+  breakfast: 'Breakfast',
+  lunch: 'Lunch',
+  dinner: 'Dinner',
+  snack: 'Snack / Other',
+};
+
 export interface Per100g {
   calories: number;
   protein_g: number;


### PR DESCRIPTION
## Summary
- Add `MEAL_LABELS: Record<Meal, string>` to `types.ts` with `snack: 'Snack / Other'` (all others retain their simple capitalized form)
- Replace the local `mealLabel` capitalize function in `NutritionTracker.tsx` with `MEAL_LABELS[meal]`
- Replace the inline `m.charAt(0).toUpperCase() + m.slice(1)` in `EntryEditor.tsx` meal selector with `MEAL_LABELS[m]`
- The stored/DB enum value `'snack'` is **not** changed — display-label only

Closes #138

## Test plan
- [ ] Open the nutrition tracker — the "Snack" section heading should now read "Snack / Other"
- [ ] Open the entry editor meal selector — the fourth button should read "Snack / Other"
- [ ] Verify Breakfast / Lunch / Dinner buttons are unchanged
- [ ] Log an entry with meal = snack and confirm the stored value is still `snack`

## Mobile fit note
The meal selector uses four equal-width buttons across the row. "Snack / Other" is 13 characters vs the previous "Snack" (5). On narrow (~375px) mobile widths the label will soft-wrap to two lines ("Snack /" + "Other") if the font/button sizing doesn't allow it to fit on one line. This is acceptable wrapping behavior; no CSS changes were made (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)