### PR TITLE
Fix: widen entry three-dots dropdown to prevent text wrap

### DIFF
--- a/client/src/features/nutrition/NutritionTracker.module.scss
+++ b/client/src/features/nutrition/NutritionTracker.module.scss
@@ -337,7 +337,8 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
-  min-width: 110px;
+  min-width: 170px;
+  max-width: calc(100vw - 32px);
   z-index: 200;
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.45);
 }
@@ -353,6 +354,7 @@
   border-radius: 7px;
   cursor: pointer;
   text-align: left;
+  white-space: nowrap;
   // Explicit tap target
   min-height: 44px;
   display: flex;


### PR DESCRIPTION
## Summary
- The per-entry three-dots dropdown (`.entryDropdown` in NutritionTracker.module.scss) had a `min-width` of only 110px, causing "Save as meal" to wrap to two lines.
- Bumped `min-width` to 170px and added `max-width: calc(100vw - 32px)` so the dropdown can never overflow a mobile viewport.
- Added `white-space: nowrap` to `.entryDropdownItem` so item labels stay on one line.
- The dropdown remains right-aligned (`right: 0` inside a `position: relative` wrapper anchored at the card's top-right), so widening it grows the box leftward — it won't run off the right edge of the screen.

Closes #160

## Test plan
- [x] `npx tsc --noEmit` — no errors
- [x] `npm run build` — succeeds
- [x] Verified computed width of `.entryDropdown` (170px+) is wider than the "Save as meal" label so it no longer wraps