### PR TITLE
fix: proposal-denial as system-prompt context, not in the user's message

### DIFF
--- a/client/src/features/nutrition/NutritionChat.tsx
+++ b/client/src/features/nutrition/NutritionChat.tsx
@@ -1144,10 +1144,12 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
   // ---- Send ----
   const canSend = (text.trim().length > 0 || pendingPhotos.length > 0 || pendingBarcode !== null) && !isStreaming;
 
-  // Denial-note tracking: deny no longer auto-sends a message (see
+  // Denial tracking: deny no longer auto-sends a message (see
   // handleProposalDeny/handleCustomFoodDeny below). Instead the agent learns
-  // about the denial(s) via a short note prepended to the user's NEXT
-  // outgoing message. Count (rather than a boolean) lets a combined note say
+  // about the denial(s) on the user's NEXT send — but WITHOUT polluting the
+  // visible user message. We pass a transient `deniedProposalCount` in the
+  // request body (like selectedDate); the backend folds it into the system
+  // prompt for that one turn. Count (not a boolean) lets the note say
   // "proposals" when the user denies more than one before their next send.
   const [pendingDenialCount, setPendingDenialCount] = useState(0);
 
@@ -1166,15 +1168,11 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
 
     let msgText = text.trim();
 
-    // Prepend a concise denial note so the model sees it, then mark the
-    // denial(s) as communicated so the note isn't repeated on later sends.
-    if (pendingDenialCount > 0) {
-      const note = pendingDenialCount > 1
-        ? '(Note: I denied your previous proposals — please adjust.)'
-        : '(Note: I denied your previous proposal — please adjust.)';
-      msgText = msgText ? `${note}\n${msgText}` : note;
-      setPendingDenialCount(0);
-    }
+    // Communicate any pending denial(s) to the agent via the request body (see
+    // pendingDenialCount above) — NOT by editing the user's visible message —
+    // then clear the count so it isn't re-sent on later turns.
+    const deniedProposalCount = pendingDenialCount;
+    if (deniedProposalCount > 0) setPendingDenialCount(0);
 
     // A barcode-only send (no typed text) still needs SOME text content: the
     // structured product data travels as a `data-barcodeAttachment` part, which
@@ -1209,7 +1207,7 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
 
     await sendMessage(
       { parts } as Parameters<typeof sendMessage>[0],
-      { body: { selectedDate } },
+      { body: { selectedDate, deniedProposalCount } },
     );
   }, [canSend, text, pendingPhotos, pendingBarcode, pendingDenialCount, selectedDate, sendMessage]);
 

--- a/routes/nutrition.ts
+++ b/routes/nutrition.ts
@@ -358,11 +358,15 @@ router.delete('/chat/transcript', async (req, res): Promise<any> => {
 // POST /chat — Nutrition AI agent chat endpoint (streams UI message stream)
 router.post('/chat', async (req, res): Promise<any> => {
   const { uuid }: User = res.locals.user;
-  const { messages, selectedDate, effort } = req.body as {
+  const { messages, selectedDate, effort, deniedProposalCount } = req.body as {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     messages: any[];
     selectedDate?: string;
     effort?: 'none' | 'minimal' | 'low' | 'medium' | 'high';
+    // Transient: how many proposals the user denied since their last send (the
+    // UI clears its counter after sending). Folded into the system prompt for
+    // this turn only — never persisted, never shown in the visible message.
+    deniedProposalCount?: number;
   };
 
   if (!Array.isArray(messages)) {
@@ -388,6 +392,7 @@ router.post('/chat', async (req, res): Promise<any> => {
       selectedDate: date,
       messages: messages as Parameters<typeof streamNutritionChat>[0]['messages'],
       effort,
+      deniedProposalCount,
     });
 
     // Build the UI message stream ONCE. Its onEnd callback persists the assistant

--- a/services/nutrition/agent.ts
+++ b/services/nutrition/agent.ts
@@ -21,6 +21,12 @@ export interface NutritionChatOptions {
   effort?: 'none' | 'minimal' | 'low' | 'medium' | 'high';
   /** When true, instructs the agent to log the entry immediately without asking follow-up questions. */
   autoConfirm?: boolean;
+  /**
+   * How many proposals the user denied since their previous message. Transient
+   * per-turn signal (the client passes it in the request body) folded into the
+   * system prompt so the agent reconsiders — kept out of the visible user message.
+   */
+  deniedProposalCount?: number;
 }
 
 /**
@@ -120,6 +126,7 @@ export async function streamNutritionChat({
   messages,
   effort,
   autoConfirm,
+  deniedProposalCount,
 }: NutritionChatOptions) {
   // Fetch context in parallel — degrade gracefully if DB not available
   const [recent, goals, todayDay] = await Promise.all([
@@ -238,6 +245,9 @@ Do NOT call \`propose_custom_food\` just because the user logged something once 
 ${summariseEntries(recent)}
 ` + (autoConfirm
     ? '\n\nIMPORTANT: This is an automated API call. Do NOT ask any follow-up questions. Do NOT ask for confirmation. Log the food entry immediately based on the prompt provided. Use your best judgment on quantities and macros. Call propose_entry as soon as you have identified the food and estimated the portion.'
+    : '')
+  + ((deniedProposalCount ?? 0) > 0
+    ? `\n\nIMPORTANT: The user just DENIED your ${(deniedProposalCount ?? 0) > 1 ? 'previous proposals' : 'previous proposal'} (the propose_entry/propose_custom_food card${(deniedProposalCount ?? 0) > 1 ? 's' : ''} above). Do not simply re-send the same proposal — reconsider your approach based on their latest message, and adjust the food, portion, or macros accordingly before proposing again.`
     : '');
 
   const modelMessages = await convertToModelMessages(messages);


### PR DESCRIPTION
Follow-up to #161. The deny flow prepended `(Note: I denied your previous proposal — please adjust.)` to the user's **visible** message. Instead, pass a transient `deniedProposalCount` in the request body (like `selectedDate`); the backend folds it into the system prompt for that turn only.

- Invisible in the UI transcript, never persisted.
- Agent still reconsiders — backend smoke-tested live: with `deniedProposalCount:1` and a clean user message, the agent re-searched and re-proposed an adjusted portion (small banana 101g vs the denied 126g), no errors, and the note text appears 0× in the stream.

Files: `NutritionChat.tsx` (body flag, drop the prepend), `routes/nutrition.ts` (read + pass through), `services/nutrition/agent.ts` (fold into system prompt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)