### PR TITLE
fix: left-align ingredient card title, compact add-ingredient button

### DIFF
--- a/client/src/features/nutrition/EntryEditor.module.scss
+++ b/client/src/features/nutrition/EntryEditor.module.scss
@@ -150,6 +150,13 @@
   gap: 12px;
 }
 
+.ingredientsHeaderRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
 .ingredientsLabel {
   font-family: $sarabun;
   font-size: 13px;
@@ -157,6 +164,26 @@
   letter-spacing: $sarabun-spacing;
   color: rgba($text, 0.6);
   text-transform: uppercase;
+}
+
+// Compact plus button, right-aligned in the "Ingredients" heading row
+.addIngredientBtn {
+  flex-shrink: 0;
+  min-width: 40px;
+  min-height: 40px;
+  padding: 0;
+  background-color: transparent;
+  color: $primary;
+  border: 2px solid $primary-border;
+  border-radius: 8px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:active {
+    background-color: $primary-translucent;
+  }
 }
 
 .ingredientsList {

--- a/client/src/features/nutrition/EntryEditor.tsx
+++ b/client/src/features/nutrition/EntryEditor.tsx
@@ -24,6 +24,7 @@ import type {
 } from './types';
 import { MEALS, MEAL_LABELS } from './types';
 import styles from './EntryEditor.module.scss';
+import { Plus } from 'lucide-react';
 import IngredientSheet, { IngredientCardList } from './IngredientSheet';
 import {
   GRAMS_UNIT,
@@ -424,11 +425,20 @@ export default function EntryEditor({
 
       {/* Ingredient cards + Add button */}
       <div className={styles.ingredientsSection}>
-        <span className={styles.ingredientsLabel}>Ingredients</span>
+        <div className={styles.ingredientsHeaderRow}>
+          <span className={styles.ingredientsLabel}>Ingredients</span>
+          <button
+            type="button"
+            className={styles.addIngredientBtn}
+            onClick={openSheetForAdd}
+            aria-label="Add ingredient"
+          >
+            <Plus size={16} aria-hidden="true" style={{ display: 'block' }} />
+          </button>
+        </div>
         <IngredientCardList
           rows={rows}
           onEditRow={openSheetForEdit}
-          onAddRow={openSheetForAdd}
         />
       </div>
 

--- a/client/src/features/nutrition/IngredientSheet.module.scss
+++ b/client/src/features/nutrition/IngredientSheet.module.scss
@@ -413,6 +413,7 @@
   display: flex;
   align-items: center;
   gap: 10px;
+  text-align: left; // buttons default to text-align:center — override so children left-align
   -webkit-tap-highlight-color: transparent;
 
   &:active {
@@ -426,10 +427,13 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
   gap: 5px;
 }
 
 .cardName {
+  align-self: stretch;
+  text-align: left;
   font-family: $sarabun;
   font-size: 15px;
   font-weight: 600;
@@ -482,28 +486,6 @@
   display: block; // iOS Safari SVG fix
   flex-shrink: 0;
   color: rgba($text, 0.3);
-}
-
-// Add ingredient button
-.addBtn {
-  align-self: flex-start;
-  min-height: 44px;
-  padding: 8px 16px;
-  background-color: transparent;
-  color: $primary;
-  border: 2px dashed $primary-border;
-  border-radius: 10px;
-  font-family: $sarabun;
-  font-size: 15px;
-  letter-spacing: $sarabun-spacing;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-
-  &:active {
-    background-color: $primary-translucent;
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/client/src/features/nutrition/IngredientSheet.tsx
+++ b/client/src/features/nutrition/IngredientSheet.tsx
@@ -8,7 +8,10 @@
  * the inline chat proposal card (not inside any dialog).
  *
  * Usage pattern (two sub-components exported):
- *   <IngredientCardList>   — renders the static summary cards + "Add ingredient" button.
+ *   <IngredientCardList>   — renders the static summary cards. The "Add ingredient"
+ *                            action lives in the caller's heading row (see EntryEditor /
+ *                            MealBuilder), not here — callers wire it to the same
+ *                            handler they pass in as `onAddRow` when opening the sheet.
  *   <IngredientSheet>      — the actual sheet (controls its own open state via onClose).
  *
  * Callers (EntryEditor, MealBuilder) lift the state: they own the `rows` array
@@ -28,7 +31,7 @@ import type {
   IngredientSource,
 } from './types';
 import styles from './IngredientSheet.module.scss';
-import { X, Plus, Trash2, ChevronRight, ScanBarcode } from 'lucide-react';
+import { X, Trash2, ChevronRight, ScanBarcode } from 'lucide-react';
 import {
   portionsCache,
   GRAMS_UNIT,
@@ -551,11 +554,9 @@ export interface IngredientCardListProps {
   rows: EditorRow[];
   /** Called with the row that was tapped — caller opens the sheet in edit mode. */
   onEditRow: (row: EditorRow) => void;
-  /** Called when "Add ingredient" is tapped — caller opens the sheet in add mode. */
-  onAddRow: () => void;
 }
 
-export function IngredientCardList({ rows, onEditRow, onAddRow }: IngredientCardListProps) {
+export function IngredientCardList({ rows, onEditRow }: IngredientCardListProps) {
   return (
     <div className={styles.cardList}>
       {rows.map(row => (
@@ -588,15 +589,6 @@ export function IngredientCardList({ rows, onEditRow, onAddRow }: IngredientCard
           />
         </button>
       ))}
-
-      <button
-        type="button"
-        className={styles.addBtn}
-        onClick={onAddRow}
-      >
-        <Plus size={16} aria-hidden="true" style={{ display: 'block' }} />
-        Add ingredient
-      </button>
     </div>
   );
 }

--- a/client/src/features/nutrition/MealBuilder.module.scss
+++ b/client/src/features/nutrition/MealBuilder.module.scss
@@ -194,6 +194,33 @@
   gap: 12px;
 }
 
+.sectionHeaderRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+// Compact plus button, right-aligned in the "Ingredients" heading row
+.addIngredientBtn {
+  flex-shrink: 0;
+  min-width: 40px;
+  min-height: 40px;
+  padding: 0;
+  background-color: transparent;
+  color: $primary;
+  border: 2px solid $primary-border;
+  border-radius: 8px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:active {
+    background-color: $primary-translucent;
+  }
+}
+
 .sectionLabel {
   font-family: $sarabun;
   font-size: 13px;

--- a/client/src/features/nutrition/MealBuilder.tsx
+++ b/client/src/features/nutrition/MealBuilder.tsx
@@ -546,11 +546,20 @@ export default function MealBuilder({ open, kind, initialDraft, prefillRows, onC
 
               {/* Ingredient cards */}
               <div className={styles.section}>
-                <span className={styles.sectionLabel}>Ingredients</span>
+                <div className={styles.sectionHeaderRow}>
+                  <span className={styles.sectionLabel}>Ingredients</span>
+                  <button
+                    type="button"
+                    className={styles.addIngredientBtn}
+                    onClick={openSheetForAdd}
+                    aria-label="Add ingredient"
+                  >
+                    <Plus size={16} aria-hidden="true" style={{ display: 'block' }} />
+                  </button>
+                </div>
                 <IngredientCardList
                   rows={rows}
                   onEditRow={openSheetForEdit}
-                  onAddRow={openSheetForAdd}
                 />
               </div>
 


### PR DESCRIPTION
## Summary
- **#167**: `.cardName` in `IngredientSheet.tsx`'s `IngredientCardList` was inheriting `text-align: center` from the `<button>` element's UA default. Explicitly set `text-align: left` on `.card` and `.cardName`, and `align-items: flex-start` on `.cardContent`.
- **#164**: Replaced the full-width dashed "Add ingredient" button at the bottom of `IngredientCardList` with a compact plus icon-button placed in the same row as the "Ingredients" heading label, right-aligned. Applied consistently in both `EntryEditor.tsx` and `MealBuilder.tsx`, wired to the same `onAddRow` handler each already had. Removed the now-unused `onAddRow` prop from `IngredientCardListProps` and the `.addBtn` style from `IngredientSheet.module.scss`.

## Changes
- `client/src/features/nutrition/IngredientSheet.tsx` / `.module.scss`
- `client/src/features/nutrition/EntryEditor.tsx` / `.module.scss`
- `client/src/features/nutrition/MealBuilder.tsx` / `.module.scss`

New `.addIngredientBtn` is a 40x40px tappable icon button (mobile touch-target compliant), `aria-label="Add ingredient"`, uses lucide `Plus` at `size={16}` with `style={{ display: 'block' }}` (iOS Safari SVG fix).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds
- [ ] Manual/visual check of ingredient card title alignment and new plus button in EntryEditor + MealBuilder

Closes #167
Closes #164