### PR TITLE
feat: ingredient list redesign — summary cards + portaled bottom sheet (#144)

### DIFF
--- a/client/src/features/nutrition/EntryEditor.tsx
+++ b/client/src/features/nutrition/EntryEditor.tsx
@@ -11,36 +11,26 @@ import {
   useState,
   useCallback,
   useEffect,
-  useRef,
 } from 'react';
 import Modal from '../../components/Modal.jsx';
-import BarcodeScanner from './BarcodeScanner';
-import { useCreateEntry, useUpdateEntry, useFoodSearch, lookupBarcode, getPortions, getCustomFood } from './api';
+import { useCreateEntry, useUpdateEntry } from './api';
 import type {
   EntryEditorProps,
   Meal,
   IngredientInput,
   EntryInput,
-  FoodSearchResult,
   FoodPortion,
   ProposeIngredient,
 } from './types';
 import { MEALS, MEAL_LABELS } from './types';
 import styles from './EntryEditor.module.scss';
-import { ScanBarcode } from 'lucide-react';
+import IngredientSheet, { IngredientCardList } from './IngredientSheet';
 import {
-  portionsCache,
   GRAMS_UNIT,
   type EditorRow,
   nextKey,
   emptyRow,
   round2,
-  recomputeMacros,
-  immediatePortions,
-  rowFromFood,
-  buildPortionListFromFetched,
-  buildPortionList,
-  applyNewPortions,
 } from './ingredientMath';
 
 // ---------------------------------------------------------------------------
@@ -96,349 +86,6 @@ function rowFromProposedIngredient(ing: ProposeIngredient): EditorRow {
     // Macros already resolved; no per100g needed for live recompute.
     per100g: null,
   };
-}
-
-// ---------------------------------------------------------------------------
-// Debounce hook
-// ---------------------------------------------------------------------------
-function useDebounce<T>(value: T, delay: number): T {
-  const [debounced, setDebounced] = useState(value);
-  useEffect(() => {
-    const t = setTimeout(() => setDebounced(value), delay);
-    return () => clearTimeout(t);
-  }, [value, delay]);
-  return debounced;
-}
-
-// ---------------------------------------------------------------------------
-// Search dropdown for a single ingredient row
-// ---------------------------------------------------------------------------
-interface SearchDropdownProps {
-  query: string;
-  onSelect: (food: FoodSearchResult) => void;
-}
-
-function SearchDropdown({ query, onSelect }: SearchDropdownProps) {
-  const debouncedQuery = useDebounce(query, 300);
-  const { data: results = [], isFetching } = useFoodSearch(debouncedQuery);
-
-  if (!query.trim() || (results.length === 0 && !isFetching)) return null;
-
-  return (
-    <ul className={styles.dropdown} role="listbox">
-      {isFetching && (
-        <li className={styles.dropdownHint}>Searching…</li>
-      )}
-      {!isFetching && results.length === 0 && (
-        <li className={styles.dropdownHint}>No results</li>
-      )}
-      {results.map(food => (
-        <li
-          key={`${food.source}:${food.source_ref}`}
-          className={styles.dropdownItem}
-          role="option"
-          aria-selected={false}
-          onPointerDown={e => {
-            e.preventDefault();
-            onSelect(food);
-          }}
-        >
-          <span className={styles.dropdownName}>{food.name}</span>
-          <span className={styles.dropdownMeta}>
-            {food.per100g.calories} kcal/100g · {food.source === 'custom' ? (food.kind === 'meal' ? 'Custom · Meal' : food.kind === 'food' ? 'Custom · Food' : 'Custom') : food.source.toUpperCase()}
-          </span>
-        </li>
-      ))}
-    </ul>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Single ingredient row
-// ---------------------------------------------------------------------------
-interface IngredientRowProps {
-  row: EditorRow;
-  onChange: (updated: EditorRow) => void;
-  onRemove: () => void;
-  onOpenBarcode: () => void;
-  onExpandMeal?: (rows: EditorRow[]) => void;
-}
-
-function IngredientRowEditor({ row, onChange, onRemove, onOpenBarcode, onExpandMeal }: IngredientRowProps) {
-  const [searchQuery, setSearchQuery] = useState('');
-  const [showSearch, setShowSearch] = useState(false);
-
-  // ---- Async portion fetching for USDA foods ----
-  useEffect(() => {
-    if (row.source !== 'usda' || !row.source_ref) return;
-
-    const ref = row.source_ref;
-
-    if (portionsCache.has(ref)) {
-      const cached = portionsCache.get(ref)!;
-      const merged = buildPortionList(row, cached);
-      if (merged.length !== row.portions.length) {
-        onChange(applyNewPortions(row, merged));
-      }
-      return;
-    }
-
-    let cancelled = false;
-    getPortions('usda', ref).then(fetched => {
-      if (cancelled) return;
-      portionsCache.set(ref, fetched);
-      const merged = buildPortionList(row, fetched);
-      onChange(applyNewPortions(row, merged));
-    }).catch(() => {
-      // Silently ignore — user still has 'g' and any serving option.
-    });
-
-    return () => { cancelled = true; };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [row.source_ref]);
-
-  function handleNameChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const name = e.target.value;
-    setSearchQuery(name);
-    setShowSearch(true);
-    onChange({
-      ...row,
-      name,
-      source: 'manual',
-      source_ref: null,
-      per100g: null,
-      portions: [GRAMS_UNIT],
-      unitLabel: 'g',
-      unitGrams: 1,
-    });
-  }
-
-  function handleSelectFood(food: FoodSearchResult) {
-    setShowSearch(false);
-    setSearchQuery('');
-
-    // Custom meal: expand its ingredients as a snapshot into the editor rows.
-    if (food.source === 'custom' && food.kind === 'meal' && onExpandMeal) {
-      const id = parseInt(food.source_ref, 10);
-      if (!isNaN(id)) {
-        getCustomFood(id).then(customFood => {
-          const expandedRows: EditorRow[] = customFood.ingredients.map(ing => ({
-            rowKey: nextKey(),
-            name: ing.name,
-            grams: ing.grams,
-            quantity: ing.grams,
-            unitLabel: 'g',
-            unitGrams: 1,
-            portions: [GRAMS_UNIT],
-            source: ing.source,
-            source_ref: ing.source_ref ?? null,
-            calories: ing.calories,
-            protein_g: ing.protein_g,
-            carbs_g: ing.carbs_g,
-            fat_g: ing.fat_g,
-            fiber_g: ing.fiber_g ?? null,
-            sugar_g: ing.sugar_g ?? null,
-            sodium_mg: ing.sodium_mg ?? null,
-            per100g: null,
-          }));
-          onExpandMeal(expandedRows);
-        }).catch(() => {
-          // Fallback: add as single row with batch macros
-          onChange(rowFromFood(food, immediatePortions(food)));
-        });
-        return;
-      }
-    }
-
-    const cached = food.source === 'usda' && food.source_ref
-      ? portionsCache.get(food.source_ref)
-      : undefined;
-    const portions = cached
-      ? buildPortionListFromFetched(food, cached)
-      : immediatePortions(food);
-    onChange(rowFromFood(food, portions));
-  }
-
-  function handleQuantityChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const quantity = parseFloat(e.target.value) || 0;
-    const effectiveGrams = quantity * row.unitGrams;
-    if (row.per100g) {
-      onChange({ ...row, quantity, grams: effectiveGrams, ...recomputeMacros(row.per100g, effectiveGrams) });
-    } else {
-      onChange({ ...row, quantity, grams: effectiveGrams });
-    }
-  }
-
-  function handleUnitChange(e: React.ChangeEvent<HTMLSelectElement>) {
-    const label = e.target.value;
-    const selected = row.portions.find(p => p.label === label) ?? GRAMS_UNIT;
-    const effectiveGrams = row.quantity * selected.grams;
-    if (row.per100g) {
-      onChange({
-        ...row,
-        unitLabel: selected.label,
-        unitGrams: selected.grams,
-        grams: effectiveGrams,
-        ...recomputeMacros(row.per100g, effectiveGrams),
-      });
-    } else {
-      onChange({ ...row, unitLabel: selected.label, unitGrams: selected.grams, grams: effectiveGrams });
-    }
-  }
-
-  function handleMacroChange(field: 'calories' | 'protein_g' | 'carbs_g' | 'fat_g', value: string) {
-    onChange({ ...row, [field]: parseFloat(value) || 0 });
-  }
-
-  const macrosReadOnly = row.per100g !== null;
-  const showUnitDropdown = row.portions.length > 1;
-
-  return (
-    <div className={styles.row}>
-      <div className={styles.rowNameWrap}>
-        <div className={styles.rowNameInputWrap}>
-          <input
-            className={styles.input}
-            type="text"
-            placeholder="Ingredient name"
-            value={row.name}
-            onChange={handleNameChange}
-            onFocus={() => setShowSearch(true)}
-            onBlur={() => {
-              setTimeout(() => setShowSearch(false), 150);
-            }}
-            aria-label="Ingredient name"
-          />
-          {showSearch && (
-            <SearchDropdown query={searchQuery} onSelect={handleSelectFood} />
-          )}
-        </div>
-        <button
-          type="button"
-          className={styles.barcodeBtn}
-          onClick={onOpenBarcode}
-          aria-label="Scan barcode"
-          title="Scan barcode"
-        >
-          <ScanBarcode className={styles.barcodeIcon} size={16} aria-hidden="true" />
-        </button>
-      </div>
-
-      <div className={styles.rowNutrients}>
-        {/* Zone 1: Quantity + unit — stay together */}
-        <div className={styles.portionGroup}>
-          <label className={styles.nutrientLabel} aria-label="Quantity">
-            <span>Qty</span>
-            <input
-              className={styles.inputSmall}
-              type="number"
-              min="0"
-              step="0.1"
-              value={row.quantity === 0 ? '' : row.quantity}
-              onChange={handleQuantityChange}
-              aria-label="Quantity"
-            />
-          </label>
-          {showUnitDropdown ? (
-            <label className={styles.nutrientLabel}>
-              <span>Unit</span>
-              <select
-                className={styles.unitSelect}
-                value={row.unitLabel}
-                onChange={handleUnitChange}
-                aria-label="Unit"
-              >
-                {row.portions.map(p => (
-                  <option key={p.label} value={p.label}>
-                    {p.label === 'g' ? 'g' : `${p.label} (${p.grams}g)`}
-                  </option>
-                ))}
-              </select>
-            </label>
-          ) : (
-            <label className={styles.nutrientLabel}>
-              <span>Unit</span>
-              <span className={styles.unitStatic}>g</span>
-            </label>
-          )}
-        </div>
-
-        {/* Zone 2: Macro fields */}
-        <div className={styles.macrosGroup}>
-          <label className={styles.nutrientLabel}>
-            <span>kcal</span>
-            <input
-              className={styles.inputSmall}
-              type="number"
-              min="0"
-              step="0.1"
-              value={row.calories === 0 ? '' : row.calories}
-              onChange={e => handleMacroChange('calories', e.target.value)}
-              readOnly={macrosReadOnly}
-              aria-label="Calories"
-            />
-          </label>
-
-          <label className={styles.nutrientLabel}>
-            <span>Prot</span>
-            <input
-              className={styles.inputSmall}
-              type="number"
-              min="0"
-              step="0.1"
-              value={row.protein_g === 0 ? '' : row.protein_g}
-              onChange={e => handleMacroChange('protein_g', e.target.value)}
-              readOnly={macrosReadOnly}
-              aria-label="Protein g"
-            />
-          </label>
-
-          <label className={styles.nutrientLabel}>
-            <span>Carbs</span>
-            <input
-              className={styles.inputSmall}
-              type="number"
-              min="0"
-              step="0.1"
-              value={row.carbs_g === 0 ? '' : row.carbs_g}
-              onChange={e => handleMacroChange('carbs_g', e.target.value)}
-              readOnly={macrosReadOnly}
-              aria-label="Carbs g"
-            />
-          </label>
-
-          <label className={styles.nutrientLabel}>
-            <span>Fat</span>
-            <input
-              className={styles.inputSmall}
-              type="number"
-              min="0"
-              step="0.1"
-              value={row.fat_g === 0 ? '' : row.fat_g}
-              onChange={e => handleMacroChange('fat_g', e.target.value)}
-              readOnly={macrosReadOnly}
-              aria-label="Fat g"
-            />
-          </label>
-        </div>
-
-        <button
-          type="button"
-          className={styles.removeRowBtn}
-          onClick={onRemove}
-          aria-label="Remove ingredient"
-        >
-          ✕
-        </button>
-      </div>
-
-      {macrosReadOnly && (
-        <p className={styles.rowHint}>
-          Macros computed from per-100g values · adjust qty/unit to recalculate
-        </p>
-      )}
-    </div>
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -533,11 +180,9 @@ export default function EntryEditor({
     return [emptyRow()];
   });
 
-  // ----- Barcode scanner state -----
-  const [scanningRowKey, setScanningRowKey] = useState<number | null>(null);
-  const [barcodeError, setBarcodeError] = useState<string | null>(null);
-  const scanningRowKeyRef = useRef<number | null>(null);
-  scanningRowKeyRef.current = scanningRowKey;
+  // ----- Ingredient sheet state -----
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [editingRow, setEditingRow] = useState<EditorRow | null>(null);
 
   // ----- Error display -----
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -586,59 +231,60 @@ export default function EntryEditor({
   }, [open, inline, modeKind]);
 
   // ----- Row helpers -----
-  const updateRow = useCallback((key: number, updated: EditorRow) => {
-    setRows(prev => prev.map(r => (r.rowKey === key ? updated : r)));
-  }, []);
-
   const removeRow = useCallback((key: number) => {
     setRows(prev => prev.filter(r => r.rowKey !== key));
   }, []);
 
-  const addRow = useCallback(() => {
-    setRows(prev => [...prev, emptyRow()]);
-  }, []);
-
-  // Called when a custom meal is selected: replace the current empty row (or
-  // append if the row has content) with the meal's ingredient snapshot.
-  const handleExpandMeal = useCallback((rowKey: number, expandedRows: EditorRow[]) => {
+  // Called when a custom meal is selected: replace the editing row (if editing
+  // an empty row) or append the expanded rows.
+  const handleExpandMeal = useCallback((expandedRows: EditorRow[]) => {
     setRows(prev => {
-      const idx = prev.findIndex(r => r.rowKey === rowKey);
-      if (idx === -1) return [...prev, ...expandedRows];
-      // Replace the trigger row with the expanded rows only if it's still empty.
-      const trigger = prev[idx];
-      if (!trigger.name.trim()) {
-        return [...prev.slice(0, idx), ...expandedRows, ...prev.slice(idx + 1)];
+      if (editingRow !== null) {
+        const idx = prev.findIndex(r => r.rowKey === editingRow.rowKey);
+        if (idx !== -1 && !prev[idx].name.trim()) {
+          return [...prev.slice(0, idx), ...expandedRows, ...prev.slice(idx + 1)];
+        }
       }
       return [...prev, ...expandedRows];
     });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editingRow]);
+
+  // ----- Sheet open/close helpers -----
+  const openSheetForAdd = useCallback(() => {
+    setEditingRow(null);
+    setSheetOpen(true);
   }, []);
 
-  // ----- Barcode callbacks -----
-  const handleOpenBarcode = useCallback((rowKey: number) => {
-    setBarcodeError(null);
-    setScanningRowKey(rowKey);
+  const openSheetForEdit = useCallback((row: EditorRow) => {
+    setEditingRow(row);
+    setSheetOpen(true);
   }, []);
 
-  const handleBarcodeDetected = useCallback(async (code: string) => {
-    setScanningRowKey(null);
-    const targetKey = scanningRowKeyRef.current;
-    if (targetKey === null) return;
-    try {
-      const food = await lookupBarcode(code);
-      if (!food) {
-        setBarcodeError(`Barcode ${code} not found in database.`);
-        return;
+  const closeSheet = useCallback(() => {
+    setSheetOpen(false);
+    setEditingRow(null);
+  }, []);
+
+  // Sheet Done: add new row or update existing
+  const handleSheetDone = useCallback((row: EditorRow) => {
+    setRows(prev => {
+      const idx = prev.findIndex(r => r.rowKey === row.rowKey);
+      if (idx !== -1) {
+        // Update existing
+        return prev.map(r => (r.rowKey === row.rowKey ? row : r));
       }
-      const newRow = rowFromFood(food);
-      setRows(prev => prev.map(r => (r.rowKey === targetKey ? { ...newRow, rowKey: targetKey } : r)));
-    } catch {
-      setBarcodeError('Failed to look up barcode. Try again.');
-    }
+      // Add new
+      return [...prev, row];
+    });
   }, []);
 
-  const handleBarcodeClose = useCallback(() => {
-    setScanningRowKey(null);
-  }, []);
+  // Sheet Delete: remove the row being edited
+  const handleSheetDelete = useCallback(() => {
+    if (editingRow !== null) {
+      removeRow(editingRow.rowKey);
+    }
+  }, [editingRow, removeRow]);
 
   // ----- Save -----
   const firstValidIngredient = rows.find(r => r.name.trim().length > 0 && r.grams > 0);
@@ -776,34 +422,15 @@ export default function EntryEditor({
         />
       </div>
 
-      {/* Ingredient rows */}
+      {/* Ingredient cards + Add button */}
       <div className={styles.ingredientsSection}>
         <span className={styles.ingredientsLabel}>Ingredients</span>
-        <div className={styles.ingredientsList}>
-          {rows.map(row => (
-            <IngredientRowEditor
-              key={row.rowKey}
-              row={row}
-              onChange={updated => updateRow(row.rowKey, updated)}
-              onRemove={() => removeRow(row.rowKey)}
-              onOpenBarcode={() => handleOpenBarcode(row.rowKey)}
-              onExpandMeal={expandedRows => handleExpandMeal(row.rowKey, expandedRows)}
-            />
-          ))}
-        </div>
-        <button
-          type="button"
-          className={styles.addRowBtn}
-          onClick={addRow}
-        >
-          + Add ingredient
-        </button>
+        <IngredientCardList
+          rows={rows}
+          onEditRow={openSheetForEdit}
+          onAddRow={openSheetForAdd}
+        />
       </div>
-
-      {/* Barcode lookup error */}
-      {barcodeError && (
-        <p className={styles.errorMsg}>{barcodeError}</p>
-      )}
 
       {/* Live totals */}
       <Totals rows={rows} />
@@ -862,6 +489,19 @@ export default function EntryEditor({
     </div>
   );
 
+  // The portaled ingredient sheet is rendered outside of both inline and dialog modes
+  // so it always layers above the host container.
+  const ingredientSheet = (
+    <IngredientSheet
+      open={sheetOpen}
+      editRow={editingRow}
+      onClose={closeSheet}
+      onDone={handleSheetDone}
+      onDelete={editingRow !== null ? handleSheetDelete : undefined}
+      onExpandMeal={handleExpandMeal}
+    />
+  );
+
   // #9: inline mode — render as a card in the chat message thread, no Dialog
   if (inline) {
     return (
@@ -869,13 +509,7 @@ export default function EntryEditor({
         <div className={styles.inlineEditorCard}>
           {editorContent}
         </div>
-
-        {scanningRowKey !== null && (
-          <BarcodeScanner
-            onDetected={handleBarcodeDetected}
-            onClose={handleBarcodeClose}
-          />
-        )}
+        {ingredientSheet}
       </>
     );
   }
@@ -892,13 +526,7 @@ export default function EntryEditor({
       >
         {editorContent}
       </Modal>
-
-      {scanningRowKey !== null && (
-        <BarcodeScanner
-          onDetected={handleBarcodeDetected}
-          onClose={handleBarcodeClose}
-        />
-      )}
+      {ingredientSheet}
     </>
   );
 }

--- a/client/src/features/nutrition/IngredientSheet.module.scss
+++ b/client/src/features/nutrition/IngredientSheet.module.scss
@@ -1,0 +1,499 @@
+@import "../../styles/variables";
+
+// ---------------------------------------------------------------------------
+// IngredientSheet — portal bottom sheet for editing a single ingredient.
+// z-index 1100 so it appears above MealBuilder (1000) and inline chat editors.
+// ---------------------------------------------------------------------------
+
+// Scrim / overlay
+.overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.55);
+  z-index: 1100;
+  animation: fadeIn 140ms ease;
+}
+
+// Sheet container — slides up from bottom
+.sheet {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  max-width: 680px;
+  margin: 0 auto;
+  z-index: 1101;
+  background-color: $surface;
+  border-radius: 20px 20px 0 0;
+  display: flex;
+  flex-direction: column;
+  max-height: 92dvh;
+  padding-bottom: env(safe-area-inset-bottom);
+  animation: slideUp 250ms cubic-bezier(0.32, 0.72, 0, 1);
+
+  @media (min-width: #{$mobile-width + 1px}) {
+    border-radius: 20px;
+    max-height: 88dvh;
+    top: 50%;
+    bottom: auto;
+    transform: translateY(-50%);
+    animation: none;
+  }
+}
+
+// Header row: close button + title + primary action
+.header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 16px 12px;
+  border-bottom: 1px solid rgba($surface-border, 0.4);
+  flex-shrink: 0;
+}
+
+.headerTitle {
+  flex: 1;
+  margin: 0;
+  font-family: $sarabun;
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: $sarabun-spacing;
+  color: $text;
+}
+
+.closeBtn {
+  min-width: 36px;
+  min-height: 36px;
+  background: transparent;
+  border: none;
+  color: rgba($text, 0.5);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+
+  &:active {
+    background-color: rgba($text, 0.1);
+  }
+}
+
+// Done / primary action button in the header
+.doneBtn {
+  min-height: 36px;
+  padding: 6px 16px;
+  background-color: $primary;
+  color: $background;
+  border: none;
+  border-radius: 10px;
+  font-family: $sarabun;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: $sarabun-spacing;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+
+  &:not(:disabled):active {
+    background-color: $primary-dark;
+  }
+}
+
+// Scrollable body
+.body {
+  flex: 1;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 16px 16px 24px;
+}
+
+// ---------------------------------------------------------------------------
+// Single ingredient form — same visual language as EntryEditor/MealBuilder rows
+// ---------------------------------------------------------------------------
+
+// Name row (input + barcode button)
+.nameRow {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+  position: relative;
+}
+
+.nameInputWrap {
+  flex: 1;
+  position: relative;
+}
+
+// Full-width text input (name field, base size for reuse)
+.input {
+  background-color: transparent;
+  color: $text;
+  border: none;
+  border-bottom: 2px solid $primary-border;
+  padding: 6px 4px;
+  font-family: $sarabun;
+  font-size: 16px; // 16px prevents iOS auto-zoom on focus
+  letter-spacing: $sarabun-spacing;
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 44px;
+
+  &::placeholder {
+    color: rgba($text, 0.4);
+  }
+
+  &:focus {
+    outline: none;
+    border-bottom-color: $primary;
+  }
+}
+
+// Smaller numeric inputs
+.inputSmall {
+  background-color: transparent;
+  color: $text;
+  border: none;
+  border-bottom: 2px solid $primary-border;
+  padding: 4px 2px;
+  font-family: $sarabun;
+  font-size: 16px; // 16px prevents iOS zoom
+  letter-spacing: $sarabun-spacing;
+  min-height: 40px;
+  width: 80px;
+  text-align: right;
+  box-sizing: border-box;
+
+  &[readonly] {
+    color: rgba($text, 0.55);
+    border-bottom-style: dashed;
+  }
+
+  &:focus {
+    outline: none;
+    border-bottom-color: $primary;
+  }
+}
+
+.barcodeBtn {
+  flex-shrink: 0;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 8px;
+  background-color: transparent;
+  border: 2px solid $surface-border;
+  border-radius: 8px;
+  color: rgba($text, 0.7);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:active {
+    color: $primary;
+    border-color: $primary-border;
+  }
+}
+
+.barcodeIcon {
+  display: block; // iOS Safari SVG flex-child fix
+  width: 16px;
+  height: 16px;
+}
+
+// Portion / qty row
+.portionRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  align-items: flex-end;
+}
+
+.fieldLabel {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-family: $sarabun;
+  font-size: 11px;
+  letter-spacing: $sarabun-spacing;
+  color: rgba($text, 0.55);
+}
+
+.unitSelect {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-color: transparent;
+  color: $text;
+  border: none;
+  border-bottom: 2px solid $primary-border;
+  padding: 4px 24px 4px 2px;
+  font-family: $sarabun;
+  font-size: 16px; // 16px prevents iOS zoom
+  letter-spacing: $sarabun-spacing;
+  min-height: 40px;
+  min-width: 64px;
+  max-width: 180px;
+  cursor: pointer;
+  box-sizing: border-box;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath d='M1 1l5 5 5-5' stroke='%23EBEDE9' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round' fill='none'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 4px center;
+
+  &:focus {
+    outline: none;
+    border-bottom-color: $primary;
+  }
+
+  option {
+    background-color: $surface;
+    color: $text;
+  }
+}
+
+.unitStatic {
+  display: inline-block;
+  font-family: $sarabun;
+  font-size: 16px;
+  letter-spacing: $sarabun-spacing;
+  color: rgba($text, 0.55);
+  border-bottom: 2px solid rgba($surface-border, 0.5);
+  padding: 4px 2px;
+  min-height: 40px;
+  min-width: 28px;
+  box-sizing: border-box;
+  line-height: 1.6;
+}
+
+// Macros grid inside the sheet body
+.macrosSection {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.macrosSectionLabel {
+  font-family: $sarabun;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: $sarabun-spacing;
+  color: rgba($text, 0.6);
+  text-transform: uppercase;
+}
+
+.macrosGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 16px;
+  align-items: flex-end;
+}
+
+.rowHint {
+  margin: 0;
+  font-family: $sarabun;
+  font-size: 11px;
+  color: rgba($text, 0.4);
+  letter-spacing: $sarabun-spacing;
+}
+
+// Search dropdown (positioned inside .nameInputWrap)
+.dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  z-index: 1200; // above sheet (1101)
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+  background-color: $surface;
+  border: 1px solid $surface-border;
+  border-radius: 10px;
+  max-height: 220px;
+  overflow-y: auto;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.55);
+}
+
+.dropdownItem {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px 14px;
+  cursor: pointer;
+
+  &:active {
+    background-color: rgba($primary, 0.12);
+  }
+}
+
+.dropdownName {
+  font-family: $sarabun;
+  font-size: 15px;
+  color: $text;
+  letter-spacing: $sarabun-spacing;
+}
+
+.dropdownMeta {
+  font-family: $sarabun;
+  font-size: 12px;
+  color: rgba($text, 0.5);
+  letter-spacing: $sarabun-spacing;
+}
+
+.dropdownHint {
+  padding: 10px 14px;
+  font-family: $sarabun;
+  font-size: 14px;
+  color: rgba($text, 0.5);
+  letter-spacing: $sarabun-spacing;
+}
+
+// Delete button — shown in edit mode at the bottom
+.deleteBtn {
+  align-self: flex-start;
+  min-height: 44px;
+  padding: 10px 20px;
+  background-color: transparent;
+  color: $error;
+  border: 2px solid rgba($error, 0.4);
+  border-radius: 10px;
+  font-family: $sarabun;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: $sarabun-spacing;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+
+  &:active {
+    background-color: rgba($error, 0.1);
+    border-color: $error;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Ingredient summary cards (shown in list before opening sheet)
+// ---------------------------------------------------------------------------
+
+.cardList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.card {
+  background-color: rgba($background, 0.5);
+  border: 1px solid rgba($surface-border, 0.5);
+  border-radius: 12px;
+  padding: 12px 14px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  -webkit-tap-highlight-color: transparent;
+
+  &:active {
+    background-color: rgba($primary, 0.07);
+    border-color: rgba($primary-border, 0.35);
+  }
+}
+
+.cardContent {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.cardName {
+  font-family: $sarabun;
+  font-size: 15px;
+  font-weight: 600;
+  color: $text;
+  letter-spacing: $sarabun-spacing;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cardMacros {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.cardCalories {
+  font-family: $sarabun;
+  font-size: 14px;
+  font-weight: 700;
+  color: $primary;
+  letter-spacing: $sarabun-spacing;
+  flex-shrink: 0;
+}
+
+.macroChips {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.chip {
+  font-family: $sarabun;
+  font-size: 12px;
+  letter-spacing: $sarabun-spacing;
+  color: rgba($text, 0.6);
+  background-color: rgba($text, 0.08);
+  border-radius: 5px;
+  padding: 2px 7px;
+  white-space: nowrap;
+}
+
+.cardChevron {
+  display: block; // iOS Safari SVG fix
+  flex-shrink: 0;
+  color: rgba($text, 0.3);
+}
+
+// Add ingredient button
+.addBtn {
+  align-self: flex-start;
+  min-height: 44px;
+  padding: 8px 16px;
+  background-color: transparent;
+  color: $primary;
+  border: 2px dashed $primary-border;
+  border-radius: 10px;
+  font-family: $sarabun;
+  font-size: 15px;
+  letter-spacing: $sarabun-spacing;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+
+  &:active {
+    background-color: $primary-translucent;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Animations
+// ---------------------------------------------------------------------------
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes slideUp {
+  from { transform: translateY(48px); opacity: 0; }
+  to   { transform: translateY(0);    opacity: 1; }
+}

--- a/client/src/features/nutrition/IngredientSheet.tsx
+++ b/client/src/features/nutrition/IngredientSheet.tsx
@@ -1,0 +1,611 @@
+/**
+ * IngredientSheet — reusable bottom-sheet editor for a single ingredient row.
+ *
+ * Portaled to document.body so it always overlays correctly even when rendered
+ * inside an inline chat proposal card or inside MealBuilder's own sheet.
+ *
+ * Usage pattern (two sub-components exported):
+ *   <IngredientCardList>   — renders the static summary cards + "Add ingredient" button.
+ *   <IngredientSheet>      — the actual portal sheet (controls its own open state via onClose).
+ *
+ * Callers (EntryEditor, MealBuilder) lift the state: they own the `rows` array
+ * and call sheet callbacks to add / update / remove rows.
+ */
+import {
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+} from 'react';
+import { createPortal } from 'react-dom';
+import BarcodeScanner from './BarcodeScanner';
+import { useFoodSearch, lookupBarcode, getPortions, getCustomFood } from './api';
+import type {
+  FoodSearchResult,
+  FoodPortion,
+  IngredientSource,
+} from './types';
+import styles from './IngredientSheet.module.scss';
+import { X, Plus, Trash2, ChevronRight, ScanBarcode } from 'lucide-react';
+import {
+  portionsCache,
+  GRAMS_UNIT,
+  type EditorRow,
+  nextKey,
+  emptyRow,
+  round2,
+  recomputeMacros,
+  immediatePortions,
+  rowFromFood,
+  buildPortionListFromFetched,
+  buildPortionList,
+  applyNewPortions,
+} from './ingredientMath';
+
+// ---------------------------------------------------------------------------
+// Debounce hook
+// ---------------------------------------------------------------------------
+function useDebounce<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(t);
+  }, [value, delay]);
+  return debounced;
+}
+
+// ---------------------------------------------------------------------------
+// Search dropdown inside the sheet
+// ---------------------------------------------------------------------------
+interface SearchDropdownProps {
+  query: string;
+  onSelect: (food: FoodSearchResult) => void;
+}
+
+function SearchDropdown({ query, onSelect }: SearchDropdownProps) {
+  const debouncedQuery = useDebounce(query, 300);
+  const { data: results = [], isFetching } = useFoodSearch(debouncedQuery);
+
+  if (!query.trim() || (results.length === 0 && !isFetching)) return null;
+
+  return (
+    <ul className={styles.dropdown} role="listbox">
+      {isFetching && <li className={styles.dropdownHint}>Searching…</li>}
+      {!isFetching && results.length === 0 && (
+        <li className={styles.dropdownHint}>No results</li>
+      )}
+      {results.map(food => (
+        <li
+          key={`${food.source}:${food.source_ref}`}
+          className={styles.dropdownItem}
+          role="option"
+          aria-selected={false}
+          onPointerDown={e => {
+            e.preventDefault();
+            onSelect(food);
+          }}
+        >
+          <span className={styles.dropdownName}>{food.name}</span>
+          <span className={styles.dropdownMeta}>
+            {food.per100g.calories} kcal/100g ·{' '}
+            {food.source === 'custom'
+              ? food.kind === 'meal'
+                ? 'Custom · Meal'
+                : 'Custom · Food'
+              : food.source.toUpperCase()}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// The single-ingredient form rendered inside the sheet
+// ---------------------------------------------------------------------------
+interface IngredientFormProps {
+  row: EditorRow;
+  onChange: (updated: EditorRow) => void;
+  onExpandMeal?: (rows: EditorRow[]) => void;
+  /** Called when user taps the barcode button inside the sheet */
+  onOpenBarcode: () => void;
+}
+
+function IngredientForm({ row, onChange, onExpandMeal, onOpenBarcode }: IngredientFormProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [showSearch, setShowSearch] = useState(false);
+
+  // ---- Async portion fetching for USDA foods ----
+  useEffect(() => {
+    if (row.source !== 'usda' || !row.source_ref) return;
+    const ref = row.source_ref;
+
+    if (portionsCache.has(ref)) {
+      const cached = portionsCache.get(ref)!;
+      const merged = buildPortionList(row, cached);
+      if (merged.length !== row.portions.length) {
+        onChange(applyNewPortions(row, merged));
+      }
+      return;
+    }
+
+    let cancelled = false;
+    getPortions('usda', ref)
+      .then(fetched => {
+        if (cancelled) return;
+        portionsCache.set(ref, fetched);
+        const merged = buildPortionList(row, fetched);
+        onChange(applyNewPortions(row, merged));
+      })
+      .catch(() => {/* silently ignore — 'g' still available */});
+
+    return () => { cancelled = true; };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [row.source_ref]);
+
+  function handleNameChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const name = e.target.value;
+    setSearchQuery(name);
+    setShowSearch(true);
+    onChange({
+      ...row,
+      name,
+      source: 'manual',
+      source_ref: null,
+      per100g: null,
+      portions: [GRAMS_UNIT],
+      unitLabel: 'g',
+      unitGrams: 1,
+    });
+  }
+
+  function handleSelectFood(food: FoodSearchResult) {
+    setShowSearch(false);
+    setSearchQuery('');
+
+    // Custom meal: expand its ingredients as a snapshot
+    if (food.source === 'custom' && food.kind === 'meal' && onExpandMeal) {
+      const id = parseInt(food.source_ref, 10);
+      if (!isNaN(id)) {
+        getCustomFood(id)
+          .then(customFood => {
+            const expandedRows: EditorRow[] = customFood.ingredients.map(ing => ({
+              rowKey: nextKey(),
+              name: ing.name,
+              grams: ing.grams,
+              quantity: ing.grams,
+              unitLabel: 'g',
+              unitGrams: 1,
+              portions: [GRAMS_UNIT],
+              source: ing.source as IngredientSource,
+              source_ref: ing.source_ref ?? null,
+              calories: ing.calories,
+              protein_g: ing.protein_g,
+              carbs_g: ing.carbs_g,
+              fat_g: ing.fat_g,
+              fiber_g: ing.fiber_g ?? null,
+              sugar_g: ing.sugar_g ?? null,
+              sodium_mg: ing.sodium_mg ?? null,
+              per100g: null,
+            }));
+            onExpandMeal(expandedRows);
+          })
+          .catch(() => {
+            onChange(rowFromFood(food, immediatePortions(food)));
+          });
+        return;
+      }
+    }
+
+    const cached =
+      food.source === 'usda' && food.source_ref
+        ? portionsCache.get(food.source_ref)
+        : undefined;
+    const portions = cached
+      ? buildPortionListFromFetched(food, cached)
+      : immediatePortions(food);
+    onChange(rowFromFood(food, portions));
+  }
+
+  function handleQuantityChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const quantity = parseFloat(e.target.value) || 0;
+    const effectiveGrams = quantity * row.unitGrams;
+    if (row.per100g) {
+      onChange({ ...row, quantity, grams: effectiveGrams, ...recomputeMacros(row.per100g, effectiveGrams) });
+    } else {
+      onChange({ ...row, quantity, grams: effectiveGrams });
+    }
+  }
+
+  function handleUnitChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const label = e.target.value;
+    const selected = row.portions.find(p => p.label === label) ?? GRAMS_UNIT;
+    const effectiveGrams = row.quantity * selected.grams;
+    if (row.per100g) {
+      onChange({
+        ...row,
+        unitLabel: selected.label,
+        unitGrams: selected.grams,
+        grams: effectiveGrams,
+        ...recomputeMacros(row.per100g, effectiveGrams),
+      });
+    } else {
+      onChange({ ...row, unitLabel: selected.label, unitGrams: selected.grams, grams: effectiveGrams });
+    }
+  }
+
+  function handleMacroChange(
+    field: 'calories' | 'protein_g' | 'carbs_g' | 'fat_g',
+    value: string,
+  ) {
+    onChange({ ...row, [field]: parseFloat(value) || 0 });
+  }
+
+  const macrosReadOnly = row.per100g !== null;
+  const showUnitDropdown = row.portions.length > 1;
+
+  return (
+    <>
+      {/* Name + barcode */}
+      <div className={styles.nameRow}>
+        <div className={styles.nameInputWrap}>
+          <input
+            className={styles.input}
+            type="text"
+            placeholder="Ingredient name"
+            value={row.name}
+            onChange={handleNameChange}
+            onFocus={() => setShowSearch(true)}
+            onBlur={() => setTimeout(() => setShowSearch(false), 150)}
+            aria-label="Ingredient name"
+          />
+          {showSearch && (
+            <SearchDropdown query={searchQuery} onSelect={handleSelectFood} />
+          )}
+        </div>
+        <button
+          type="button"
+          className={styles.barcodeBtn}
+          onClick={onOpenBarcode}
+          aria-label="Scan barcode"
+          title="Scan barcode"
+        >
+          <ScanBarcode className={styles.barcodeIcon} size={16} aria-hidden="true" />
+        </button>
+      </div>
+
+      {/* Qty + Unit */}
+      <div className={styles.portionRow}>
+        <label className={styles.fieldLabel} aria-label="Quantity">
+          <span>Qty</span>
+          <input
+            className={styles.inputSmall}
+            type="number"
+            min="0"
+            step="0.1"
+            value={row.quantity === 0 ? '' : row.quantity}
+            onChange={handleQuantityChange}
+            aria-label="Quantity"
+          />
+        </label>
+        {showUnitDropdown ? (
+          <label className={styles.fieldLabel}>
+            <span>Unit</span>
+            <select
+              className={styles.unitSelect}
+              value={row.unitLabel}
+              onChange={handleUnitChange}
+              aria-label="Unit"
+            >
+              {row.portions.map(p => (
+                <option key={p.label} value={p.label}>
+                  {p.label === 'g' ? 'g' : `${p.label} (${p.grams}g)`}
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : (
+          <label className={styles.fieldLabel}>
+            <span>Unit</span>
+            <span className={styles.unitStatic}>g</span>
+          </label>
+        )}
+      </div>
+
+      {/* Macro fields */}
+      <div className={styles.macrosSection}>
+        <span className={styles.macrosSectionLabel}>Macros</span>
+        <div className={styles.macrosGrid}>
+          <label className={styles.fieldLabel}>
+            <span>kcal</span>
+            <input
+              className={styles.inputSmall}
+              type="number"
+              min="0"
+              step="0.1"
+              value={row.calories === 0 ? '' : row.calories}
+              onChange={e => handleMacroChange('calories', e.target.value)}
+              readOnly={macrosReadOnly}
+              aria-label="Calories"
+            />
+          </label>
+          <label className={styles.fieldLabel}>
+            <span>Prot</span>
+            <input
+              className={styles.inputSmall}
+              type="number"
+              min="0"
+              step="0.1"
+              value={row.protein_g === 0 ? '' : row.protein_g}
+              onChange={e => handleMacroChange('protein_g', e.target.value)}
+              readOnly={macrosReadOnly}
+              aria-label="Protein g"
+            />
+          </label>
+          <label className={styles.fieldLabel}>
+            <span>Carbs</span>
+            <input
+              className={styles.inputSmall}
+              type="number"
+              min="0"
+              step="0.1"
+              value={row.carbs_g === 0 ? '' : row.carbs_g}
+              onChange={e => handleMacroChange('carbs_g', e.target.value)}
+              readOnly={macrosReadOnly}
+              aria-label="Carbs g"
+            />
+          </label>
+          <label className={styles.fieldLabel}>
+            <span>Fat</span>
+            <input
+              className={styles.inputSmall}
+              type="number"
+              min="0"
+              step="0.1"
+              value={row.fat_g === 0 ? '' : row.fat_g}
+              onChange={e => handleMacroChange('fat_g', e.target.value)}
+              readOnly={macrosReadOnly}
+              aria-label="Fat g"
+            />
+          </label>
+        </div>
+        {macrosReadOnly && (
+          <p className={styles.rowHint}>
+            Macros computed from per-100g values · adjust qty/unit to recalculate
+          </p>
+        )}
+      </div>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// IngredientSheet — the portal sheet itself
+// ---------------------------------------------------------------------------
+export interface IngredientSheetProps {
+  /**
+   * When open, the sheet is visible.
+   * If editRow is provided, the sheet opens in "edit" mode (pre-filled + Delete button).
+   * If editRow is null/undefined, the sheet opens in "add" mode (blank form + Add action).
+   */
+  open: boolean;
+  editRow?: EditorRow | null;
+  onClose: () => void;
+  /** Called with the new/updated row when Done is tapped. */
+  onDone: (row: EditorRow) => void;
+  /** Called when Delete is tapped in edit mode. */
+  onDelete?: () => void;
+  /**
+   * Called when the user selects a custom meal that should expand into multiple rows.
+   * The sheet closes itself and passes the expanded rows up.
+   */
+  onExpandMeal?: (rows: EditorRow[]) => void;
+}
+
+export default function IngredientSheet({
+  open,
+  editRow,
+  onClose,
+  onDone,
+  onDelete,
+  onExpandMeal,
+}: IngredientSheetProps) {
+  const isEdit = editRow != null;
+  const [row, setRow] = useState<EditorRow>(() => editRow ?? emptyRow());
+  const [barcodeOpen, setBarcodeOpen] = useState(false);
+  const [barcodeError, setBarcodeError] = useState<string | null>(null);
+
+  // Reset inner state whenever the sheet opens or switches to a different row.
+  useEffect(() => {
+    if (open) {
+      setRow(editRow ?? emptyRow());
+      setBarcodeError(null);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, editRow?.rowKey]);
+
+  // Close on Escape key
+  useEffect(() => {
+    if (!open) return;
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [open, onClose]);
+
+  const handleOpenBarcode = useCallback(() => {
+    setBarcodeError(null);
+    setBarcodeOpen(true);
+  }, []);
+
+  const handleBarcodeDetected = useCallback(async (code: string) => {
+    setBarcodeOpen(false);
+    try {
+      const food = await lookupBarcode(code);
+      if (!food) {
+        setBarcodeError(`Barcode ${code} not found in database.`);
+        return;
+      }
+      setRow(rowFromFood(food));
+    } catch {
+      setBarcodeError('Failed to look up barcode. Try again.');
+    }
+  }, []);
+
+  const handleExpandMeal = useCallback((expandedRows: EditorRow[]) => {
+    onExpandMeal?.(expandedRows);
+    onClose();
+  }, [onExpandMeal, onClose]);
+
+  const handleDone = useCallback(() => {
+    onDone(row);
+    onClose();
+  }, [row, onDone, onClose]);
+
+  const handleDelete = useCallback(() => {
+    onDelete?.();
+    onClose();
+  }, [onDelete, onClose]);
+
+  if (!open) return null;
+
+  const title = isEdit ? 'Edit ingredient' : 'Add ingredient';
+  const canDone = row.name.trim().length > 0;
+
+  const sheetContent = (
+    <>
+      {/* Scrim — tap to close */}
+      <div
+        className={styles.overlay}
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Sheet panel */}
+      <div
+        className={styles.sheet}
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+      >
+        {/* Header */}
+        <div className={styles.header}>
+          <button
+            type="button"
+            className={styles.closeBtn}
+            onClick={onClose}
+            aria-label="Close"
+          >
+            <X size={16} aria-hidden="true" style={{ display: 'block' }} />
+          </button>
+          <h2 className={styles.headerTitle}>{title}</h2>
+          <button
+            type="button"
+            className={styles.doneBtn}
+            onClick={handleDone}
+            disabled={!canDone}
+          >
+            {isEdit ? 'Done' : 'Add'}
+          </button>
+        </div>
+
+        {/* Form */}
+        <div className={styles.body}>
+          <IngredientForm
+            row={row}
+            onChange={setRow}
+            onOpenBarcode={handleOpenBarcode}
+            onExpandMeal={onExpandMeal ? handleExpandMeal : undefined}
+          />
+
+          {barcodeError && (
+            <p className={styles.rowHint} style={{ color: 'var(--error, #ED1518)' }}>
+              {barcodeError}
+            </p>
+          )}
+
+          {/* Delete button — only shown in edit mode */}
+          {isEdit && onDelete && (
+            <button
+              type="button"
+              className={styles.deleteBtn}
+              onClick={handleDelete}
+            >
+              <Trash2 size={16} aria-hidden="true" style={{ display: 'block' }} />
+              Delete ingredient
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Barcode scanner — renders inside portal to overlay everything */}
+      {barcodeOpen && (
+        <BarcodeScanner
+          onDetected={handleBarcodeDetected}
+          onClose={() => setBarcodeOpen(false)}
+        />
+      )}
+    </>
+  );
+
+  return createPortal(sheetContent, document.body);
+}
+
+// ---------------------------------------------------------------------------
+// IngredientCardList — static summary cards + "Add ingredient" button.
+// Rendered in the editor view (not portaled).
+// ---------------------------------------------------------------------------
+export interface IngredientCardListProps {
+  rows: EditorRow[];
+  /** Called with the row that was tapped — caller opens the sheet in edit mode. */
+  onEditRow: (row: EditorRow) => void;
+  /** Called when "Add ingredient" is tapped — caller opens the sheet in add mode. */
+  onAddRow: () => void;
+}
+
+export function IngredientCardList({ rows, onEditRow, onAddRow }: IngredientCardListProps) {
+  return (
+    <div className={styles.cardList}>
+      {rows.map(row => (
+        <button
+          key={row.rowKey}
+          type="button"
+          className={styles.card}
+          onClick={() => onEditRow(row)}
+          aria-label={`Edit ${row.name || 'ingredient'}`}
+        >
+          <div className={styles.cardContent}>
+            <span className={styles.cardName}>
+              {row.name || <span style={{ opacity: 0.4 }}>Untitled ingredient</span>}
+            </span>
+            <div className={styles.cardMacros}>
+              <span className={styles.cardCalories}>
+                {Math.round(row.calories)} kcal
+              </span>
+              <div className={styles.macroChips}>
+                <span className={styles.chip}>P {round2(row.protein_g)}g</span>
+                <span className={styles.chip}>C {round2(row.carbs_g)}g</span>
+                <span className={styles.chip}>F {round2(row.fat_g)}g</span>
+              </div>
+            </div>
+          </div>
+          <ChevronRight
+            className={styles.cardChevron}
+            size={16}
+            aria-hidden="true"
+          />
+        </button>
+      ))}
+
+      <button
+        type="button"
+        className={styles.addBtn}
+        onClick={onAddRow}
+      >
+        <Plus size={16} aria-hidden="true" style={{ display: 'block' }} />
+        Add ingredient
+      </button>
+    </div>
+  );
+}

--- a/client/src/features/nutrition/MealBuilder.tsx
+++ b/client/src/features/nutrition/MealBuilder.tsx
@@ -22,10 +22,8 @@ import {
   useCallback,
   useRef,
 } from 'react';
-import { useFoodSearch, useCreateCustomFood, useUpdateCustomFood, getCustomFood } from './api';
+import { useCreateCustomFood, useUpdateCustomFood } from './api';
 import type {
-  FoodSearchResult,
-  FoodPortion,
   CustomFoodRow,
   CustomFoodInput,
   CustomServing,
@@ -35,19 +33,18 @@ import type {
 } from './types';
 import styles from './MealBuilder.module.scss';
 import { X, Plus, Trash2 } from 'lucide-react';
+import IngredientSheet, { IngredientCardList } from './IngredientSheet';
 import {
   GRAMS_UNIT,
   type EditorRow as BuilderRow,
   nextKey,
   emptyRow as emptyBuilderRow,
   round2,
-  recomputeMacros,
-  rowFromFood,
   sumRows,
 } from './ingredientMath';
 
 // ---------------------------------------------------------------------------
-// Debounce hook
+// Debounce hook (used for autosave)
 // ---------------------------------------------------------------------------
 function useDebounce<T>(value: T, delay: number): T {
   const [debounced, setDebounced] = useState(value);
@@ -56,210 +53,6 @@ function useDebounce<T>(value: T, delay: number): T {
     return () => clearTimeout(t);
   }, [value, delay]);
   return debounced;
-}
-
-// ---------------------------------------------------------------------------
-// Mini search dropdown for ingredient rows
-// ---------------------------------------------------------------------------
-interface DropdownProps {
-  query: string;
-  onSelect: (food: FoodSearchResult) => void;
-}
-
-function IngredientDropdown({ query, onSelect }: DropdownProps) {
-  const debouncedQ = useDebounce(query, 300);
-  const { data: results = [], isFetching } = useFoodSearch(debouncedQ);
-
-  if (!query.trim() || (results.length === 0 && !isFetching)) return null;
-
-  return (
-    <ul className={styles.dropdown} role="listbox">
-      {isFetching && <li className={styles.dropdownHint}>Searching…</li>}
-      {!isFetching && results.length === 0 && <li className={styles.dropdownHint}>No results</li>}
-      {results.map(food => (
-        <li
-          key={`${food.source}:${food.source_ref}`}
-          className={styles.dropdownItem}
-          role="option"
-          aria-selected={false}
-          onPointerDown={e => { e.preventDefault(); onSelect(food); }}
-        >
-          <span className={styles.dropdownName}>{food.name}</span>
-          <span className={styles.dropdownMeta}>
-            {food.per100g.calories} kcal/100g ·{' '}
-            {food.source === 'custom'
-              ? (food.kind === 'meal' ? 'Custom · Meal' : food.kind === 'food' ? 'Custom · Food' : 'Custom')
-              : food.source.toUpperCase()}
-          </span>
-        </li>
-      ))}
-    </ul>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Single ingredient row for MealBuilder
-// ---------------------------------------------------------------------------
-interface IngredientRowProps {
-  row: BuilderRow;
-  onChange: (updated: BuilderRow) => void;
-  onRemove: () => void;
-  onExpandMeal?: (rows: BuilderRow[]) => void;
-}
-
-function BuilderIngredientRow({ row, onChange, onRemove, onExpandMeal }: IngredientRowProps) {
-  const [searchQuery, setSearchQuery] = useState('');
-  const [showSearch, setShowSearch] = useState(false);
-
-  function handleNameChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const name = e.target.value;
-    setSearchQuery(name);
-    setShowSearch(true);
-    onChange({ ...row, name, source: 'manual', source_ref: null, per100g: null, portions: [GRAMS_UNIT], unitLabel: 'g', unitGrams: 1 });
-  }
-
-  async function handleSelectFood(food: FoodSearchResult) {
-    setShowSearch(false);
-    setSearchQuery('');
-
-    // Custom meal: expand ingredients as snapshot rows
-    if (food.source === 'custom' && food.kind === 'meal' && onExpandMeal) {
-      const id = parseInt(food.source_ref, 10);
-      if (!isNaN(id)) {
-        try {
-          const customFood = await getCustomFood(id);
-          const expandedRows: BuilderRow[] = customFood.ingredients.map(ing => ({
-            rowKey: nextKey(),
-            name: ing.name,
-            grams: ing.grams,
-            quantity: ing.grams,
-            unitLabel: 'g',
-            unitGrams: 1,
-            portions: [GRAMS_UNIT],
-            source: ing.source as IngredientSource,
-            source_ref: ing.source_ref ?? null,
-            calories: ing.calories,
-            protein_g: ing.protein_g,
-            carbs_g: ing.carbs_g,
-            fat_g: ing.fat_g,
-            fiber_g: ing.fiber_g ?? null,
-            sugar_g: ing.sugar_g ?? null,
-            sodium_mg: ing.sodium_mg ?? null,
-            per100g: null,
-          }));
-          onExpandMeal(expandedRows);
-        } catch {
-          onChange(rowFromFood(food));
-        }
-        return;
-      }
-    }
-
-    // Custom food or external: add as single row with custom portions
-    const portions: FoodPortion[] = food.source === 'custom' && food.portions?.length
-      ? [GRAMS_UNIT, ...food.portions.filter(p => p.label !== 'g')]
-      : [GRAMS_UNIT];
-    onChange(rowFromFood(food, portions));
-  }
-
-  function handleQuantityChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const quantity = parseFloat(e.target.value) || 0;
-    const grams = quantity * row.unitGrams;
-    onChange({ ...row, quantity, grams, ...(row.per100g ? recomputeMacros(row.per100g, grams) : {}) });
-  }
-
-  function handleUnitChange(e: React.ChangeEvent<HTMLSelectElement>) {
-    const label = e.target.value;
-    const selected = row.portions.find(p => p.label === label) ?? GRAMS_UNIT;
-    const grams = row.quantity * selected.grams;
-    onChange({ ...row, unitLabel: selected.label, unitGrams: selected.grams, grams, ...(row.per100g ? recomputeMacros(row.per100g, grams) : {}) });
-  }
-
-  function handleMacro(field: 'calories' | 'protein_g' | 'carbs_g' | 'fat_g' | 'fiber_g' | 'sugar_g' | 'sodium_mg', val: string) {
-    onChange({ ...row, [field]: parseFloat(val) || 0 });
-  }
-
-  const macrosReadOnly = row.per100g !== null;
-  const showUnit = row.portions.length > 1;
-
-  return (
-    <div className={styles.ingredientRow}>
-      <div className={styles.rowNameWrap}>
-        <div className={styles.rowNameInputWrap}>
-          <input
-            className={styles.input}
-            type="text"
-            placeholder="Ingredient name"
-            value={row.name}
-            onChange={handleNameChange}
-            onFocus={() => setShowSearch(true)}
-            onBlur={() => setTimeout(() => setShowSearch(false), 150)}
-            aria-label="Ingredient name"
-          />
-          {showSearch && <IngredientDropdown query={searchQuery} onSelect={handleSelectFood} />}
-        </div>
-        <button type="button" className={styles.removeBtn} onClick={onRemove} aria-label="Remove ingredient">
-          <X size={16} aria-hidden="true" style={{ display: 'block' }} />
-        </button>
-      </div>
-      <div className={styles.rowFields}>
-        <label className={styles.fieldLabel}>
-          <span>Qty</span>
-          <input
-            className={styles.inputSmall}
-            type="number" min="0" step="0.1"
-            value={row.quantity === 0 ? '' : row.quantity}
-            onChange={handleQuantityChange}
-            aria-label="Quantity"
-          />
-        </label>
-        {showUnit ? (
-          <label className={styles.fieldLabel}>
-            <span>Unit</span>
-            <select className={styles.unitSelect} value={row.unitLabel} onChange={handleUnitChange} aria-label="Unit">
-              {row.portions.map(p => (
-                <option key={p.label} value={p.label}>
-                  {p.label === 'g' ? 'g' : `${p.label} (${p.grams}g)`}
-                </option>
-              ))}
-            </select>
-          </label>
-        ) : (
-          <label className={styles.fieldLabel}>
-            <span>Unit</span>
-            <span className={styles.unitStatic}>g</span>
-          </label>
-        )}
-        <label className={styles.fieldLabel}>
-          <span>kcal</span>
-          <input className={styles.inputSmall} type="number" min="0" step="0.1"
-            value={row.calories === 0 ? '' : row.calories}
-            onChange={e => handleMacro('calories', e.target.value)} readOnly={macrosReadOnly} aria-label="Calories" />
-        </label>
-        <label className={styles.fieldLabel}>
-          <span>Prot</span>
-          <input className={styles.inputSmall} type="number" min="0" step="0.1"
-            value={row.protein_g === 0 ? '' : row.protein_g}
-            onChange={e => handleMacro('protein_g', e.target.value)} readOnly={macrosReadOnly} aria-label="Protein g" />
-        </label>
-        <label className={styles.fieldLabel}>
-          <span>Carbs</span>
-          <input className={styles.inputSmall} type="number" min="0" step="0.1"
-            value={row.carbs_g === 0 ? '' : row.carbs_g}
-            onChange={e => handleMacro('carbs_g', e.target.value)} readOnly={macrosReadOnly} aria-label="Carbs g" />
-        </label>
-        <label className={styles.fieldLabel}>
-          <span>Fat</span>
-          <input className={styles.inputSmall} type="number" min="0" step="0.1"
-            value={row.fat_g === 0 ? '' : row.fat_g}
-            onChange={e => handleMacro('fat_g', e.target.value)} readOnly={macrosReadOnly} aria-label="Fat g" />
-        </label>
-      </div>
-      {macrosReadOnly && (
-        <p className={styles.rowHint}>Macros computed from per-100g values · adjust qty/unit to recalculate</p>
-      )}
-    </div>
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -624,29 +417,57 @@ export default function MealBuilder({ open, kind, initialDraft, prefillRows, onC
   // ---------------------------------------------------------------------------
   // Row helpers
   // ---------------------------------------------------------------------------
-  const updateRow = useCallback((key: number, updated: BuilderRow) => {
-    setRows(prev => prev.map(r => r.rowKey === key ? updated : r));
-  }, []);
-
   const removeRow = useCallback((key: number) => {
     setRows(prev => prev.filter(r => r.rowKey !== key));
   }, []);
 
-  const addRow = useCallback(() => {
-    setRows(prev => [...prev, emptyBuilderRow()]);
+  // Ingredient sheet state
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [editingRow, setEditingRow] = useState<BuilderRow | null>(null);
+
+  const openSheetForAdd = useCallback(() => {
+    setEditingRow(null);
+    setSheetOpen(true);
   }, []);
 
-  const handleExpandMeal = useCallback((rowKey: number, expandedRows: BuilderRow[]) => {
+  const openSheetForEdit = useCallback((row: BuilderRow) => {
+    setEditingRow(row);
+    setSheetOpen(true);
+  }, []);
+
+  const closeSheet = useCallback(() => {
+    setSheetOpen(false);
+    setEditingRow(null);
+  }, []);
+
+  const handleSheetDone = useCallback((row: BuilderRow) => {
     setRows(prev => {
-      const idx = prev.findIndex(r => r.rowKey === rowKey);
-      if (idx === -1) return [...prev, ...expandedRows];
-      const trigger = prev[idx];
-      if (!trigger.name.trim()) {
-        return [...prev.slice(0, idx), ...expandedRows, ...prev.slice(idx + 1)];
+      const idx = prev.findIndex(r => r.rowKey === row.rowKey);
+      if (idx !== -1) {
+        return prev.map(r => (r.rowKey === row.rowKey ? row : r));
+      }
+      return [...prev, row];
+    });
+  }, []);
+
+  const handleSheetDelete = useCallback(() => {
+    if (editingRow !== null) {
+      removeRow(editingRow.rowKey);
+    }
+  }, [editingRow, removeRow]);
+
+  const handleExpandMeal = useCallback((expandedRows: BuilderRow[]) => {
+    setRows(prev => {
+      if (editingRow !== null) {
+        const idx = prev.findIndex(r => r.rowKey === editingRow.rowKey);
+        if (idx !== -1 && !prev[idx].name.trim()) {
+          return [...prev.slice(0, idx), ...expandedRows, ...prev.slice(idx + 1)];
+        }
       }
       return [...prev, ...expandedRows];
     });
-  }, []);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editingRow]);
 
   // ---------------------------------------------------------------------------
   // Render
@@ -723,23 +544,14 @@ export default function MealBuilder({ open, kind, initialDraft, prefillRows, onC
                 </div>
               </div>
 
-              {/* Ingredient rows */}
+              {/* Ingredient cards */}
               <div className={styles.section}>
                 <span className={styles.sectionLabel}>Ingredients</span>
-                <div className={styles.ingredientList}>
-                  {rows.map(row => (
-                    <BuilderIngredientRow
-                      key={row.rowKey}
-                      row={row}
-                      onChange={updated => updateRow(row.rowKey, updated)}
-                      onRemove={() => removeRow(row.rowKey)}
-                      onExpandMeal={expandedRows => handleExpandMeal(row.rowKey, expandedRows)}
-                    />
-                  ))}
-                </div>
-                <button type="button" className={styles.addIngredientBtn} onClick={addRow}>
-                  <Plus size={14} aria-hidden="true" style={{ display: 'block' }} /> Add ingredient
-                </button>
+                <IngredientCardList
+                  rows={rows}
+                  onEditRow={openSheetForEdit}
+                  onAddRow={openSheetForAdd}
+                />
               </div>
 
               {/* Macro readouts */}
@@ -930,6 +742,16 @@ export default function MealBuilder({ open, kind, initialDraft, prefillRows, onC
           {saveError && <p className={styles.errorMsg}>{saveError}</p>}
         </div>
       </div>
+
+      {/* Ingredient sheet — portaled to body so it overlays MealBuilder's own sheet */}
+      <IngredientSheet
+        open={sheetOpen}
+        editRow={editingRow}
+        onClose={closeSheet}
+        onDone={handleSheetDone}
+        onDelete={editingRow !== null ? handleSheetDelete : undefined}
+        onExpandMeal={handleExpandMeal}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **Static summary cards** replace the old dense inline `IngredientRowEditor` in both `EntryEditor` and `MealBuilder`. Each card shows: ingredient name, kcal (bold/green), and P/C/F macro chips.
- **"+ Add ingredient" button** appears below the cards (dashed border, matching existing `addRowBtn` style).
- **`IngredientSheet`** — new reusable portal bottom sheet (`createPortal` to `document.body`). Contains the full single-ingredient editor: food-search dropdown, qty/unit fields, macro fields (read-only when per100g auto-computed), barcode scanner. Slides up from the bottom on mobile; centered modal on desktop.
- Tapping a **card** opens the sheet pre-filled in edit mode with a **Delete ingredient** button.
- Tapping **"+ Add ingredient"** opens the sheet blank in add mode. Done/Add taps commit to parent rows.
- Custom-meal expansion still works: selecting a custom meal in the search dropdown expands its ingredients into the parent list and closes the sheet.

## Portal / overlay rationale (inline-chat case)

`EntryEditor` renders inline inside the chat thread (`inline={true}`) as a card in the message list — it has no fixed/absolute stacking context of its own. `MealBuilder` also renders inside its own `position: fixed` sheet (z-index 1000). By using `createPortal(…, document.body)`, `IngredientSheet` is appended directly to `<body>` and uses `z-index: 1101` (overlay at 1100), guaranteeing it floats above both the inline chat card and MealBuilder's sheet regardless of DOM nesting.

## Files changed

- `client/src/features/nutrition/IngredientSheet.tsx` — new component (default export `IngredientSheet` + named export `IngredientCardList`)
- `client/src/features/nutrition/IngredientSheet.module.scss` — new stylesheet (portal sheet, cards, animations)
- `client/src/features/nutrition/EntryEditor.tsx` — replaces `IngredientRowEditor` + `SearchDropdown` with `IngredientCardList` + `IngredientSheet`; removes `BarcodeScanner` (now inside `IngredientSheet`)
- `client/src/features/nutrition/MealBuilder.tsx` — replaces `BuilderIngredientRow` + `IngredientDropdown` with `IngredientCardList` + `IngredientSheet`

Callers not touched: `NutritionChat.tsx`, `MyFoodsSheet.tsx`, `NutritionTracker.tsx`.

## What I verified

- `cd client && npx vite build` — clean (0 TS errors, 0 new warnings)
- `npm run build` (backend tsc) — clean
- Public props of `EntryEditor` and `MealBuilder` unchanged; all callers still compile

## Assumptions / gaps for runtime validation

- Tested via build only; runtime testing in a browser against the live app is needed
- The barcode flow inside the sheet: on scan, a `BarcodeScanner` portal renders from within the already-portaled `IngredientSheet`; both go to `document.body`, so there's no double-nesting issue
- `MealBuilder`'s food-mode (single ingredient, no rows array) — the ingredient sheet only applies to meal mode's ingredient list; food mode's macro fields are unchanged

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)