### PR TITLE
feat: scanned barcodes become chat attachments (not composer text)

### DIFF
--- a/client/src/features/nutrition/BarcodeAttachmentCard.tsx
+++ b/client/src/features/nutrition/BarcodeAttachmentCard.tsx
@@ -1,0 +1,139 @@
+/**
+ * BarcodeAttachmentCard — READ-ONLY preview for a scanned barcode chat attachment.
+ *
+ * Tapping the barcode chip in the composer (pending) or in a sent message
+ * (transcript) opens this card. It reuses IngredientSheet's Radix Dialog shell
+ * and CSS classes (.sheet/.header/.body/.macrosSection/.macrosGrid/...) plus
+ * ingredientMath's rowFromFood()/recomputeMacros() so the macro figures and
+ * layout match the rest of the app exactly — this is intentionally NOT an
+ * editable form: there are no inputs, no barcode/search affordances, no Done
+ * button. Just name + resolved serving + macros, and a Close button.
+ */
+import * as Dialog from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import { rowFromFood } from './ingredientMath';
+import type { BarcodeAttachmentData } from './types';
+import styles from './IngredientSheet.module.scss';
+
+export interface BarcodeAttachmentCardProps {
+  open: boolean;
+  data: BarcodeAttachmentData;
+  onClose: () => void;
+}
+
+export default function BarcodeAttachmentCard({ open, data, onClose }: BarcodeAttachmentCardProps) {
+  const row = rowFromFood(data.product);
+
+  return (
+    <Dialog.Root open={open} onOpenChange={isOpen => { if (!isOpen) onClose(); }}>
+      <Dialog.Portal>
+        <Dialog.Overlay className={styles.overlay} />
+        <Dialog.Content
+          className={styles.sheet}
+          aria-label="Scanned product"
+          onOpenAutoFocus={e => e.preventDefault()}
+          onEscapeKeyDown={e => e.stopPropagation()}
+        >
+          <Dialog.Title className={styles.srOnly}>Scanned product</Dialog.Title>
+
+          <div className={styles.header}>
+            <button
+              type="button"
+              className={styles.closeBtn}
+              onClick={onClose}
+              aria-label="Close"
+            >
+              <X size={16} aria-hidden="true" style={{ display: 'block' }} />
+            </button>
+            <h2 className={styles.headerTitle}>Scanned product</h2>
+            <span style={{ width: 32 }} aria-hidden="true" />
+          </div>
+
+          <div className={styles.body}>
+            {data.imageDataUrl && (
+              <img
+                src={data.imageDataUrl}
+                alt=""
+                aria-hidden="true"
+                style={{
+                  width: '100%',
+                  maxHeight: 160,
+                  objectFit: 'cover',
+                  borderRadius: 12,
+                  marginBottom: 12,
+                  display: 'block',
+                }}
+              />
+            )}
+
+            <div className={styles.nameRow}>
+              <div className={styles.nameInputWrap}>
+                <p style={{ fontWeight: 600, margin: 0 }}>{row.name}</p>
+              </div>
+            </div>
+
+            <div className={styles.portionRow}>
+              <label className={styles.fieldLabel} aria-label="Quantity">
+                <span>Qty</span>
+                <span className={styles.unitStatic}>{row.quantity}</span>
+              </label>
+              <label className={styles.fieldLabel}>
+                <span>Unit</span>
+                <span className={styles.unitStatic}>{row.unitLabel}</span>
+              </label>
+            </div>
+
+            <div className={styles.macrosSection}>
+              <span className={styles.macrosSectionLabel}>Macros</span>
+              <div className={styles.macrosGrid}>
+                <label className={styles.fieldLabel}>
+                  <span>kcal</span>
+                  <input
+                    className={styles.inputSmall}
+                    type="text"
+                    value={Math.round(row.calories)}
+                    readOnly
+                    aria-label="Calories"
+                  />
+                </label>
+                <label className={styles.fieldLabel}>
+                  <span>Prot</span>
+                  <input
+                    className={styles.inputSmall}
+                    type="text"
+                    value={row.protein_g}
+                    readOnly
+                    aria-label="Protein g"
+                  />
+                </label>
+                <label className={styles.fieldLabel}>
+                  <span>Carbs</span>
+                  <input
+                    className={styles.inputSmall}
+                    type="text"
+                    value={row.carbs_g}
+                    readOnly
+                    aria-label="Carbs g"
+                  />
+                </label>
+                <label className={styles.fieldLabel}>
+                  <span>Fat</span>
+                  <input
+                    className={styles.inputSmall}
+                    type="text"
+                    value={row.fat_g}
+                    readOnly
+                    aria-label="Fat g"
+                  />
+                </label>
+              </div>
+              <p className={styles.rowHint}>
+                From Open Food Facts (barcode {data.code}) · read-only — this is a preview of the scanned product, not an editable entry.
+              </p>
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/client/src/features/nutrition/BarcodeScanner.tsx
+++ b/client/src/features/nutrition/BarcodeScanner.tsx
@@ -7,8 +7,43 @@ import { BarcodeFormat, DecodeHintType } from '@zxing/library';
 import styles from './BarcodeScanner.module.scss';
 
 interface BarcodeScannerProps {
-  onDetected: (code: string) => void;
+  /** `imageDataUrl` is a best-effort still-frame capture at detect time (JPEG data URL,
+   *  downscaled). It's optional — if frame capture fails, the code is still returned. */
+  onDetected: (code: string, imageDataUrl?: string) => void;
   onClose: () => void;
+}
+
+// Downscale target for the captured still frame — this is only ever used as a
+// small UI thumbnail (chip + tap preview), never sent to the model, so a modest
+// resolution keeps localStorage/DB payloads small.
+const FRAME_MAX_EDGE = 480;
+const FRAME_JPEG_QUALITY = 0.7;
+
+/** Best-effort capture of the current video frame as a downscaled JPEG data URL. */
+function captureVideoFrame(video: HTMLVideoElement): string | undefined {
+  try {
+    const vw = video.videoWidth;
+    const vh = video.videoHeight;
+    if (!vw || !vh) return undefined;
+
+    let width = vw;
+    let height = vh;
+    if (width > FRAME_MAX_EDGE || height > FRAME_MAX_EDGE) {
+      const ratio = Math.min(FRAME_MAX_EDGE / width, FRAME_MAX_EDGE / height);
+      width = Math.round(width * ratio);
+      height = Math.round(height * ratio);
+    }
+
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return undefined;
+    ctx.drawImage(video, 0, 0, width, height);
+    return canvas.toDataURL('image/jpeg', FRAME_JPEG_QUALITY);
+  } catch {
+    return undefined;
+  }
 }
 
 // Restrict decoding to retail product barcode formats. Scanning fewer
@@ -74,10 +109,13 @@ export default function BarcodeScanner({ onDetected, onClose }: BarcodeScannerPr
           (result, _err, ctrl) => {
             if (result && !detectedRef.current) {
               detectedRef.current = true;
+              // Capture a still frame BEFORE stopping the stream — the video
+              // element's current frame becomes unavailable once the tracks stop.
+              const imageDataUrl = videoRef.current ? captureVideoFrame(videoRef.current) : undefined;
               // Stop scanning; let the parent handle the detected code.
               ctrl.stop();
               stream.getTracks().forEach(t => t.stop());
-              onDetected(result.getText());
+              onDetected(result.getText(), imageDataUrl);
             }
           },
         );

--- a/client/src/features/nutrition/NutritionChat.module.scss
+++ b/client/src/features/nutrition/NutritionChat.module.scss
@@ -646,6 +646,92 @@
   letter-spacing: $sarabun-spacing;
 }
 
+// ---- Pending barcode-attachment chip (composer thumbnail strip) ----
+// Mirrors .thumbnail sizing so it sits inline with photo thumbnails, plus a
+// small badge overlay so a scanned product doesn't look like a plain photo.
+.barcodeThumbBtn {
+  position: relative;
+  display: block;
+  width: 64px;
+  height: 64px;
+  padding: 0;
+  border: 2px solid rgba($surface-border, 0.5);
+  border-radius: 10px;
+  background: none;
+  cursor: pointer;
+  overflow: hidden;
+}
+
+.barcodeThumbBadge {
+  position: absolute;
+  bottom: 2px;
+  right: 2px;
+  width: 18px;
+  height: 18px;
+  padding: 2px;
+  border-radius: 50%;
+  background-color: $primary;
+  color: $background;
+}
+
+// ---- Sent barcode-attachment chip (rendered inline in the message thread) ----
+.barcodeAttachmentChip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  max-width: 240px;
+  padding: 6px 10px 6px 6px;
+  border: 1px solid rgba($surface-border, 0.5);
+  border-radius: 12px;
+  background: none;
+  cursor: pointer;
+  text-align: left;
+}
+
+.barcodeAttachmentThumb {
+  display: block;
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.barcodeAttachmentThumbFallback {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  background-color: rgba($surface-border, 0.3);
+  color: $text;
+  flex-shrink: 0;
+}
+
+.barcodeAttachmentBadge {
+  position: absolute;
+  left: 30px;
+  top: 30px;
+  width: 16px;
+  height: 16px;
+  padding: 2px;
+  border-radius: 50%;
+  background-color: $primary;
+  color: $background;
+}
+
+.barcodeAttachmentName {
+  font-family: $sarabun;
+  font-size: 13px;
+  letter-spacing: $sarabun-spacing;
+  color: $text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 // ---- Composer area ----
 // #93: The camera + barcode buttons float ABOVE the textarea as small circles,
 //      left-aligned. The composer row itself holds only the textarea + send button.

--- a/client/src/features/nutrition/NutritionChat.tsx
+++ b/client/src/features/nutrition/NutritionChat.tsx
@@ -36,14 +36,15 @@ import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport, isToolUIPart, getToolName } from 'ai';
 import type { FileUIPart, UIMessage, ToolUIPart, DynamicToolUIPart } from 'ai';
 import ReactMarkdown from 'react-markdown';
-import { useCreateEntry, useCreateCustomFood, fetchTranscript, clearTranscript } from './api';
+import { useCreateEntry, useCreateCustomFood, fetchTranscript, clearTranscript, lookupBarcode } from './api';
 import type { StoredChatMessage } from './api';
 import EntryEditor from './EntryEditor';
 import MealBuilder from './MealBuilder';
 import BarcodeScanner from './BarcodeScanner';
+import BarcodeAttachmentCard from './BarcodeAttachmentCard';
 import ToolCallCard from './ToolCallCard';
 import ConfirmModal from '../../components/ConfirmModal';
-import type { EntryInput, EntryEditorMode, ProposeEntryArgs, ProposeCustomFoodArgs, CustomFoodInput } from './types';
+import type { EntryInput, EntryEditorMode, ProposeEntryArgs, ProposeCustomFoodArgs, CustomFoodInput, BarcodeAttachmentData } from './types';
 import styles from './NutritionChat.module.scss';
 import { ChevronDown, Trash2, Camera, ScanBarcode, Square, Send, Images, AlertCircle, ChevronRight, MessageSquare } from 'lucide-react';
 import useIsMobile from '../../hooks/useIsMobile';
@@ -118,6 +119,18 @@ interface PendingPhoto {
   file: File;
   previewUrl: string;
   dataUrl?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Pending barcode attachment state — mirrors PendingPhoto but for a scanned
+// barcode. `imageDataUrl` is the still-frame screenshot (UI-only thumbnail +
+// tap preview); `product` is the structured Open Food Facts data that gets
+// fed to the agent as a pre-fetched tool-result (see services/nutrition/agent.ts).
+// ---------------------------------------------------------------------------
+interface PendingBarcode {
+  code: string;
+  imageDataUrl?: string;
+  product: BarcodeAttachmentData['product'];
 }
 
 // ---------------------------------------------------------------------------
@@ -468,6 +481,7 @@ interface MessageProps {
   onCustomFoodDeny: (partKey: string) => void;
   deniedCustomFoodProposals: Set<string>;
   confirmedCustomFoodProposals: Map<string, string>; // partKey → food name
+  onOpenBarcodeAttachment: (data: BarcodeAttachmentData) => void;
 }
 
 function ChatMessage({
@@ -483,6 +497,7 @@ function ChatMessage({
   onCustomFoodDeny,
   deniedCustomFoodProposals,
   confirmedCustomFoodProposals,
+  onOpenBarcodeAttachment,
 }: MessageProps) {
   const isUser = message.role === 'user';
   // #15/#17: interrupted flag from StoredChatMessage cast
@@ -541,6 +556,31 @@ function ChatMessage({
               alt="Attached image"
               className={styles.attachedImage}
             />
+          );
+        }
+
+        // ---- Barcode attachment part (a scanned barcode attached to this message) ----
+        // Renders as a tappable chip; tap opens the read-only BarcodeAttachmentCard.
+        if (part.type === 'data-barcodeAttachment') {
+          const data = (part as unknown as { data: BarcodeAttachmentData }).data;
+          return (
+            <button
+              key={idx}
+              type="button"
+              className={styles.barcodeAttachmentChip}
+              onClick={() => onOpenBarcodeAttachment(data)}
+              aria-label={`View scanned product: ${data.product.name}`}
+            >
+              {data.imageDataUrl ? (
+                <img src={data.imageDataUrl} alt="" aria-hidden="true" className={styles.barcodeAttachmentThumb} />
+              ) : (
+                <span className={styles.barcodeAttachmentThumbFallback} aria-hidden="true">
+                  <ScanBarcode size={16} aria-hidden="true" style={{ display: 'block' }} />
+                </span>
+              )}
+              <ScanBarcode className={styles.barcodeAttachmentBadge} size={16} aria-hidden="true" style={{ display: 'block' }} />
+              <span className={styles.barcodeAttachmentName}>{data.product.name}</span>
+            </button>
           );
         }
 
@@ -968,6 +1008,11 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
   const [pendingPhotos, setPendingPhotos] = useState<PendingPhoto[]>([]);
   const [photoError, setPhotoError] = useState<string | null>(null);
   const [barcodeOpen, setBarcodeOpen] = useState(false);
+  const [pendingBarcode, setPendingBarcode] = useState<PendingBarcode | null>(null);
+  const [barcodeNotice, setBarcodeNotice] = useState<string | null>(null);
+  // Tap-to-preview: holds whichever barcode attachment (pending in composer, or
+  // already sent in the transcript) the user tapped. null = no card open.
+  const [barcodePreview, setBarcodePreview] = useState<BarcodeAttachmentData | null>(null);
 
   // #70: confirm-clear-chat dialog state
   const [showClearConfirm, setShowClearConfirm] = useState(false);
@@ -1065,59 +1110,39 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
   }, []);
 
   // ---- Barcode handling ----
+  // The scanned barcode becomes a chat ATTACHMENT (like a photo), not textarea
+  // text. Not-found scans are REJECTED — nothing is attached, and the user is
+  // told to describe the item manually or photograph the nutrition label.
   const [barcodeLoading, setBarcodeLoading] = useState(false);
 
-  const handleBarcodeDetected = useCallback(async (code: string) => {
+  const handleBarcodeDetected = useCallback(async (code: string, imageDataUrl?: string) => {
     setBarcodeOpen(false);
     setBarcodeLoading(true);
+    setBarcodeNotice(null);
     try {
-      const res = await fetch(`https://world.openfoodfacts.org/api/v0/product/${code}.json`);
-      const data = await res.json() as {
-        status: number;
-        product?: {
-          product_name?: string;
-          nutriments?: {
-            'energy-kcal_100g'?: number;
-            'proteins_100g'?: number;
-            'carbohydrates_100g'?: number;
-            'fat_100g'?: number;
-          };
-          serving_quantity?: number;
-          serving_quantity_unit?: string;
-        };
-      };
-
-      if (data.status === 1 && data.product) {
-        const p = data.product;
-        const name = p.product_name ?? 'Unknown product';
-        const n = p.nutriments ?? {};
-        const kcal = n['energy-kcal_100g'] != null ? Math.round(n['energy-kcal_100g']) : '?';
-        const protein = n['proteins_100g'] != null ? Math.round(n['proteins_100g']) : '?';
-        const carbs = n['carbohydrates_100g'] != null ? Math.round(n['carbohydrates_100g']) : '?';
-        const fat = n['fat_100g'] != null ? Math.round(n['fat_100g']) : '?';
-
-        let formatted = `[Scanned: ${code}]\nProduct: ${name}\nPer 100g: ${kcal} kcal | ${protein}g protein | ${carbs}g carbs | ${fat}g fat`;
-        if (p.serving_quantity != null) {
-          const unit = p.serving_quantity_unit ?? 'g';
-          formatted += `\nServing size: ${p.serving_quantity}${unit}`;
-        }
-
-        setText(prev => prev ? `${formatted}\n${prev}` : formatted);
-      } else {
-        console.warn('Open Food Facts: product not found for barcode', code);
-        setText(prev => prev ? `${prev} barcode:${code}` : `barcode:${code}`);
+      const product = await lookupBarcode(code);
+      if (!product) {
+        setBarcodeNotice(
+          `Couldn't find a product for barcode ${code}. Describe it in the chat, or take a photo of the nutrition label instead.`,
+        );
+        return;
       }
-    } catch (err) {
-      console.warn('Open Food Facts lookup failed:', err);
-      setText(prev => prev ? `${prev} barcode:${code}` : `barcode:${code}`);
+      setPendingBarcode({ code, imageDataUrl, product });
+    } catch {
+      setBarcodeNotice(
+        `Barcode lookup failed. Describe the item in the chat, or take a photo of the nutrition label instead.`,
+      );
     } finally {
       setBarcodeLoading(false);
-      textareaRef.current?.focus();
     }
   }, []);
 
+  const removePendingBarcode = useCallback(() => {
+    setPendingBarcode(null);
+  }, []);
+
   // ---- Send ----
-  const canSend = (text.trim().length > 0 || pendingPhotos.length > 0) && !isStreaming;
+  const canSend = (text.trim().length > 0 || pendingPhotos.length > 0 || pendingBarcode !== null) && !isStreaming;
 
   // Denial-note tracking: deny no longer auto-sends a message (see
   // handleProposalDeny/handleCustomFoodDeny below). Instead the agent learns
@@ -1151,17 +1176,42 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
       setPendingDenialCount(0);
     }
 
+    // A barcode-only send (no typed text) still needs SOME text content: the
+    // structured product data travels as a `data-barcodeAttachment` part, which
+    // convertToModelMessages drops from the user turn by design (it's UI-only —
+    // the model instead receives it as a pre-fetched tool-result, see agent.ts).
+    // Without this fallback the user turn could end up with empty content.
+    if (pendingBarcode && !msgText) {
+      msgText = `Log this scanned product: ${pendingBarcode.product.name}`;
+    }
+
+    const barcodePart = pendingBarcode
+      ? [{
+          type: 'data-barcodeAttachment' as const,
+          data: {
+            code: pendingBarcode.code,
+            imageDataUrl: pendingBarcode.imageDataUrl ?? null,
+            product: pendingBarcode.product,
+          } satisfies BarcodeAttachmentData,
+        }]
+      : [];
+
     pendingPhotos.forEach(p => URL.revokeObjectURL(p.previewUrl));
     setText('');
     setPendingPhotos([]);
+    setPendingBarcode(null);
+
+    const parts = [
+      ...files,
+      ...barcodePart,
+      ...(msgText ? [{ type: 'text' as const, text: msgText }] : []),
+    ];
 
     await sendMessage(
-      files.length > 0
-        ? { text: msgText || undefined, files } as Parameters<typeof sendMessage>[0]
-        : { text: msgText } as Parameters<typeof sendMessage>[0],
+      { parts } as Parameters<typeof sendMessage>[0],
       { body: { selectedDate } },
     );
-  }, [canSend, text, pendingPhotos, pendingDenialCount, selectedDate, sendMessage]);
+  }, [canSend, text, pendingPhotos, pendingBarcode, pendingDenialCount, selectedDate, sendMessage]);
 
   // #14: Stop button calls useChat stop()
   const handleStop = useCallback(() => {
@@ -1421,6 +1471,7 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
               onCustomFoodDeny={handleCustomFoodDeny}
               deniedCustomFoodProposals={deniedCustomFoodProposals}
               confirmedCustomFoodProposals={confirmedCustomFoodProposals}
+              onOpenBarcodeAttachment={setBarcodePreview}
             />
           ))}
 
@@ -1452,8 +1503,8 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
           <div ref={messagesEndRef} />
         </div>
 
-        {/* Photo thumbnails */}
-        {pendingPhotos.length > 0 && (
+        {/* Photo thumbnails + pending barcode attachment chip */}
+        {(pendingPhotos.length > 0 || pendingBarcode) && (
           <div className={styles.thumbnails}>
             {pendingPhotos.map(p => (
               <div key={p.previewUrl} className={styles.thumbnailWrap}>
@@ -1469,11 +1520,48 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
                 {!p.dataUrl && <span className={styles.thumbnailProcessing} />}
               </div>
             ))}
+
+            {/* #barcode-attachment: scanned-product chip — tap to preview, X to remove */}
+            {pendingBarcode && (
+              <div className={styles.thumbnailWrap}>
+                <button
+                  type="button"
+                  className={styles.barcodeThumbBtn}
+                  onClick={() => setBarcodePreview({
+                    code: pendingBarcode.code,
+                    imageDataUrl: pendingBarcode.imageDataUrl ?? null,
+                    product: pendingBarcode.product,
+                  })}
+                  aria-label={`View scanned product: ${pendingBarcode.product.name}`}
+                >
+                  {pendingBarcode.imageDataUrl ? (
+                    <img src={pendingBarcode.imageDataUrl} alt="Scanned product" className={styles.thumbnail} />
+                  ) : (
+                    <span className={styles.thumbnail} style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                      <ScanBarcode size={16} aria-hidden="true" style={{ display: 'block' }} />
+                    </span>
+                  )}
+                  <ScanBarcode className={styles.barcodeThumbBadge} size={16} aria-hidden="true" style={{ display: 'block' }} />
+                </button>
+                <button
+                  type="button"
+                  className={styles.thumbnailRemove}
+                  onClick={removePendingBarcode}
+                  aria-label="Remove scanned product"
+                >
+                  ✕
+                </button>
+              </div>
+            )}
           </div>
         )}
 
         {photoError && (
           <p className={styles.photoError}>{photoError}</p>
+        )}
+
+        {barcodeNotice && (
+          <p className={styles.photoError}>{barcodeNotice}</p>
         )}
 
         {/* Composer — #3/#61: safe-area padding, #4: 16px font-size on mobile
@@ -1654,6 +1742,15 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
         <BarcodeScanner
           onDetected={handleBarcodeDetected}
           onClose={() => setBarcodeOpen(false)}
+        />
+      )}
+
+      {/* Read-only tap preview for a scanned-barcode attachment (pending or sent) */}
+      {barcodePreview && (
+        <BarcodeAttachmentCard
+          open={true}
+          data={barcodePreview}
+          onClose={() => setBarcodePreview(null)}
         />
       )}
 

--- a/client/src/features/nutrition/types.ts
+++ b/client/src/features/nutrition/types.ts
@@ -43,6 +43,18 @@ export interface FoodSearchResult {
   kind?: 'food' | 'meal';
 }
 
+// ---- Barcode chat attachment (a scanned barcode attached to a chat message) ----
+// The screenshot (`imageDataUrl`) is UI-ONLY — it renders as the chip thumbnail
+// and the tap-to-preview card, but is NEVER sent to the model as vision. Only
+// `product` (structured per-100g macros from Open Food Facts) is fed to the
+// agent, injected server-side as a pre-fetched tool-result (see
+// services/nutrition/agent.ts) since the `lookup_barcode` tool was removed.
+export interface BarcodeAttachmentData {
+  code: string;
+  imageDataUrl?: string | null;
+  product: FoodSearchResult;
+}
+
 export interface IngredientInput {
   name: string;
   grams: number;

--- a/services/nutrition/agent.ts
+++ b/services/nutrition/agent.ts
@@ -2,6 +2,7 @@
 // Runs a tool-calling loop via the Vercel AI SDK's streamText, returning
 // the StreamTextResult for the route to pipe to the HTTP response.
 import { streamText, tool, stepCountIs, convertToModelMessages } from 'ai';
+import type { ModelMessage } from 'ai';
 import { openai } from '@ai-sdk/openai';
 import { z } from 'zod';
 import { proposeEntryArgsSchema, proposeCustomFoodArgsSchema } from '../../schemas/nutrition';
@@ -20,6 +21,83 @@ export interface NutritionChatOptions {
   effort?: 'none' | 'minimal' | 'low' | 'medium' | 'high';
   /** When true, instructs the agent to log the entry immediately without asking follow-up questions. */
   autoConfirm?: boolean;
+}
+
+/**
+ * Task C — barcode-attachment grounding.
+ *
+ * The client attaches a scanned barcode as a `data-barcodeAttachment` UI
+ * message part (see client/src/features/nutrition/NutritionChat.tsx). Data
+ * parts (`type` starting with `data-`) are UI-only: `convertToModelMessages`
+ * silently drops them from the converted user turn (there's no `convertDataPart`
+ * option passed below), so the model never sees the raw part — only the
+ * synthetic tool-call/tool-result pair we splice in ourselves, built here.
+ *
+ * This mirrors exactly what the removed `lookup_barcode` tool used to return
+ * (a FoodSearchResult-shaped product: name/source/source_ref/per100g/
+ * serving_grams), so the model treats it as already-retrieved grounding for a
+ * `lookup_barcode` call it never actually makes (that tool no longer exists).
+ */
+interface BarcodeAttachmentProduct {
+  name: string;
+  source: string;
+  source_ref: string;
+  per100g: Record<string, number | null | undefined>;
+  serving_grams?: number | null;
+  portions?: unknown;
+}
+
+/** Find a `data-barcodeAttachment` part on the LAST message, if it's a user turn. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function findBarcodeAttachment(messages: any[]): { code: string; product: BarcodeAttachmentProduct } | null {
+  const last = messages[messages.length - 1];
+  if (!last || last.role !== 'user' || !Array.isArray(last.parts)) return null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const part = last.parts.find((p: any) => p?.type === 'data-barcodeAttachment');
+  const data = part?.data;
+  if (!data?.code || !data?.product) return null;
+  return { code: data.code, product: data.product };
+}
+
+/**
+ * Build the synthetic assistant tool-call + tool message pair that replays the
+ * scanned product as a `lookup_barcode` tool-result. Appended to the END of
+ * `modelMessages` — safe because when the LAST raw client message is a 'user'
+ * message, `convertToModelMessages` always appends its converted form as the
+ * final entry in the returned array (one user message → exactly one pushed
+ * ModelMessage), so these synthetic messages land immediately after it.
+ */
+function buildBarcodeToolResultMessages(
+  attachment: { code: string; product: BarcodeAttachmentProduct },
+): ModelMessage[] {
+  const toolCallId = `barcode-scan-${attachment.code}-${Date.now()}`;
+  return [
+    {
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool-call',
+          toolCallId,
+          toolName: 'lookup_barcode',
+          input: { code: attachment.code },
+        },
+      ],
+    },
+    {
+      role: 'tool',
+      content: [
+        {
+          type: 'tool-result',
+          toolCallId,
+          toolName: 'lookup_barcode',
+          // JSON round-trip: strips the object down to plain JSON so it satisfies
+          // ToolResultOutput's `value: JSONValue` (mirrors the pattern used by the
+          // search_food_history tools above for the same reason).
+          output: { type: 'json', value: JSON.parse(JSON.stringify(attachment.product)) },
+        },
+      ],
+    },
+  ];
 }
 
 /** Build a compact text summary of recent entries for the system prompt context block. */
@@ -68,7 +146,7 @@ TODAY'S DATE: ${selectedDate}
 
 ## Your job
 Help the user identify, quantify, and log what they ate. When the user describes food:
-1. Search for it with \`search_foods\` (or \`lookup_barcode\` for barcodes) to get accurate per-100g macros — NEVER invent or estimate calories without grounding them in a tool result.
+1. Search for it with \`search_foods\` to get accurate per-100g macros — NEVER invent or estimate calories without grounding them in a tool result. If the user scanned a barcode, its product data is already provided to you (see "Barcode scans" below) — you do not need to search for it.
    - For a **multi-item meal** (two or more distinct foods in one message), use ONE \`search_foods_batch\` call with all queries at once instead of multiple \`search_foods\` calls. Use \`search_foods\` only for single-item lookups.
    - Both \`search_foods\` and \`search_foods_batch\` automatically attach portion sizes to the top result, so you often do NOT need a separate \`get_portions\` call.
    - Results may include the user's own saved custom foods/meals (source: 'custom'). **Prefer custom results when they match what the user is describing** — they already carry the user's preferred portions and notes. Logging a saved custom meal is identical to logging any other food: use the normal \`propose_entry\` flow with the custom item's ingredients.
@@ -104,8 +182,11 @@ When to keep as one entry: a single composite dish with multiple ingredients ("c
 When building a multi-ingredient entry (recipe, dish, or meal), do NOT add ingredients that contribute negligible calories — typically zero or near-zero calorie items such as: salt, pepper, spices, dried herbs (basil, oregano, cumin, etc.), garlic powder, onion powder, cinnamon, water, vinegar, zero-calorie seasonings, or cooking spray. These items are too small to affect the log meaningfully.
 Only include such ingredients if the user **explicitly asks** to log them (e.g. "include the salt" or "log all spices too").
 
+## Barcode scans
+When the user scans a barcode in the app, the product's per-100g macros (name, macros, serving size, and its Open Food Facts id) are fetched by the client BEFORE your turn even starts, and appear earlier in this conversation as the result of a lookup already performed — you do NOT have a barcode-lookup tool to call yourself, and you never will for this turn. Treat that result as authoritative grounding: use its macros and id directly (\`source: 'off'\`, \`source_ref\` = the Open Food Facts product id) when calling \`propose_entry\` with \`source: 'barcode'\`. Do not re-search \`search_foods\` for an item that arrived this way, and do not question or re-derive its macros.
+
 ## Web-search fallback
-- Only use \`web_search\` when \`search_foods\`, \`search_foods_batch\`, and \`lookup_barcode\` all return nothing useful (e.g. a local restaurant item, branded boba, or a food not in the food database). **NEVER use \`web_search\` for arithmetic or calculation — use the \`calculator\` tool instead.**
+- Only use \`web_search\` when \`search_foods\` and \`search_foods_batch\` return nothing useful (e.g. a local restaurant item, branded boba, or a food not in the food database) and no scanned-barcode grounding is available for the item. **NEVER use \`web_search\` for arithmetic or calculation — use the \`calculator\` tool instead.**
 - Prefer official brand or restaurant nutrition pages. Extract per-serving or per-100g macros.
 - **Always cite the source URL** in your reply when using web-search data.
 - Use ingredient \`source: 'manual'\` for any web-derived items.
@@ -160,6 +241,13 @@ ${summariseEntries(recent)}
     : '');
 
   const modelMessages = await convertToModelMessages(messages);
+
+  // Task C: replay a scanned-barcode attachment on the current turn as a
+  // pre-fetched `lookup_barcode` tool-result (see buildBarcodeToolResultMessages).
+  const barcodeAttachment = findBarcodeAttachment(messages);
+  if (barcodeAttachment) {
+    modelMessages.push(...buildBarcodeToolResultMessages(barcodeAttachment));
+  }
 
   const result = streamText({
     model: openai('gpt-5.5'),
@@ -219,23 +307,13 @@ ${summariseEntries(recent)}
         },
       }),
 
-      /** Open Food Facts barcode lookup. */
-      lookup_barcode: tool({
-        description:
-          'Look up a food product by UPC/EAN barcode via Open Food Facts. Returns per-100g macros or null if not found.',
-        inputSchema: z.object({
-          code: z.string().describe('Numeric barcode string (UPC-12 or EAN-13)'),
-        }),
-        execute: async ({ code }) => providers.lookupBarcode(code),
-      }),
-
       /** Household serving sizes for a food (USDA FDC or OFF). */
       get_portions: tool({
         description:
           'Fetch household serving sizes (e.g. "1 medium", "1 cup") for a food from USDA FDC or OFF. Call this after search_foods to help convert a described portion to grams. Not needed if portions are already attached to the search result.',
         inputSchema: z.object({
           source: z.enum(['usda', 'off']).describe('Data source the food came from'),
-          ref: z.string().describe('source_ref from search_foods or lookup_barcode result'),
+          ref: z.string().describe('source_ref from a search_foods result'),
         }),
         execute: async ({ source, ref }) => providers.getPortions(source, ref),
       }),
@@ -447,9 +525,9 @@ ${summariseEntries(recent)}
 
       /**
        * Web search — fallback for foods not in the food database (e.g. local restaurant
-       * items, branded boba). Only use after search_foods / search_foods_batch /
-       * lookup_barcode all return nothing useful. Always cite the source URL in your reply.
-       * Use ingredient source: 'manual' for web-derived items.
+       * items, branded boba). Only use after search_foods / search_foods_batch return
+       * nothing useful (and no scanned-barcode grounding is available). Always cite
+       * the source URL in your reply. Use ingredient source: 'manual' for web-derived items.
        */
       web_search: openai.tools.webSearch(),
 


### PR DESCRIPTION
## Summary

A scanned barcode now becomes a chat **attachment** — like a photo — instead of a formatted string injected into the composer textarea. The pre-fetched Open Food Facts nutrition data is fed to the AI agent as grounding, and the now-redundant `lookup_barcode` tool is removed.

## Task A — BarcodeScanner captures a still frame
`BarcodeScanner.tsx`: on detect, captures a downscaled JPEG still frame from the `<video>` element (canvas draw, max edge 480px, quality 0.7) *before* stopping the camera stream (the frame is unavailable once tracks stop). `onDetected` signature is now `(code: string, imageDataUrl?: string) => void` — image capture is best-effort; if it fails, the code is still returned. The existing single-stream/format-hint decode logic is untouched.

## Task B — Barcode attachment chip + tap preview (client)
- `NutritionChat.tsx`: `handleBarcodeDetected` no longer builds a `[Scanned: ...]` string or calls `setText(...)`. It now calls the existing `lookupBarcode()` helper (hits our own `GET /nutrition/barcode/:code`, which already wraps the OFF lookup — reused instead of hitting OFF directly from the client). 
  - **Found** → becomes a `PendingBarcode` (code + screenshot + structured product), rendered as a removable chip in the composer (screenshot thumbnail + a small `ScanBarcode` badge so it doesn't read as a plain photo), alongside `pendingPhotos`.
  - **Not found / lookup failure** → REJECTED per the locked decision: nothing is attached, an inline notice tells the user to describe the item or photograph the nutrition label.
  - Tapping the chip (pending, or already sent in the transcript) opens `BarcodeAttachmentCard` — new component, read-only, reusing `IngredientSheet.module.scss`'s Dialog shell/classes and `ingredientMath.rowFromFood()`/`recomputeMacros()` so the macro figures and layout match the rest of the app. No inputs, no barcode/search affordances, no Done button — just name + resolved serving + macros + a Close button.
  - On send: the attachment rides along as a `data-barcodeAttachment` UI message part (alongside `FileUIPart`s and the text part) via `sendMessage({ parts })`. It renders identically (chip + tap→card) in the sent transcript.
  - The screenshot is **UI-only** — chip thumbnail + tap preview. It is never sent to the model as vision (see Task C).

## Task C — Feed scanned data to the agent as a tool-result; remove `lookup_barcode`
- Removed the `lookup_barcode` tool from `services/nutrition/agent.ts` and all its system-prompt mentions (rewrote the barcode-related guidance, added a new "## Barcode scans" section explaining the grounding is pre-supplied). All internal backticks stayed escaped (`\``) per the template-literal footgun; both `tsc` runs below confirm nothing broke.
- **Chosen representation**: `data-*` UI message parts are dropped by `convertToModelMessages` by default (confirmed by reading `node_modules/ai/src/ui/convert-to-model-messages.ts` — `isDataUIPart` branches return `undefined` unless a `convertDataPart` option is supplied, which we don't pass). So the raw `data-barcodeAttachment` part on the user's turn is silently invisible to the model. Instead, `streamNutritionChat` now:
  1. Detects a `data-barcodeAttachment` part on the **last** raw client message (only relevant if it's the current turn — historical scans in earlier turns don't need replaying, since by then they'd already been proposed/confirmed).
  2. Appends a synthetic `assistant` message with a `tool-call` content part (`toolName: 'lookup_barcode'`, `input: { code }`) followed by a `tool` message with the matching `tool-result` (`output: { type: 'json', value: <product> }`), onto the end of `modelMessages`.
  3. This is safe to simply push at the end because when the last raw message is `role: 'user'`, `convertToModelMessages` always appends its converted form as the final array entry (one user message → exactly one pushed `ModelMessage`).
  - Net effect: the model sees exactly the same shape a live `lookup_barcode` call+result would have produced, without the tool existing or being callable again this turn. The prompt tells the model this explicitly and to use the product's OFF id as `source_ref` when calling `propose_entry` with `source: 'barcode'`.

## Task D — Persistence
No schema or persistence-layer changes were needed. `routes/nutrition.ts`'s `appendMessage(uuid, date, msgId, 'user', parts)` already stores whatever raw `parts` array the client sent (JSON in a `LONGTEXT` column) — the same path photo attachments already use for their base64 `dataUrl`. The `data-barcodeAttachment` part (code + screenshot + product) round-trips through `getTranscript` → `storedToUIMessages` → `ChatMessage` unchanged, so a reload re-renders the same chip and tap-preview card. Server-side, `findBarcodeAttachment` only inspects the **current** (last) message for injection purposes, so replayed history from prior turns is inert (as intended — those turns were already resolved).

**Risk note**: the stored screenshot is a small downscaled JPEG (~480px, quality 0.7) inline as a data URL, same pattern as existing photo attachments — no new size class of data, but worth confirming actual payload sizes on a real device.

## Verification
- `cd client && npx tsc --noEmit` → exit 0
- `npx tsc --noEmit` (repo root/backend) → exit 0 — this also validates the escaped-backtick system prompt in `agent.ts` didn't break

## Needs live/device validation (not exercisable in this environment — no camera, no live AI)
- Actual camera scan → still-frame capture quality/orientation on a real device (iOS Safari especially)
- Not-found barcode → rejection notice UX
- Chip → tap → read-only card rendering/macros on a real scanned product
- Send → agent receives the injected tool-result and calls `propose_entry` with correct `source: 'barcode'` / `source_ref`
- Reload after a barcode-attachment send → chip + tap card still render correctly
- Actual DB row size for `chat_messages.parts` with a real screenshot attached

## Unrelated
This branch is unrelated to #156 (the separate commercial-SDK evaluation) — not referencing it further.