### PR TITLE
fix: improve barcode scanner reliability (resolution, format hints, single stream)

### DIFF
--- a/client/src/features/nutrition/BarcodeScanner.tsx
+++ b/client/src/features/nutrition/BarcodeScanner.tsx
@@ -3,12 +3,28 @@
 
 import { useEffect, useRef } from 'react';
 import { BrowserMultiFormatReader } from '@zxing/browser';
+import { BarcodeFormat, DecodeHintType } from '@zxing/library';
 import styles from './BarcodeScanner.module.scss';
 
 interface BarcodeScannerProps {
   onDetected: (code: string) => void;
   onClose: () => void;
 }
+
+// Restrict decoding to retail product barcode formats. Scanning fewer
+// formats per frame is faster and meaningfully more reliable than the
+// default (which tries every supported format, including 2D formats
+// we never expect from a "scan barcode" product lookup flow).
+const PRODUCT_BARCODE_FORMATS = [
+  BarcodeFormat.EAN_13,
+  BarcodeFormat.EAN_8,
+  BarcodeFormat.UPC_A,
+  BarcodeFormat.UPC_E,
+  BarcodeFormat.CODE_128,
+];
+
+const hints = new Map<DecodeHintType, unknown>();
+hints.set(DecodeHintType.POSSIBLE_FORMATS, PRODUCT_BARCODE_FORMATS);
 
 export default function BarcodeScanner({ onDetected, onClose }: BarcodeScannerProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -19,16 +35,24 @@ export default function BarcodeScanner({ onDetected, onClose }: BarcodeScannerPr
   const detectedRef = useRef(false);
 
   useEffect(() => {
-    const reader = new BrowserMultiFormatReader();
+    const reader = new BrowserMultiFormatReader(hints);
     readerRef.current = reader;
 
     let cancelled = false;
 
     async function start() {
       try {
-        // Request environment-facing (rear) camera explicitly.
+        // Request environment-facing (rear) camera explicitly, at as high
+        // a resolution as the device supports. `ideal` (not `exact`) lets
+        // this degrade gracefully on devices that can't hit 1080p — but on
+        // capable phones a higher-res frame is the single biggest win for
+        // 1D barcode decode reliability on iOS Safari.
         const stream = await navigator.mediaDevices.getUserMedia({
-          video: { facingMode: 'environment' },
+          video: {
+            facingMode: 'environment',
+            width: { ideal: 1920 },
+            height: { ideal: 1080 },
+          },
         });
 
         if (cancelled) {
@@ -41,8 +65,11 @@ export default function BarcodeScanner({ onDetected, onClose }: BarcodeScannerPr
         if (!videoRef.current) return;
         videoRef.current.srcObject = stream;
 
-        const controls = await reader.decodeFromVideoDevice(
-          undefined,
+        // Decode from the single stream we already acquired above, rather
+        // than calling decodeFromVideoDevice (which would open a *second*
+        // getUserMedia stream on top of this one).
+        const controls = await reader.decodeFromStream(
+          stream,
           videoRef.current,
           (result, _err, ctrl) => {
             if (result && !detectedRef.current) {


### PR DESCRIPTION
## Summary

Free reliability pass on the existing ZXing-based barcode scanner (`BarcodeScanner.tsx`) — no library swap, no rewrite. Targets iOS Safari as the primary platform.

Three changes, all in `client/src/features/nutrition/BarcodeScanner.tsx`:

1. **Higher-resolution camera stream.** `getUserMedia` now requests `width: { ideal: 1920 }, height: { ideal: 1080 }` alongside `facingMode: 'environment'`, instead of the previous unconstrained request (which defaults to ~640x480). Using `ideal` (not `exact`) lets it degrade gracefully on devices that can't hit 1080p. This is the single biggest decode-reliability lever available on iOS Safari.
2. **Restricted to product barcode formats.** The `BrowserMultiFormatReader` is now constructed with `DecodeHintType.POSSIBLE_FORMATS` set to `[EAN_13, EAN_8, UPC_A, UPC_E, CODE_128]`, so it no longer scans every supported format (including 2D formats never relevant to a product lookup). Fewer formats per frame = faster and more reliable.
3. **Single camera stream.** Previously the component called `getUserMedia` directly *and* `reader.decodeFromVideoDevice(undefined, ...)`, which internally opens a second `getUserMedia` stream. It now decodes from the one stream it already acquired via `reader.decodeFromStream(stream, videoRef.current, cb)`. All existing cleanup semantics are preserved: on unmount or after a successful detect, both the ZXing controls and the stream's tracks are stopped, and the `detectedRef` guard still prevents double-invoking `onDetected`.

Zoom and tap-to-focus are **not** addressed here — those aren't controllable via web APIs on iOS Safari and are tracked separately in #156 (evaluating commercial SDKs like STRICH/Scandit). This PR does not close #156.

The component's external contract is unchanged: still `onDetected: (code: string) => void` / `onClose: () => void`, called exactly once.

### Installed `@zxing/browser` version and APIs used
- `@zxing/browser@0.2.0` (confirmed installed, matches `^0.2.0` in `client/package.json`), `@zxing/library@0.22.0`.
- Verified against installed `.d.ts` files (not assumed from memory):
  - `BrowserMultiFormatReader(hints?: Map<DecodeHintType, any>, options?)` — hints passed via constructor.
  - `BarcodeFormat`, `DecodeHintType` imported from `@zxing/library`.
  - `decodeFromStream(stream: MediaStream, preview: string | HTMLVideoElement | undefined, callbackFn): Promise<IScannerControls>` — exists in this version, used to decode from the single already-acquired stream.

## Test plan
- [x] `cd client && npx tsc --noEmit` — clean, no errors (exit 0).
- [ ] **Not validated**: real-device camera behavior (resolution actually negotiated, decode success rate, format-hint correctness) — this environment cannot exercise a live camera. Please test on an actual iOS Safari device before considering this reliability improvement confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)