### PR TITLE
fix: ingredient row alignment + barcode scanner z-order

### DIFF
--- a/client/src/features/nutrition/BarcodeScanner.module.scss
+++ b/client/src/features/nutrition/BarcodeScanner.module.scss
@@ -1,10 +1,12 @@
 @import "../../styles/variables";
 
-// Full-screen overlay rendered on top of everything (z-index above modals).
+// Full-screen overlay rendered on top of everything, including the
+// IngredientSheet it's mounted inside of (#177: scanner must cover the
+// sheet, so this must beat IngredientSheet's .sheet at z-index 1101).
 .overlay {
   position: fixed;
   inset: 0;
-  z-index: 1100;
+  z-index: 1102;
   background-color: rgba(0, 0, 0, 0.92);
   display: flex;
   align-items: center;

--- a/client/src/features/nutrition/IngredientSheet.module.scss
+++ b/client/src/features/nutrition/IngredientSheet.module.scss
@@ -445,6 +445,12 @@
 }
 
 .cardMacros {
+  // #180: without align-self:stretch this flex item (a child of the column
+  // .cardContent) only shrinks to fit its content width — same as .cardName
+  // needs it above — leaving .macroChips no spare row width for its own
+  // margin-left:auto to push into, so the chips never actually reach the
+  // right edge.
+  align-self: stretch;
   display: flex;
   align-items: center;
   gap: 6px;


### PR DESCRIPTION
## Summary
- Right-align the P/C/F macro chips to the row's right edge while keeping kcal left-aligned, in `IngredientCardList` (IngredientSheet.tsx). Root cause: `.cardMacros` (child of the column-flex `.cardContent`) lacked `align-self: stretch`, so it only shrink-wrapped to its content width — leaving `.macroChips`' existing `margin-left: auto` with no spare row width to push into. Added `align-self: stretch` to `.cardMacros` (mirrors the same fix already present on `.cardName`).
- Raise the BarcodeScanner's z-index so it renders above (not below) the add-ingredient sheet it's mounted inside. Both are siblings inside the same `Dialog.Portal`, so this is a plain z-index bump: BarcodeScanner `.overlay` 1100 → 1102 (was tying with IngredientSheet's `.overlay` at 1100 and losing to `.sheet` at 1101).

Closes #180
Closes #177

## Test plan
- [x] `cd client && npx tsc --noEmit -p tsconfig.json` — passes clean (no errors)
- [x] `cd client && npm run build` — production build succeeds
- [ ] Manual/visual check in the running app: ingredient card rows show kcal left / P-C-F chips right; opening barcode scanner from within the add-ingredient sheet shows the scanner on top of the sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)