### PR TITLE
fix: persist assistant chat message when client disconnects mid-stream

### DIFF
--- a/client/src/features/nutrition/NutritionChat.tsx
+++ b/client/src/features/nutrition/NutritionChat.tsx
@@ -588,6 +588,14 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
     messages: initialMessages,
   });
 
+  // Keep a ref to the latest messages so the (stable) refetch callback can compare
+  // the incoming DB transcript against what's currently loaded without re-creating
+  // itself on every message change.
+  const messagesRef = useRef<UIMessage[]>(messages);
+  useEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
+
   // Persist messages on every change
   useEffect(() => {
     if (messages.length > 0) {
@@ -595,15 +603,36 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
     }
   }, [messages, selectedDate]);
 
-  // #15: Fetch transcript from DB on mount (DB is source of truth)
-  const fetchAndApplyTranscript = useCallback(async (date: string) => {
+  // #15: Fetch transcript from DB on mount (DB is source of truth).
+  //
+  // Bug fix (#chat-midstream-persistence, part 2): don't let a leaner DB transcript
+  // clobber a richer local cache. On return-after-disconnect the DB refetch could
+  // return fewer messages (e.g. only the user message) than what's currently loaded
+  // — a completed/partial assistant message. Combined with the effect above that
+  // persists `messages` to localStorage, blindly applying the shorter DB set would
+  // discard the more-complete transcript.
+  //
+  // Rule: the more-complete set wins. If the DB transcript has fewer messages than
+  // what's currently loaded, keep the loaded set (and re-save it, since a shorter DB
+  // may have overwritten the cache on a previous pass). Otherwise the DB version is
+  // at least as complete, so it wins — preserving DB-as-source-of-truth for the
+  // normal case and for runs that completed server-side while backgrounded.
+  const fetchAndApplyTranscript = useCallback(async (date: string, baseline?: UIMessage[]) => {
     try {
       const stored = await fetchTranscript(date);
-      if (stored.length > 0) {
-        const uiMessages = storedToUIMessages(stored);
-        setMessages(uiMessages);
-        saveMessagesForDate(date, uiMessages);
+      if (stored.length === 0) return;
+      const uiMessages = storedToUIMessages(stored);
+      // `baseline` is the known-correct current set for `date` (e.g. the freshly
+      // loaded cache on a day switch, where messagesRef may still hold the old day).
+      // Fall back to the live ref when no explicit baseline is given.
+      const current = baseline ?? messagesRef.current;
+      if (uiMessages.length < current.length) {
+        // DB is missing messages the cache/UI has — never lose them.
+        saveMessagesForDate(date, current);
+        return;
       }
+      setMessages(uiMessages);
+      saveMessagesForDate(date, uiMessages);
     } catch {
       // Silently fall back to localStorage cache
     }
@@ -621,7 +650,7 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
       loadedDateRef.current = selectedDate;
       const cached = loadMessagesForDate(selectedDate);
       setMessages(cached);
-      fetchAndApplyTranscript(selectedDate);
+      fetchAndApplyTranscript(selectedDate, cached);
     }
   }, [selectedDate, setMessages, fetchAndApplyTranscript]);
 

--- a/routes/nutrition.ts
+++ b/routes/nutrition.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { pipeUIMessageStreamToResponse } from 'ai';
+import { pipeUIMessageStreamToResponse, consumeStream } from 'ai';
 import { authenticateToken } from './auth';
 import { validateId } from '../utils/validation';
 import handleSqlError from '../utils/handleSqlError';
@@ -390,45 +390,58 @@ router.post('/chat', async (req, res): Promise<any> => {
       effort,
     });
 
-    // Track the in-progress assistant row so we can mark it interrupted if needed.
-    let assistantRowId: number | null = null;
+    // Build the UI message stream ONCE. Its onEnd callback persists the assistant
+    // UIMessage (with full parts: text/reasoning/tool-*) so that after reload, tool
+    // cards and reasoning render correctly.
+    //
+    // Bug fix (#chat-midstream-persistence): onEnd only fires when this UI-message
+    // stream is fully drained. Previously we only piped it to the HTTP response, so
+    // when the client disconnected mid-stream `res` stopped being written, the stream
+    // stopped being pulled, and onEnd NEVER fired — losing the assistant row.
+    // (`result.consumeStream()` on the BASE stream ran the model to completion but is a
+    // separate consumer; it does not drive this derived stream's onEnd.)
+    //
+    // Fix: tee the UI-message stream. Pipe one branch to the response for the client,
+    // and drain the other branch server-side with consumeStream(). The server-side
+    // drain guarantees the stream reaches completion — and thus onEnd fires exactly
+    // once — regardless of whether the client is still connected. onEnd lives on the
+    // single source stream, so persistence happens in exactly one place (no double-insert).
+    const uiStream = result.toUIMessageStream({
+      sendReasoning: true,
+      // #127: capture the final UIMessage (which has parts: text/reasoning/tool-*) so
+      // that persisted transcripts round-trip correctly after reload.
+      onEnd: async ({ responseMessage, isAborted }) => {
+        try {
+          const msgId = (responseMessage as { id?: string }).id ?? `asst-${Date.now()}`;
+          const parts = Array.isArray(responseMessage.parts) ? responseMessage.parts : [];
+          const assistantRowId = await appendMessage(uuid, date, msgId, 'assistant', parts);
+          if (isAborted && assistantRowId !== null) {
+            await markInterrupted(assistantRowId).catch(() => {});
+          }
+        } catch {
+          // best-effort — don't break anything
+        }
+      },
+      // #130: surface real error details (single-user personal app — leaking internals is fine)
+      onError: (error: unknown): string => {
+        if (error == null) return 'Unknown error';
+        if (typeof error === 'string') return error;
+        if (error instanceof Error) return error.message;
+        try { return JSON.stringify(error); } catch { return String(error); }
+      },
+    });
 
-    // Consume the stream on the server regardless of client connection, so onEnd fires.
-    // This means the run completes even if the client disconnects mid-stream.
-    result.consumeStream();
+    const [toClient, toDrain] = uiStream.tee();
 
-    // Stream the AI SDK UI message stream to the Express response using the
-    // standalone helper (avoids the deprecated result method).
-    // onEnd — persist the assistant UIMessage (with full parts: text, reasoning, tool-calls)
-    //   so that after page reload, tool calls and reasoning render correctly.
-    // onError — surface the real error detail to the client instead of the SDK's
-    //   generic "An error occurred." (#130).
+    // Drain one branch server-side so the run always completes and onEnd fires,
+    // even if the client has disconnected. Best-effort — never throw.
+    consumeStream({ stream: toDrain, onError: () => {} }).catch(() => {});
+
+    // Stream the other branch to the Express response using the standalone helper
+    // (avoids the deprecated result method).
     pipeUIMessageStreamToResponse({
       response: res,
-      stream: result.toUIMessageStream({
-        sendReasoning: true,
-        // #127: capture the final UIMessage (which has parts: text/reasoning/tool-*) so
-        // that persisted transcripts round-trip correctly after reload.
-        onEnd: async ({ responseMessage, isAborted }) => {
-          try {
-            const msgId = (responseMessage as { id?: string }).id ?? `asst-${Date.now()}`;
-            const parts = Array.isArray(responseMessage.parts) ? responseMessage.parts : [];
-            assistantRowId = await appendMessage(uuid, date, msgId, 'assistant', parts);
-            if (isAborted && assistantRowId !== null) {
-              await markInterrupted(assistantRowId).catch(() => {});
-            }
-          } catch {
-            // best-effort — don't break anything
-          }
-        },
-        // #130: surface real error details (single-user personal app — leaking internals is fine)
-        onError: (error: unknown): string => {
-          if (error == null) return 'Unknown error';
-          if (typeof error === 'string') return error;
-          if (error instanceof Error) return error.message;
-          try { return JSON.stringify(error); } catch { return String(error); }
-        },
-      }),
+      stream: toClient,
     });
   } catch (error) {
     // Only reached if streamText itself throws before streaming begins


### PR DESCRIPTION
## Summary
In the Nutrition AI chat, if the user sends a message then navigates away while the agent is still responding, the entire assistant response was lost — on return only the user message remained. This fixes the mid-stream-disconnect case of the chat-resume feature.

## Root cause
Assistant-message persistence lived in the `onEnd` callback of the derived UI-message stream (`result.toUIMessageStream(...)`), which only fires when that stream is fully drained. The only consumer of that stream was `pipeUIMessageStreamToResponse`, so when the client disconnected, `res` stopped being written, the UI stream stopped being pulled, and `onEnd` never fired — the assistant row was never inserted. `result.consumeStream()` drove the **base** stream to completion (the `ai_usage` row still wrote, proving the model ran server-side) but it's an independent consumer and does not drive the derived stream's `onEnd`. The user message survived because it's persisted eagerly before streaming.

## Changes
### Server — `routes/nutrition.ts` (the real bug)
Build the UI-message stream once and `tee()` it. Pipe one branch to the HTTP response for the client; drain the other branch server-side with `consumeStream()`. The server-side drain guarantees the source stream reaches completion — so `onEnd` fires exactly once — whether or not the client is still connected.
- **No double-insert:** `onEnd` stays on the single source stream, so persistence happens in exactly one place. Both branches of a tee read the same underlying data; there is one `onEnd`, one insert.
- Removed the now-redundant base-stream `result.consumeStream()` (the tee drain drives the whole pipeline).
- Preserved full UIMessage `parts` (text / reasoning / tool-* including `propose_entry` / `propose_custom_food`) so reload renders reasoning blocks, tool cards, and inline proposal cards.
- Preserved `isAborted` → `markInterrupted(rowId)`.
- Persistence stays best-effort (never throws into the stream).

### Client — `client/src/features/nutrition/NutritionChat.tsx` (cache clobber)
`fetchAndApplyTranscript` no longer lets a leaner DB snapshot overwrite a richer localStorage cache. It now keeps the more-complete set: if the DB transcript has fewer messages than what's currently loaded, it keeps (and re-saves) the loaded set; otherwise the DB version wins (DB stays source of truth when it is at least as complete). A `messagesRef` provides the current set without re-creating the stable callback; the day-switch effect passes the freshly-loaded cache as an explicit baseline so it doesn't compare against the previous day's messages.

## Assumptions
- "More complete" is measured by message count. In this app a turn is user-then-assistant, so a DB set missing the trailing assistant message is strictly shorter — count is a correct and simple proxy for "missing the assistant message."
- No schema/migration change needed; `chat_messages` already has the right columns.
- `ai` ^7.0.0: `toUIMessageStream()` returns a `ReadableStream` supporting `.tee()`, and `consumeStream({ stream })` drains a branch. Verified against the installed d.ts.

## Verification
- Backend `npm run build` (`tsc`) passes.
- `cd client && npm run build` (Vite/TS) passes.
- Reasoned through disconnect-mid-stream: model runs server-side, `toDrain` branch is drained regardless of `res`, source completes, `onEnd` fires, assistant row inserted with full parts; on return the client refetches and the merge keeps the complete transcript. Normal completed turn still yields exactly one assistant row (single `onEnd`). Clear-chat still empties both DB and cache (empty refetch no-ops). Day-switch loads the right day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)