### PR TITLE
feat: customizable opt-in, reorderable tabs with homepage + empty state (#110)

### DIFF
--- a/client/src/api/tabPreferences.js
+++ b/client/src/api/tabPreferences.js
@@ -1,0 +1,45 @@
+// React Query hooks for the customizable-tabs feature (#110). Mirrors the
+// nutrition goals hooks (features/nutrition/api.ts): shared axios instance,
+// { data, message } envelope unwrapped, per-user and account-scoped.
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import clientApi from './clientApi.js';
+
+export const tabPreferencesKey = ['tab-preferences'];
+
+/**
+ * Fetch the user's ordered enabled tabs. Pass `enabled` (truthy only when logged
+ * in) so the query doesn't run for logged-out visitors. Returns string[] — an
+ * empty array means the new-account empty state.
+ */
+export function useTabPreferences(enabled) {
+  return useQuery({
+    queryKey: tabPreferencesKey,
+    queryFn: async () => {
+      const res = await clientApi.get('/users/tab-preferences');
+      return res.data.data;
+    },
+    enabled: !!enabled,
+  });
+}
+
+/** Persist the ordered enabled tabs. Optimistically updates the cache so the UI
+ *  (nav list, homepage) reacts instantly to toggles/reorders. */
+export function usePutTabPreferences() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (enabledTabs) => {
+      const res = await clientApi.put('/users/tab-preferences', { enabledTabs });
+      return res.data.data;
+    },
+    onMutate: async (enabledTabs) => {
+      await qc.cancelQueries({ queryKey: tabPreferencesKey });
+      const prev = qc.getQueryData(tabPreferencesKey);
+      qc.setQueryData(tabPreferencesKey, enabledTabs);
+      return { prev };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.prev !== undefined) qc.setQueryData(tabPreferencesKey, ctx.prev);
+    },
+    onSuccess: (data) => qc.setQueryData(tabPreferencesKey, data),
+  });
+}

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -7,10 +7,37 @@ import FeedbackModal from "../features/nutrition/FeedbackModal";
 import NavDrawer from "./NavDrawer";
 import { MessageSquare, Menu } from 'lucide-react';
 
-function Header() {
+/**
+ * Header.
+ *
+ * The nav drawer's open/edit state is *optionally controlled*: pass
+ * `drawerOpen` + `onDrawerOpenChange` (and optionally `editMode`) to drive it
+ * from a parent (Workouts does this so the empty-state CTA can open the drawer
+ * in edit mode). When those props are omitted (SignIn/SignUp), Header manages
+ * the state internally.
+ */
+function Header({
+  drawerOpen: controlledOpen,
+  onDrawerOpenChange,
+  editMode: controlledEditMode,
+  onEditModeChange,
+}) {
   const { user } = useUser();
   const [feedbackOpen, setFeedbackOpen] = useState(false);
-  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const [internalEditMode, setInternalEditMode] = useState(false);
+
+  const isControlled = controlledOpen !== undefined;
+  const drawerOpen = isControlled ? controlledOpen : internalOpen;
+  const setDrawerOpen = isControlled ? onDrawerOpenChange : setInternalOpen;
+
+  const editMode = controlledEditMode !== undefined ? controlledEditMode : internalEditMode;
+  const setEditMode = onEditModeChange ?? setInternalEditMode;
+
+  const closeDrawer = () => {
+    setDrawerOpen(false);
+    setEditMode(false);
+  };
 
   return (
     <>
@@ -64,8 +91,10 @@ function Header() {
       {/* #143: Left slide-out navigation drawer */}
       <NavDrawer
         open={drawerOpen}
-        onClose={() => setDrawerOpen(false)}
+        onClose={closeDrawer}
         user={user}
+        editMode={editMode}
+        onEditModeChange={setEditMode}
       />
     </>
   );

--- a/client/src/components/NavDrawer.jsx
+++ b/client/src/components/NavDrawer.jsx
@@ -1,43 +1,35 @@
 import { useEffect, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { X } from 'lucide-react';
+import { X, ChevronUp, ChevronDown, Plus, Minus } from 'lucide-react';
 import styles from '../styles/NavDrawer.module.scss';
-
-const TABS = {
-  WORKOUTS: 'workouts',
-  BODY_WEIGHT: 'body-weight',
-  HABITS: 'habits',
-  NUTRITION: 'nutrition',
-};
-
-const TAB_LABELS = {
-  [TABS.WORKOUTS]: 'Workouts',
-  [TABS.BODY_WEIGHT]: 'Body Weight',
-  [TABS.HABITS]: 'Habits',
-  [TABS.NUTRITION]: 'Nutrition',
-};
-
-const VALID_TABS = new Set(Object.values(TABS));
+import { TABS, TAB_LABELS, DEFAULT_ORDER, VALID_TABS } from '../config/tabs';
+import { useTabPreferences, usePutTabPreferences } from '../api/tabPreferences';
 
 /**
  * NavDrawer — left slide-out navigation panel.
  *
  * Props:
- *   open      {boolean}  whether the drawer is visible
- *   onClose   {function} called when user requests close (overlay tap / Escape / X / item select)
- *   user      {object|null|undefined}  auth state from useAuth / UserProvider
+ *   open         {boolean}  whether the drawer is visible
+ *   onClose      {function} called when user requests close
+ *   user         {object|null|undefined}  auth state
+ *   editMode     {boolean}  whether the tab-manager edit UI is showing (#110)
+ *   onEditModeChange {function(boolean)} toggle edit mode
  */
-function NavDrawer({ open, onClose, user }) {
+function NavDrawer({ open, onClose, user, editMode = false, onEditModeChange }) {
   const [searchParams, setSearchParams] = useSearchParams();
   const drawerRef = useRef(null);
+
+  const loggedIn = !!user;
+  const { data: prefs } = useTabPreferences(loggedIn);
+  const putPrefs = usePutTabPreferences();
 
   const tabParam = searchParams.get('tab');
   const activeTab = VALID_TABS.has(tabParam) ? tabParam : TABS.WORKOUTS;
 
-  const availableTabs = [
-    TABS.WORKOUTS,
-    ...(user ? [TABS.BODY_WEIGHT, TABS.HABITS, TABS.NUTRITION] : []),
-  ];
+  // Logged-in users navigate their enabled tabs (ordered); logged-out visitors
+  // only ever see Workouts. `prefs` is undefined while the query loads.
+  const enabled = loggedIn ? (prefs ?? []) : [TABS.WORKOUTS];
+  const disabled = DEFAULT_ORDER.filter((t) => !enabled.includes(t));
 
   // Escape key to close
   useEffect(() => {
@@ -66,6 +58,17 @@ function NavDrawer({ open, onClose, user }) {
     onClose();
   };
 
+  // ── Edit actions (#110) — each persists optimistically via putPrefs ──────────
+  const moveTab = (index, dir) => {
+    const next = [...enabled];
+    const j = index + dir;
+    if (j < 0 || j >= next.length) return;
+    [next[index], next[j]] = [next[j], next[index]];
+    putPrefs.mutate(next);
+  };
+  const removeTab = (tab) => putPrefs.mutate(enabled.filter((t) => t !== tab));
+  const addTab = (tab) => putPrefs.mutate([...enabled, tab]);
+
   return (
     <>
       {/* Overlay / scrim */}
@@ -86,35 +89,107 @@ function NavDrawer({ open, onClose, user }) {
         {/* Drawer header */}
         <div className={styles.drawerHeader}>
           <span className={styles.drawerTitle}>Menu</span>
-          <button
-            className={styles.closeBtn}
-            onClick={onClose}
-            aria-label="Close navigation menu"
-          >
-            <X size={16} aria-hidden="true" style={{ display: 'block' }} />
-          </button>
+          <div className={styles.drawerHeaderActions}>
+            {loggedIn && (
+              <button
+                className={`${styles.editBtn} ${editMode ? styles.editBtnActive : ''}`}
+                onClick={() => onEditModeChange?.(!editMode)}
+                aria-pressed={editMode}
+              >
+                {editMode ? 'Done' : 'Edit'}
+              </button>
+            )}
+            <button
+              className={styles.closeBtn}
+              onClick={onClose}
+              aria-label="Close navigation menu"
+            >
+              <X size={16} aria-hidden="true" style={{ display: 'block' }} />
+            </button>
+          </div>
         </div>
 
-        {/* Nav items */}
-        <nav aria-label="Main navigation">
-          <ul className={styles.navList} role="list">
-            {availableTabs.map((tab) => (
-              <li key={tab}>
-                <button
-                  className={`${styles.navItem} ${tab === activeTab ? styles.navItemActive : ''}`}
-                  onClick={() => handleTabSelect(tab)}
-                  aria-current={tab === activeTab ? 'page' : undefined}
-                >
-                  {TAB_LABELS[tab]}
-                </button>
-              </li>
-            ))}
-          </ul>
-        </nav>
+        {/* ── Normal navigation ──────────────────────────────────────────── */}
+        {!editMode && (
+          <nav aria-label="Main navigation">
+            <ul className={styles.navList} role="list">
+              {enabled.map((tab) => (
+                <li key={tab}>
+                  <button
+                    className={`${styles.navItem} ${tab === activeTab ? styles.navItemActive : ''}`}
+                    onClick={() => handleTabSelect(tab)}
+                    aria-current={tab === activeTab ? 'page' : undefined}
+                  >
+                    {TAB_LABELS[tab]}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        )}
+
+        {/* ── Edit mode: reorder + toggle tools (#110) ───────────────────── */}
+        {editMode && loggedIn && (
+          <div className={styles.editPanel}>
+            {enabled.length > 0 && (
+              <ul className={styles.editList} role="list">
+                {enabled.map((tab, index) => (
+                  <li key={tab} className={styles.editRow}>
+                    <span className={styles.editTabLabel}>{TAB_LABELS[tab]}</span>
+                    <div className={styles.editControls}>
+                      <button
+                        className={styles.iconBtn}
+                        onClick={() => moveTab(index, -1)}
+                        disabled={index === 0}
+                        aria-label={`Move ${TAB_LABELS[tab]} up`}
+                      >
+                        <ChevronUp size={16} aria-hidden="true" style={{ display: 'block' }} />
+                      </button>
+                      <button
+                        className={styles.iconBtn}
+                        onClick={() => moveTab(index, 1)}
+                        disabled={index === enabled.length - 1}
+                        aria-label={`Move ${TAB_LABELS[tab]} down`}
+                      >
+                        <ChevronDown size={16} aria-hidden="true" style={{ display: 'block' }} />
+                      </button>
+                      <button
+                        className={`${styles.iconBtn} ${styles.removeBtn}`}
+                        onClick={() => removeTab(tab)}
+                        aria-label={`Remove ${TAB_LABELS[tab]}`}
+                      >
+                        <Minus size={16} aria-hidden="true" style={{ display: 'block' }} />
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            {disabled.length > 0 && (
+              <div className={styles.addSection}>
+                <span className={styles.addHeading}>Add tools</span>
+                <ul className={styles.editList} role="list">
+                  {disabled.map((tab) => (
+                    <li key={tab} className={styles.editRow}>
+                      <span className={styles.editTabLabel}>{TAB_LABELS[tab]}</span>
+                      <button
+                        className={`${styles.iconBtn} ${styles.addBtn}`}
+                        onClick={() => addTab(tab)}
+                        aria-label={`Add ${TAB_LABELS[tab]}`}
+                      >
+                        <Plus size={16} aria-hidden="true" style={{ display: 'block' }} />
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        )}
       </div>
     </>
   );
 }
 
 export default NavDrawer;
-export { TABS, TAB_LABELS, VALID_TABS };

--- a/client/src/components/TabsEmptyState.jsx
+++ b/client/src/components/TabsEmptyState.jsx
@@ -1,0 +1,35 @@
+import { LayoutGrid, Plus } from 'lucide-react';
+import styles from '../styles/TabsEmptyState.module.scss';
+import { DEFAULT_ORDER, TAB_LABELS } from '../config/tabs';
+
+/**
+ * TabsEmptyState (#110) — shown in <main> when a logged-in user has no tabs
+ * enabled (a fresh account, or after disabling all tools). Explains the
+ * available tools and prompts the user to add one, opening the nav drawer's
+ * tab-manager in edit mode via `onAddTools`.
+ */
+function TabsEmptyState({ onAddTools }) {
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.iconCircle} aria-hidden="true">
+        <LayoutGrid size={28} style={{ display: 'block' }} />
+      </div>
+      <h2 className={styles.heading}>No tools enabled</h2>
+      <p className={styles.subtext}>
+        Pick the tools you want to use and set their order. The first tool is your
+        home screen.
+      </p>
+      <ul className={styles.toolList}>
+        {DEFAULT_ORDER.map((tab) => (
+          <li key={tab} className={styles.toolChip}>{TAB_LABELS[tab]}</li>
+        ))}
+      </ul>
+      <button type="button" className={styles.cta} onClick={onAddTools}>
+        <Plus size={18} aria-hidden="true" style={{ display: 'block' }} />
+        Add tools
+      </button>
+    </div>
+  );
+}
+
+export default TabsEmptyState;

--- a/client/src/config/tabs.js
+++ b/client/src/config/tabs.js
@@ -1,0 +1,29 @@
+// Single source of truth for the four top-level "tools" (tabs). Keys must match
+// the server's TAB_KEYS in schemas/tabPreferences.ts (kept in sync by hand — the
+// client and server are separate npm projects). Consolidates constants that used
+// to be duplicated in Workouts.jsx and NavDrawer.jsx.
+
+export const TABS = {
+  WORKOUTS: 'workouts',
+  BODY_WEIGHT: 'body-weight',
+  HABITS: 'habits',
+  NUTRITION: 'nutrition',
+};
+
+export const TAB_LABELS = {
+  [TABS.WORKOUTS]: 'Workouts',
+  [TABS.BODY_WEIGHT]: 'Body Weight',
+  [TABS.HABITS]: 'Habits',
+  [TABS.NUTRITION]: 'Nutrition',
+};
+
+// Default order for new/backfilled accounts; also the canonical ordering used to
+// list disabled tabs in the "Add tools" section.
+export const DEFAULT_ORDER = [
+  TABS.WORKOUTS,
+  TABS.BODY_WEIGHT,
+  TABS.HABITS,
+  TABS.NUTRITION,
+];
+
+export const VALID_TABS = new Set(DEFAULT_ORDER);

--- a/client/src/pages/Workouts.jsx
+++ b/client/src/pages/Workouts.jsx
@@ -3,6 +3,7 @@ import AddSection from '../components/AddSection.jsx';
 import BodyWeightTracker from '../components/BodyWeightTracker.jsx';
 import HabitTracker from '../components/HabitTracker.jsx';
 import NutritionTracker from '../features/nutrition/NutritionTracker';
+import TabsEmptyState from '../components/TabsEmptyState.jsx';
 import { useState, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import styles from "../styles/Workouts.module.scss";
@@ -10,32 +11,49 @@ import Header from '../components/Header.jsx';
 import clientApi from '../api/clientApi.js';
 import useAuth from '../hooks/useAuth.js';
 import { useQuery } from '@tanstack/react-query';
-
-const TABS = {
-  WORKOUTS: 'workouts',
-  BODY_WEIGHT: 'body-weight',
-  HABITS: 'habits',
-  NUTRITION: 'nutrition',
-};
-
-const VALID_TABS = new Set(Object.values(TABS));
+import { TABS } from '../config/tabs';
+import { useTabPreferences } from '../api/tabPreferences';
 
 function Workouts() {
   const [sections, setSections] = useState([]);
   const { user } = useAuth();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  // Derive active tab from URL; fall back to WORKOUTS for unknown values
-  const tabParam = searchParams.get('tab');
-  const activeTab = VALID_TABS.has(tabParam) ? tabParam : TABS.WORKOUTS;
+  // Nav drawer state lives here (not in Header) so the empty-state CTA can open
+  // the tab manager in edit mode. #110
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [editMode, setEditMode] = useState(false);
 
-  // If a confirmed-logged-out user lands on an auth-only tab, redirect to Workouts.
-  // user === null means definitively logged out; undefined means still loading — don't redirect yet.
+  const loggedIn = !!user;
+  const { data: prefs, isLoading: prefsLoading } = useTabPreferences(loggedIn);
+  const enabledTabs = loggedIn ? (prefs ?? []) : [TABS.WORKOUTS];
+  const enabledKey = enabledTabs.join('|');
+
+  const tabParam = searchParams.get('tab');
+
+  // Resolve the tab to render. Logged-out → Workouts only. Logged-in → the
+  // requested tab if it's enabled, else the first enabled tab (the homepage).
+  // null = show the empty state (logged-in with no enabled tabs). #110
+  let activeTab;
+  if (!loggedIn) {
+    activeTab = TABS.WORKOUTS;
+  } else if (enabledTabs.length > 0) {
+    activeTab = enabledTabs.includes(tabParam) ? tabParam : enabledTabs[0];
+  } else {
+    activeTab = null;
+  }
+
+  // Auto-open onto the homepage: if the URL's tab isn't enabled, redirect to the
+  // first enabled tab. Waits for prefs to load so we don't flash Workouts. #110
   useEffect(() => {
-    if (user === null && activeTab !== TABS.WORKOUTS) {
-      setSearchParams({ tab: TABS.WORKOUTS }, { replace: true });
+    if (!loggedIn || prefsLoading) return;
+    if (enabledTabs.length === 0) return; // empty state — nowhere to redirect
+    if (!tabParam || !enabledTabs.includes(tabParam)) {
+      setSearchParams({ tab: enabledTabs[0] }, { replace: true });
     }
-  }, [user, activeTab, setSearchParams]);
+    // enabledKey captures the enabled-tabs identity without an unstable array dep
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loggedIn, prefsLoading, enabledKey, tabParam, setSearchParams]);
 
   const sectionsQuery = useQuery({
     queryKey: ['sections'],
@@ -55,10 +73,23 @@ function Workouts() {
     }
   }, [sectionsQuery.data]);
 
+  const showEmptyState = loggedIn && !prefsLoading && enabledTabs.length === 0;
+
   return (
     <>
-      <Header />
+      <Header
+        drawerOpen={drawerOpen}
+        onDrawerOpenChange={setDrawerOpen}
+        editMode={editMode}
+        onEditModeChange={setEditMode}
+      />
       <main className={styles.container}>
+        {showEmptyState && (
+          <TabsEmptyState
+            onAddTools={() => { setDrawerOpen(true); setEditMode(true); }}
+          />
+        )}
+
         {/* All panels stay mounted to preserve in-memory state; hidden via CSS */}
         <div style={{ display: activeTab === TABS.WORKOUTS ? undefined : 'none' }}>
           {sections.map((s) => (

--- a/client/src/styles/NavDrawer.module.scss
+++ b/client/src/styles/NavDrawer.module.scss
@@ -59,6 +59,43 @@
   text-transform: uppercase;
 }
 
+.drawerHeaderActions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+// #110: Edit / Done toggle for the tab manager
+.editBtn {
+  background: transparent;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 12px;
+  min-height: 44px;
+  cursor: pointer;
+  color: rgba($text, 0.7);
+  font-family: $sarabun;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: $sarabun-spacing;
+
+  &:active {
+    background: $primary-translucent;
+    color: $primary;
+  }
+
+  @media (hover: hover) {
+    &:hover {
+      background: rgba($primary, 0.08);
+      color: $text;
+    }
+  }
+}
+
+.editBtnActive {
+  color: $primary;
+}
+
 .closeBtn {
   display: flex;
   align-items: center;
@@ -131,4 +168,129 @@
   color: $primary;
   background: $primary-translucent;
   font-weight: 600;
+}
+
+// ── Edit mode (#110) ─────────────────────────────────────────────────────────
+.editPanel {
+  padding: 12px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  overflow-y: auto;
+}
+
+.editList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.editRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 4px 6px 4px 12px;
+  border-radius: 10px;
+  min-height: 48px;
+  background: rgba($text, 0.03);
+}
+
+.editTabLabel {
+  color: rgba($text, 0.9);
+  font-family: $sarabun;
+  font-size: 17px;
+  font-weight: 500;
+  letter-spacing: $sarabun-spacing;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.editControls {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.iconBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  min-width: 40px;
+  background: transparent;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  color: rgba($text, 0.7);
+
+  &:active {
+    background: rgba($primary, 0.12);
+    color: $primary;
+  }
+
+  &:disabled {
+    opacity: 0.3;
+    cursor: default;
+  }
+
+  @media (hover: hover) {
+    &:hover:not(:disabled) {
+      background: rgba($primary, 0.08);
+      color: $text;
+    }
+  }
+}
+
+.removeBtn {
+  color: rgba($error, 0.85);
+
+  &:active {
+    background: rgba($error, 0.14);
+    color: $error;
+  }
+
+  @media (hover: hover) {
+    &:hover:not(:disabled) {
+      background: rgba($error, 0.1);
+      color: $error;
+    }
+  }
+}
+
+.addBtn {
+  color: $primary;
+
+  &:active {
+    background: $primary-translucent;
+  }
+
+  @media (hover: hover) {
+    &:hover:not(:disabled) {
+      background: rgba($primary, 0.1);
+      color: $primary;
+    }
+  }
+}
+
+.addSection {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.addHeading {
+  padding: 0 12px;
+  color: rgba($text, 0.45);
+  font-family: $sarabun;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: $sarabun-spacing;
+  text-transform: uppercase;
 }

--- a/client/src/styles/TabsEmptyState.module.scss
+++ b/client/src/styles/TabsEmptyState.module.scss
@@ -1,0 +1,90 @@
+@import "variables";
+
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  max-width: 420px;
+  margin: 0 auto;
+  padding: 12vh 8px 0;
+  gap: 14px;
+}
+
+.iconCircle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 68px;
+  height: 68px;
+  border-radius: 50%;
+  background: $primary-translucent;
+  color: $primary;
+}
+
+.heading {
+  margin: 0;
+  color: $text;
+  font-family: $sarabun;
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: $sarabun-spacing;
+}
+
+.subtext {
+  margin: 0;
+  color: rgba($text, 0.6);
+  font-family: $sarabun;
+  font-size: 16px;
+  line-height: 1.5;
+  letter-spacing: $sarabun-spacing;
+}
+
+.toolList {
+  list-style: none;
+  margin: 6px 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+}
+
+.toolChip {
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid $surface-border;
+  color: rgba($text, 0.7);
+  font-family: $sarabun;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: $sarabun-spacing;
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+  padding: 12px 22px;
+  min-height: 48px;
+  border: none;
+  border-radius: 12px;
+  cursor: pointer;
+  background: $primary;
+  color: $background;
+  font-family: $sarabun;
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: $sarabun-spacing;
+
+  &:active {
+    background: $primary-dark;
+  }
+
+  @media (hover: hover) {
+    &:hover {
+      background: $primary-dark;
+    }
+  }
+}

--- a/migrations/014_tab_preferences.sql
+++ b/migrations/014_tab_preferences.sql
@@ -1,0 +1,9 @@
+CREATE TABLE tab_preferences (
+  user_uuid BINARY(16) PRIMARY KEY,
+  enabled_tabs JSON NOT NULL,
+  FOREIGN KEY (user_uuid) REFERENCES users(user_uuid) ON DELETE CASCADE
+);
+
+INSERT INTO tab_preferences (user_uuid, enabled_tabs)
+SELECT user_uuid, JSON_ARRAY('workouts', 'body-weight', 'habits', 'nutrition')
+FROM users

--- a/routes/users.ts
+++ b/routes/users.ts
@@ -7,9 +7,37 @@ import bcrypt from 'bcrypt';
 const { NULL_ERROR, PARSE_ERROR, DUPLICATE_ERROR } = SqlError;
 import { authenticateToken } from "./auth";
 import { User } from "../types";
+import { tabPreferencesSchema } from "../schemas/tabPreferences";
+import { getTabPreferences, putTabPreferences } from "../services/tabPreferences";
 
 const router = Router();
 router.use(authenticateToken);
+
+// #110: customizable tabs — ordered list of enabled top-level tabs (element[0] is
+// the user's homepage). Missing row → [] → client shows the new-account empty state.
+router.get('/tab-preferences', async (req, res): Promise<any> => {
+    const { uuid }: User = res.locals.user;
+    try {
+        const data = await getTabPreferences(uuid);
+        return res.status(200).json({ data, message: "Successfully retrieved tab preferences" });
+    } catch (error) {
+        return handleSqlError(error, res);
+    }
+});
+
+router.put('/tab-preferences', async (req, res): Promise<any> => {
+    const { uuid }: User = res.locals.user;
+    const parsed = tabPreferencesSchema.safeParse(req.body);
+    if (!parsed.success) {
+        return res.status(400).json({ message: parsed.error.issues[0]?.message ?? 'Invalid request body' });
+    }
+    try {
+        const data = await putTabPreferences(uuid, parsed.data.enabledTabs);
+        return res.status(200).json({ data, message: "Tab preferences saved" });
+    } catch (error) {
+        return handleSqlError(error, res);
+    }
+});
 
 // Create
 router.post('/', async (req, res): Promise<any> => {

--- a/schemas/tabPreferences.ts
+++ b/schemas/tabPreferences.ts
@@ -1,0 +1,22 @@
+// Shared contract for the customizable-tabs feature (#110): which top-level
+// tabs a user has enabled, and in what order. Stored per-user as an ordered
+// JSON array of tab keys; element[0] is the user's homepage. The client mirrors
+// these keys in client/src/config/tabs.js (kept in sync by hand).
+import { z } from 'zod';
+
+// The four top-level "tools". Order here is the default order for new/backfilled
+// accounts. Keys must match the client's TABS in client/src/config/tabs.js.
+export const TAB_KEYS = ['workouts', 'body-weight', 'habits', 'nutrition'] as const;
+export type TabKey = (typeof TAB_KEYS)[number];
+
+// PUT /users/tab-preferences body: an ordered, duplicate-free list of valid keys.
+export const tabPreferencesSchema = z.object({
+  enabledTabs: z
+    .array(z.enum(TAB_KEYS))
+    .max(TAB_KEYS.length)
+    .refine((arr) => new Set(arr).size === arr.length, {
+      message: 'enabledTabs must not contain duplicates',
+    }),
+});
+
+export type TabPreferencesInput = z.infer<typeof tabPreferencesSchema>;

--- a/services/tabPreferences.ts
+++ b/services/tabPreferences.ts
@@ -1,0 +1,38 @@
+// Tab-preferences data access (#110) — the single place that touches the
+// tab_preferences table. Scoped per user via `WHERE user_uuid = UUID_TO_BIN(?)`.
+// enabled_tabs is stored as an ordered JSON array of tab keys; element[0] is the
+// user's homepage. A missing row means "no preferences yet" → empty list, which
+// the client renders as the new-account empty state.
+import { RowDataPacket } from 'mysql2';
+import pool from '../database';
+import { TabKey } from '../schemas/tabPreferences';
+
+/** Read the user's ordered enabled tabs. Returns [] when no row exists. */
+export async function getTabPreferences(userUuid: string): Promise<TabKey[]> {
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `SELECT enabled_tabs
+     FROM tab_preferences
+     WHERE user_uuid = UUID_TO_BIN(?)`,
+    [userUuid],
+  );
+  if (rows.length === 0) return [];
+  const value = rows[0].enabled_tabs;
+  // mysql2 returns JSON columns already parsed; guard against a driver that
+  // hands back a string just in case.
+  const arr = typeof value === 'string' ? JSON.parse(value) : value;
+  return Array.isArray(arr) ? (arr as TabKey[]) : [];
+}
+
+/** Upsert the user's ordered enabled tabs; returns the stored list. */
+export async function putTabPreferences(
+  userUuid: string,
+  enabledTabs: TabKey[],
+): Promise<TabKey[]> {
+  await pool.query(
+    `INSERT INTO tab_preferences (user_uuid, enabled_tabs)
+     VALUES (UUID_TO_BIN(?), CAST(? AS JSON))
+     ON DUPLICATE KEY UPDATE enabled_tabs = VALUES(enabled_tabs)`,
+    [userUuid, JSON.stringify(enabledTabs)],
+  );
+  return getTabPreferences(userUuid);
+}


### PR DESCRIPTION
Closes #110

## What
Top-level tabs — **Workouts, Body Weight, Habits, Nutrition** — are now per-user **opt-in** and **reorderable**. The **first enabled tab is the homepage** the app auto-opens onto. A logged-in user with no enabled tabs sees an **empty state** prompting them to add tools.

## Decisions
- Manage UI lives **inline in the nav drawer** (an Edit mode), reorder via **up/down arrows** (mobile-safe, no drag lib).
- **New accounts start empty** (→ empty state); a migration **backfills existing users with all four** enabled so nothing breaks.
- DB-backed per user (mirrors the nutrition-goals pattern). Logged-out users unchanged (Workouts only, no Edit).

## Changes
**Backend**
- `migrations/014_tab_preferences.sql` — `tab_preferences(user_uuid, enabled_tabs JSON)`, ordered array of enabled keys; backfills existing users. New accounts have no row → `[]` → empty state.
- `services/tabPreferences.ts` + `GET`/`PUT /api/users/tab-preferences` (zod-validated via `schemas/tabPreferences.ts`).

**Frontend**
- `client/src/config/tabs.js` — shared tab config (removes the `TABS` constant duplicated in Workouts.jsx + NavDrawer.jsx).
- `client/src/api/tabPreferences.js` — React Query hooks (optimistic).
- `NavDrawer` edit mode (reorder + enable/disable), `TabsEmptyState` component, prefs-aware homepage/routing in `Workouts.jsx`. Drawer open/edit state lifted to Workouts (Header made optionally-controlled) so the empty-state CTA opens the manager.

## Verification (Playwright, local Docker DB)
Migration applied + backfilled. Server `tsc` + client build clean. Drove every path: existing-user all-four/opens Workouts; reorder → homepage follows element[0]; disable → gone from nav + disabled `?tab=` redirects; disable-all → empty state; CTA opens drawer edit mode; add-from-empty enables + navigates; **new account (no row) → empty state**; logged-out → Workouts only, no Edit; persistence across reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)