### PR TITLE
fix: nightly retention policy for chat images to prevent DB quota exhaustion

### DIFF
--- a/client/src/features/nutrition/BarcodeAttachmentCard.tsx
+++ b/client/src/features/nutrition/BarcodeAttachmentCard.tsx
@@ -50,7 +50,7 @@ export default function BarcodeAttachmentCard({ open, data, onClose }: BarcodeAt
           </div>
 
           <div className={styles.body}>
-            {data.imageDataUrl && (
+            {data.imageDataUrl ? (
               <img
                 src={data.imageDataUrl}
                 alt=""
@@ -64,7 +64,11 @@ export default function BarcodeAttachmentCard({ open, data, onClose }: BarcodeAt
                   display: 'block',
                 }}
               />
-            )}
+            ) : data.imageRedacted ? (
+              <p style={{ fontSize: 12, fontStyle: 'italic', opacity: 0.6, margin: '0 0 12px' }}>
+                Photo no longer available
+              </p>
+            ) : null}
 
             <div className={styles.nameRow}>
               <div className={styles.nameInputWrap}>

--- a/client/src/features/nutrition/NutritionChat.module.scss
+++ b/client/src/features/nutrition/NutritionChat.module.scss
@@ -674,6 +674,31 @@
   color: $background;
 }
 
+// ---- Redacted image marker chip ----
+// Replaces a `file` image part once the nightly retention job strips its
+// base64 data out (2+ days old). Styled like .interruptedMarker — a small,
+// visually distinct note rather than the image just silently vanishing.
+.imageRedactedChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  background-color: rgba($surface-border, 0.15);
+  border: 1px solid rgba($surface-border, 0.4);
+  border-radius: 8px;
+  font-family: $sarabun;
+  font-size: 12px;
+  color: rgba($text, 0.55);
+  letter-spacing: $sarabun-spacing;
+}
+
+// Inline note appended to a barcode attachment chip's name when its photo
+// has been redacted by the same retention job.
+.imageRedactedNote {
+  color: rgba($text, 0.45);
+  font-style: italic;
+}
+
 // ---- Sent barcode-attachment chip (rendered inline in the message thread) ----
 .barcodeAttachmentChip {
   position: relative;

--- a/client/src/features/nutrition/NutritionChat.tsx
+++ b/client/src/features/nutrition/NutritionChat.tsx
@@ -44,9 +44,9 @@ import BarcodeScanner from './BarcodeScanner';
 import BarcodeAttachmentCard from './BarcodeAttachmentCard';
 import ToolCallCard from './ToolCallCard';
 import ConfirmModal from '../../components/ConfirmModal';
-import type { EntryInput, EntryEditorMode, ProposeEntryArgs, ProposeCustomFoodArgs, CustomFoodInput, BarcodeAttachmentData } from './types';
+import type { EntryInput, EntryEditorMode, ProposeEntryArgs, ProposeCustomFoodArgs, CustomFoodInput, BarcodeAttachmentData, ImageRedactedData } from './types';
 import styles from './NutritionChat.module.scss';
-import { ChevronDown, Trash2, Camera, ScanBarcode, Square, Send, Images, AlertCircle, ChevronRight, MessageSquare } from 'lucide-react';
+import { ChevronDown, Trash2, Camera, ScanBarcode, Square, Send, Images, AlertCircle, ChevronRight, MessageSquare, ImageOff } from 'lucide-react';
 import useIsMobile from '../../hooks/useIsMobile';
 
 // ---------------------------------------------------------------------------
@@ -563,6 +563,21 @@ function ChatMessage({
           );
         }
 
+        // ---- Redacted image marker (photo stripped by the nightly retention job) ----
+        // Replaces a `file` image part once the message is 2+ days old (see
+        // scripts/redactOldChatImages.js). Rendered as a small, visually distinct
+        // chip so the redaction leaves a visible trace instead of the image just
+        // silently disappearing.
+        if (part.type === 'data-imageRedacted') {
+          const data = (part as unknown as { data: ImageRedactedData }).data;
+          return (
+            <div key={idx} className={styles.imageRedactedChip} title={data?.mediaType}>
+              <ImageOff size={16} aria-hidden="true" style={{ display: 'block' }} />
+              <span>Photo no longer available</span>
+            </div>
+          );
+        }
+
         // ---- Barcode attachment part (a scanned barcode attached to this message) ----
         // Renders as a tappable chip; tap opens the read-only BarcodeAttachmentCard.
         if (part.type === 'data-barcodeAttachment') {
@@ -579,11 +594,18 @@ function ChatMessage({
                 <img src={data.imageDataUrl} alt="" aria-hidden="true" className={styles.barcodeAttachmentThumb} />
               ) : (
                 <span className={styles.barcodeAttachmentThumbFallback} aria-hidden="true">
-                  <ScanBarcode size={16} aria-hidden="true" style={{ display: 'block' }} />
+                  {data.imageRedacted ? (
+                    <ImageOff size={16} aria-hidden="true" style={{ display: 'block' }} />
+                  ) : (
+                    <ScanBarcode size={16} aria-hidden="true" style={{ display: 'block' }} />
+                  )}
                 </span>
               )}
               <ScanBarcode className={styles.barcodeAttachmentBadge} size={16} aria-hidden="true" style={{ display: 'block' }} />
-              <span className={styles.barcodeAttachmentName}>{data.product.name}</span>
+              <span className={styles.barcodeAttachmentName}>
+                {data.product.name}
+                {data.imageRedacted && <span className={styles.imageRedactedNote}> · photo no longer available</span>}
+              </span>
             </button>
           );
         }

--- a/client/src/features/nutrition/types.ts
+++ b/client/src/features/nutrition/types.ts
@@ -53,6 +53,20 @@ export interface BarcodeAttachmentData {
   code: string;
   imageDataUrl?: string | null;
   product: FoodSearchResult;
+  // Set by the nightly chat-image retention job (scripts/redactOldChatImages.js)
+  // when it strips `imageDataUrl` out of an old (2+ days) transcript row.
+  // `imageDataUrl` will be null when this is true; the flag lets the UI show
+  // a "photo no longer available" note instead of silently having no image.
+  imageRedacted?: boolean;
+}
+
+// ---- Redacted image marker part ----
+// Replaces a chat `file` part (image/*) whose base64 data URI was stripped by
+// the nightly retention job (scripts/redactOldChatImages.js) once the message
+// is 2+ days old. `mediaType` is preserved from the original part purely for
+// display purposes (e.g. so the UI could say "photo" vs "image" if desired).
+export interface ImageRedactedData {
+  mediaType: string;
 }
 
 export interface IngredientInput {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "start": "node dist/index.js",
     "dev": "nodemon index.ts",
     "migrate": "node scripts/migrate.js",
+    "redact-chat-images": "node scripts/redactOldChatImages.js",
+    "test": "node --test scripts/*.test.js",
     "heroku-postbuild": "npm run build && cd client && npm install && npm run build"
   },
   "keywords": [],

--- a/scripts/chatImageRedaction.js
+++ b/scripts/chatImageRedaction.js
@@ -1,0 +1,74 @@
+// Pure logic for redacting embedded base64 images out of stored chat
+// transcript `parts` arrays. Split out from redactOldChatImages.js so it can
+// be unit-tested (node:test) without a DB connection.
+//
+// Root cause / context: chat_messages.parts stores AI SDK UIMessage parts as
+// JSON, and food photos get embedded as full base64 data URIs directly in
+// that JSON. With no retention policy this filled the production JawsDB
+// free-tier 5MB quota and took the whole DB read-only. This module implements
+// the redaction step of the fix: strip embedded image bytes from old rows
+// while leaving a visible marker behind so the UI can show "photo no longer
+// available" instead of silently dropping the attachment.
+'use strict';
+
+/** True if a value looks like a base64(ish) data: URI. */
+function isDataUri(value) {
+  return typeof value === 'string' && value.startsWith('data:');
+}
+
+/**
+ * Redact embedded image data out of a single UIMessage `parts` array.
+ *
+ * - `{ type: 'file', mediaType: 'image/...', url: 'data:...' }` parts are
+ *   replaced with `{ type: 'data-imageRedacted', data: { mediaType } }`.
+ * - `{ type: 'data-barcodeAttachment', data: { imageDataUrl: 'data:...' } }`
+ *   parts have `imageDataUrl` nulled out and `imageRedacted: true` set on
+ *   `data`, keeping `code`/`product` intact.
+ * - All other part types are left untouched (including already-redacted
+ *   parts, which makes this idempotent).
+ *
+ * Returns `{ parts, changed }` — `changed` is false when nothing needed
+ * redaction, letting the caller skip the UPDATE entirely.
+ */
+function redactParts(parts) {
+  if (!Array.isArray(parts)) return { parts, changed: false };
+
+  let changed = false;
+
+  const next = parts.map((part) => {
+    if (!part || typeof part !== 'object') return part;
+
+    if (
+      part.type === 'file' &&
+      typeof part.mediaType === 'string' &&
+      part.mediaType.startsWith('image/') &&
+      isDataUri(part.url)
+    ) {
+      changed = true;
+      return { type: 'data-imageRedacted', data: { mediaType: part.mediaType } };
+    }
+
+    if (
+      part.type === 'data-barcodeAttachment' &&
+      part.data &&
+      typeof part.data === 'object' &&
+      isDataUri(part.data.imageDataUrl)
+    ) {
+      changed = true;
+      return {
+        ...part,
+        data: {
+          ...part.data,
+          imageDataUrl: null,
+          imageRedacted: true,
+        },
+      };
+    }
+
+    return part;
+  });
+
+  return { parts: next, changed };
+}
+
+module.exports = { redactParts, isDataUri };

--- a/scripts/chatImageRedaction.test.js
+++ b/scripts/chatImageRedaction.test.js
@@ -1,0 +1,83 @@
+// Focused unit test for the pure redaction logic used by
+// scripts/redactOldChatImages.js. Uses Node's built-in test runner (no repo
+// test framework is configured for the backend, so this avoids adding one
+// just for this) — run with: node --test scripts/chatImageRedaction.test.js
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { redactParts } = require('./chatImageRedaction');
+
+test('redacts an embedded base64 image file part', () => {
+  const parts = [
+    { type: 'text', text: 'here is a photo' },
+    { type: 'file', mediaType: 'image/jpeg', url: 'data:image/jpeg;base64,AAAA' },
+  ];
+  const { parts: next, changed } = redactParts(parts);
+  assert.equal(changed, true);
+  assert.deepEqual(next[0], { type: 'text', text: 'here is a photo' });
+  assert.deepEqual(next[1], { type: 'data-imageRedacted', data: { mediaType: 'image/jpeg' } });
+});
+
+test('redacts a barcode attachment image while keeping code/product', () => {
+  const parts = [
+    {
+      type: 'data-barcodeAttachment',
+      data: {
+        code: '012345678905',
+        imageDataUrl: 'data:image/jpeg;base64,BBBB',
+        product: { name: 'Widget Bar' },
+      },
+    },
+  ];
+  const { parts: next, changed } = redactParts(parts);
+  assert.equal(changed, true);
+  assert.equal(next[0].data.imageDataUrl, null);
+  assert.equal(next[0].data.imageRedacted, true);
+  assert.equal(next[0].data.code, '012345678905');
+  assert.deepEqual(next[0].data.product, { name: 'Widget Bar' });
+});
+
+test('leaves non-image parts untouched', () => {
+  const parts = [
+    { type: 'text', text: 'hello' },
+    { type: 'tool-someTool', state: 'output-available', output: { ok: true } },
+  ];
+  const { parts: next, changed } = redactParts(parts);
+  assert.equal(changed, false);
+  assert.deepEqual(next, parts);
+});
+
+test('leaves a barcode attachment with no image untouched', () => {
+  const parts = [
+    { type: 'data-barcodeAttachment', data: { code: '123', imageDataUrl: null, product: {} } },
+  ];
+  const { parts: next, changed } = redactParts(parts);
+  assert.equal(changed, false);
+  assert.deepEqual(next, parts);
+});
+
+test('is idempotent — already-redacted parts are left alone on a second pass', () => {
+  const parts = [
+    { type: 'file', mediaType: 'image/jpeg', url: 'data:image/jpeg;base64,AAAA' },
+    {
+      type: 'data-barcodeAttachment',
+      data: { code: '123', imageDataUrl: 'data:image/jpeg;base64,BBBB', product: {} },
+    },
+  ];
+  const first = redactParts(parts);
+  assert.equal(first.changed, true);
+
+  const second = redactParts(first.parts);
+  assert.equal(second.changed, false);
+  assert.deepEqual(second.parts, first.parts);
+});
+
+test('does not redact a non-data-URI file url (e.g. a hosted image link)', () => {
+  const parts = [
+    { type: 'file', mediaType: 'image/jpeg', url: 'https://example.com/photo.jpg' },
+  ];
+  const { parts: next, changed } = redactParts(parts);
+  assert.equal(changed, false);
+  assert.deepEqual(next, parts);
+});

--- a/scripts/redactOldChatImages.js
+++ b/scripts/redactOldChatImages.js
@@ -1,0 +1,102 @@
+// Nightly retention job: strips embedded base64 image data out of old
+// chat_messages rows to keep the DB from filling up with photo bytes.
+//
+// Root cause: chat photos (food photos, barcode-scan screenshots) are stored
+// as full base64 data URIs directly inside chat_messages.parts (JSON). With
+// no retention policy this exceeded the JawsDB free-tier 5MB quota and put
+// the whole database into read-only mode (login/writes failing). That
+// incident was resolved manually in prod; this script prevents recurrence
+// going forward by redacting image bytes out of rows 2+ days old, on a
+// schedule (see README note below / PR description for the required Heroku
+// Scheduler setup — this script does not schedule itself).
+//
+// Safety: only rows with `date < (today UTC - 1 day)` are touched, i.e. we
+// never redact "today" or "yesterday" — same-day / just-yesterday
+// conversations always resume with images fully intact. Redacted parts are
+// replaced with a small marker (`data-imageRedacted` / `imageRedacted: true`)
+// rather than being silently dropped, so the client can render a "photo no
+// longer available" note instead of the attachment just vanishing.
+//
+// Run manually with: node scripts/redactOldChatImages.js
+// (Same connection convention as scripts/migrate.js: JAWSDB_URL if set,
+// otherwise discrete DB_HOST/DB_PORT/DB_USERNAME/DB_PASSWORD/DB_NAME env
+// vars, matching database.ts.)
+'use strict';
+
+const mysql = require('mysql2/promise');
+const { redactParts } = require('./chatImageRedaction');
+
+async function connect() {
+  if (process.env.JAWSDB_URL) {
+    return mysql.createPool(process.env.JAWSDB_URL);
+  }
+  return mysql.createPool({
+    host: process.env.DB_HOST,
+    port: process.env.DB_PORT ? parseInt(process.env.DB_PORT, 10) : 3306,
+    user: process.env.DB_USERNAME,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME,
+  });
+}
+
+/** Today (UTC) minus 1 day, as YYYY-MM-DD — rows with date < this are redacted. */
+function cutoffDate(now = new Date()) {
+  const utcMidnight = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  const cutoff = new Date(utcMidnight - 24 * 60 * 60 * 1000);
+  return cutoff.toISOString().slice(0, 10);
+}
+
+async function run() {
+  const pool = await connect();
+  const cutoff = cutoffDate();
+  console.log(`[redact-chat-images] cutoff date: rows with date < ${cutoff}`);
+
+  let scanned = 0;
+  let redacted = 0;
+  let bytesFreed = 0;
+
+  try {
+    // parts LIKE '%base64%' is a cheap pre-filter so we only JSON.parse rows
+    // that plausibly still contain embedded image data — this is what makes
+    // repeated runs cheap/idempotent (already-redacted rows drop out here).
+    const [rows] = await pool.query(
+      `SELECT id, parts FROM chat_messages WHERE date < ? AND parts LIKE '%base64%'`,
+      [cutoff],
+    );
+
+    for (const row of rows) {
+      scanned++;
+      let parsed;
+      try {
+        parsed = JSON.parse(row.parts);
+      } catch (err) {
+        console.error(`[redact-chat-images] row ${row.id}: failed to parse parts, skipping`, err);
+        continue;
+      }
+
+      const { parts: nextParts, changed } = redactParts(parsed);
+      if (!changed) continue;
+
+      const nextJson = JSON.stringify(nextParts);
+      bytesFreed += Buffer.byteLength(row.parts, 'utf8') - Buffer.byteLength(nextJson, 'utf8');
+
+      await pool.query('UPDATE chat_messages SET parts = ? WHERE id = ?', [nextJson, row.id]);
+      redacted++;
+    }
+  } finally {
+    await pool.end();
+  }
+
+  console.log(
+    `[redact-chat-images] scanned=${scanned} redacted=${redacted} bytesFreed=${bytesFreed}`,
+  );
+}
+
+if (require.main === module) {
+  run().catch((err) => {
+    console.error('[redact-chat-images] failed:', err);
+    process.exit(1);
+  });
+}
+
+module.exports = { run, cutoffDate };


### PR DESCRIPTION
## Root cause

`chat_messages.parts` stores AI SDK `UIMessage.parts` JSON per chat turn. Food photos are embedded as full base64 data URIs directly in `parts`, with zero retention policy. This recently exceeded the JawsDB free-tier 5MB storage quota and put the whole database into read-only mode (login/writes failing in prod). **That incident has already been resolved manually in prod via data cleanup** — this PR prevents recurrence.

## What changed

- **`scripts/chatImageRedaction.js`** — pure, unit-tested logic that walks a `parts` array and redacts embedded image data:
  - `{ type: 'file', mediaType: 'image/*', url: 'data:...' }` → replaced with `{ type: 'data-imageRedacted', data: { mediaType } }`
  - `{ type: 'data-barcodeAttachment', data: { imageDataUrl: 'data:...' } }` → `imageDataUrl` set to `null` and `imageRedacted: true` added to `data` (keeps `code`/`product`)
  - Everything else (text, tool calls, etc.) untouched; idempotent — a second pass over already-redacted rows is a no-op.
- **`scripts/chatImageRedaction.test.js`** — focused unit tests via Node's built-in `node:test` runner (no test framework was configured for the backend, so this avoids adding a new one just for this). Wired up as `npm test` in root `package.json`.
- **`scripts/redactOldChatImages.js`** — the nightly job. Connects to the DB the same way `scripts/migrate.js`/`database.ts` do (`JAWSDB_URL` or discrete `DB_*` env vars). Selects rows where `date < (today UTC − 1 day)` **and** `parts LIKE '%base64%'` (cheap idempotent pre-filter), applies the redaction, and `UPDATE`s only rows that actually changed. Logs scanned/redacted/bytes-freed counts.
  - **Safety buffer**: only rows 2+ calendar days old are ever touched — today's and yesterday's messages are never redacted, so same-day conversations always resume with images fully intact regardless of timezone.
  - New npm script: `npm run redact-chat-images` (runs `node scripts/redactOldChatImages.js`).
- **Client (`client/src/features/nutrition/`)**:
  - `types.ts` — added `ImageRedactedData` and an `imageRedacted?: boolean` flag on `BarcodeAttachmentData`.
  - `NutritionChat.tsx` — renders `data-imageRedacted` parts as a small "Photo no longer available" chip (styled like the existing `.interruptedMarker`); barcode attachment chips now show the same note (with a matching fallback icon) when `imageRedacted` is set, while still showing `code`/`product`.
  - `BarcodeAttachmentCard.tsx` — the read-only preview card shows the same note in place of the image when redacted.
  - `NutritionChat.module.scss` — new `.imageRedactedChip` / `.imageRedactedNote` styles.

Verified: `tsc --noEmit` clean in both `client/` and the backend root; `npm test` (6/6 unit tests) passes; manually sanity-checked the cutoff-date math for a fixed date.

## Manual step required (not done by this PR — needs prod/Heroku access)

This PR does not touch Heroku config. To actually run the job nightly:

1. If not already installed: `heroku addons:create scheduler:standard -a peak-pr-tracker`
2. `heroku addons:open scheduler -a peak-pr-tracker`
3. Add a **daily** job running: `npm run redact-chat-images`

## Explicit constraints honored

- Same-day (and yesterday's) conversations always resume with images fully intact — 1-day safety buffer on the cutoff.
- After the cutoff, images are fine to lose — but redaction always leaves a visible marker in the resumed conversation rather than silently dropping the attachment.
- No prod DB was touched by this agent; this is implementation only.