### PR TITLE
Fix habit three-dots menu clipping and text wrapping

### DIFF
--- a/client/src/styles/HabitTracker.module.scss
+++ b/client/src/styles/HabitTracker.module.scss
@@ -308,8 +308,22 @@
   background-color: $surface;
   border: 2px solid $surface-border;
   border-radius: $border-radius;
-  overflow: hidden;
+  // #162: was `overflow: hidden`, which clipped the per-habit three-dots
+  // menu (positioned absolute inside a child). The dropdown itself never
+  // scrolls, so `visible` is safe; corner rounding is restored below on
+  // the first/last child instead of relying on clipping.
+  overflow: visible;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+
+  > *:first-child {
+    border-top-left-radius: $border-radius;
+    border-top-right-radius: $border-radius;
+  }
+
+  > *:last-child {
+    border-bottom-left-radius: $border-radius;
+    border-bottom-right-radius: $border-radius;
+  }
 }
 
 // ── Habit list item ────────────────────────────────────────────────────────────
@@ -382,6 +396,8 @@
 
 .habitMenu {
   position: absolute;
+  // Anchored by `right` (not `left`) so it naturally grows leftward as its
+  // content needs more room, keeping it clear of the right screen edge.
   right: 4px;
   top: calc(100% + 2px);
   z-index: 30;
@@ -389,13 +405,18 @@
   border: 1.5px solid $surface-border;
   border-radius: 10px;
   overflow: hidden;
-  min-width: 110px;
+  // #162: wide enough for the longest item ("Skip days with no tallys")
+  // on one line; width still grows with content via max-content.
+  min-width: 200px;
+  width: max-content;
+  max-width: calc(100vw - 32px);
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.5);
 }
 
 .habitMenuItem {
   display: block;
   width: 100%;
+  min-height: 40px;
   padding: 11px 14px;
   background: none;
   border: none;
@@ -404,8 +425,10 @@
   font-size: 15px;
   letter-spacing: $sarabun-spacing;
   text-align: left;
+  white-space: nowrap;
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
+  box-sizing: border-box;
 
   & + & {
     border-top: 1px solid rgba($surface-border, 0.5);


### PR DESCRIPTION
## Summary
- `.habitDropdown` had `overflow: hidden` which clipped the per-habit three-dots (⋮) options menu since it's positioned absolute inside a descendant (`.habitItem`). Switched to `overflow: visible`; rounded corners are now applied directly to the dropdown's first/last child instead of relying on clipping, so the visual appearance is unchanged.
- `.habitMenu` was `min-width: 110px`, too narrow for the longest item ("Skip days with no tallys"), causing wrapping. Bumped to `min-width: 200px` with `width: max-content` and `max-width: calc(100vw - 32px)` so it sizes to content but never overflows the viewport.
- `.habitMenuItem` now has `white-space: nowrap` (guarantees one line) and `min-height: 40px` (mobile tap target).
- The menu is anchored via `right: 4px` only (no `left`), so it already grows leftward as content needs more room — keeping it clear of the right edge without extra positioning logic.

Closes #162

## Test plan
- [x] `cd client && npm run build` — succeeds (pre-existing Sass `@import` deprecation warnings only, unrelated to this change)
- [ ] Manually open a habit's three-dots menu in the app and confirm it's fully visible (not clipped) and all items render on one line