### PR TITLE
fix: spurious chat disconnect error + ingredient card chip alignment

### DIFF
--- a/client/src/features/nutrition/IngredientSheet.module.scss
+++ b/client/src/features/nutrition/IngredientSheet.module.scss
@@ -460,6 +460,11 @@
   display: flex;
   gap: 4px;
   flex-wrap: wrap;
+  // #153: push the P/C/F chips to the right edge of the card, keeping kcal
+  // (and the title above it) left-aligned. Still wraps onto its own line on
+  // very narrow widths without overflowing, since it stays within .cardMacros.
+  margin-left: auto;
+  justify-content: flex-end;
 }
 
 .chip {

--- a/client/src/features/nutrition/NutritionChat.tsx
+++ b/client/src/features/nutrition/NutritionChat.tsx
@@ -277,6 +277,32 @@ function ReasoningBubble({ text, streaming }: ReasoningBubbleProps) {
 }
 
 // ---------------------------------------------------------------------------
+// #154: Disconnect/abort-error detection.
+//
+// When the user navigates away (or the tab/network drops) mid-stream, the
+// streaming fetch behind useChat is aborted. Different browsers surface this
+// differently — Safari: Error("Load failed"); Chrome/others: AbortError,
+// "network error", "Failed to fetch", "The user aborted a request". The
+// server-side run keeps completing normally and the transcript poll/refetch
+// (fetchAndApplyTranscript / dangling-run poll above) recovers the full
+// assistant reply — so this specific class of error is spurious noise, not a
+// real failure, and must not be shown as an ErrorBubble.
+// ---------------------------------------------------------------------------
+const DISCONNECT_ERROR_PATTERNS = [
+  'load failed',
+  'network error',
+  'failed to fetch',
+  'aborted',
+];
+
+function isDisconnectError(err: Error | undefined | null): boolean {
+  if (!err) return false;
+  if (err.name === 'AbortError') return true;
+  const message = (err.message || '').toLowerCase();
+  return DISCONNECT_ERROR_PATTERNS.some(pattern => message.includes(pattern));
+}
+
+// ---------------------------------------------------------------------------
 // #107: Error bubble — shown in the chat thread when useChat surfaces an error
 // ---------------------------------------------------------------------------
 interface ErrorBubbleProps {
@@ -549,8 +575,10 @@ function ChatMessage({
             );
           }
 
-          // #104: hide the calculator tool card — it's an implementation detail
-          if (toolName === 'calculator') return null;
+          // #104: hide the calculator and convert_to_grams tool cards — both are
+          // deterministic background helpers (implementation details), not
+          // something the user needs to see a tool card for.
+          if (toolName === 'calculator' || toolName === 'convert_to_grams') return null;
 
           return <ToolCallCard key={idx} part={part as ToolUIPart | DynamicToolUIPart} />;
         }
@@ -767,6 +795,15 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
 
     return () => clearInterval(interval);
   }, [pollingActive, selectedDate, fetchAndApplyTranscript]);
+
+  // #154: Clear disconnect-style errors so they don't linger in useChat state
+  // once the ErrorBubble is suppressed above (the transcript poll/refetch is
+  // what actually recovers the assistant reply, not this error).
+  useEffect(() => {
+    if (isDisconnectError(chatError)) {
+      clearError();
+    }
+  }, [chatError, clearError]);
 
   // #105: detect mobile to suppress Enter-to-send
   const { isMobile } = useIsMobile();
@@ -1250,8 +1287,11 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
             />
           ))}
 
-          {/* #107: Error bubble — shown when the chat stream/API call fails */}
-          {chatError && (
+          {/* #107/#154: Error bubble — shown when the chat stream/API call fails.
+              Disconnect-style errors (navigation away mid-stream, aborted fetch) are
+              spurious — the run completes server-side and the transcript poll above
+              recovers it — so they're suppressed rather than rendered here. */}
+          {chatError && !isDisconnectError(chatError) && (
             <div className={styles.messageGroup}>
               <ErrorBubble error={chatError} />
             </div>


### PR DESCRIPTION
## Summary
- Closes #154
- Closes #153
- Also backgrounds the `convert_to_grams` tool card the same way `calculator` already is (implementation detail, not user-facing).

### #154 — spurious "Something went wrong / Load failed"
Navigating away mid-response aborts the streaming fetch behind `useChat`. Different browsers surface this differently (Safari: `Error("Load failed")`; others: `AbortError`, "network error", "Failed to fetch"). The server-side run completes normally and the existing dangling-run poll/transcript refetch recovers the full assistant message, so this error was spurious. Added `isDisconnectError()` in `NutritionChat.tsx` to detect this class of error (case-insensitive match on "load failed" / "network error" / "failed to fetch" / "aborted", plus `err.name === 'AbortError'`) and suppress the `ErrorBubble` for it, plus call `clearError()` so it doesn't linger. Real errors (500s, auth failures, etc.) still render the bubble as before.

### convert_to_grams tool card
Extended the existing `#104` calculator-hide check to also hide `convert_to_grams` — another deterministic background helper tool, not something the user needs a card for.

### #153 — ingredient summary card alignment
In `IngredientSheet.module.scss`, `.macroChips` (the P/C/F chips in `IngredientCardList`'s summary cards) now gets `margin-left: auto; justify-content: flex-end;`, pushing the chips to the right edge of the card on the same row as the kcal figure, while kcal and the title stay left-aligned. `.cardMacros` already spans full width (flex item in a `flex-direction: column` parent), so no width change was needed. Chips still wrap onto their own line on very narrow widths without overflowing.

## Test plan
- [x] `cd client && npx tsc --noEmit` — passes clean
- [x] `cd client && npm run build` — succeeds
- [ ] Live verification of #154 recommended: it's timing/AI-response dependent and hard to fully exercise outside a live session (navigate away mid-stream in Safari vs. Chrome and confirm no error bubble appears while the transcript still recovers correctly).
- [ ] Visual check of the ingredient card alignment on a real narrow mobile viewport.