### PR TITLE
fix: dark stroke on Ask-AI FAB chat-bubble icon (#145)

### DIFF
--- a/client/src/features/nutrition/NutritionChat.module.scss
+++ b/client/src/features/nutrition/NutritionChat.module.scss
@@ -923,6 +923,7 @@
   display: block; // iOS Safari SVG fix
   width: 16px;
   height: 16px;
+  color: $background; // #145: dark stroke on the green FAB (was inheriting the button's white)
 }
 
 // ---- Animations ----


### PR DESCRIPTION
## Summary
Closes #145. The Ask-AI floating chat button's chat-bubble icon had a light (white) stroke because it inherited the FAB's `color: #fff`; lucide icons stroke with `currentColor`. On the bright-green FAB that's low contrast.

## Change
`.floatingChatBtnIcon` now sets `color: $background` (#151515) → dark stroke on the green FAB.

## Testing
Client Vite build clean. Visual: dark chat-bubble icon on the green FAB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)