### PR TITLE
fix: reuse empty ingredient row + pre-validate blank names on save

### DIFF
--- a/client/src/features/nutrition/EntryEditor.tsx
+++ b/client/src/features/nutrition/EntryEditor.tsx
@@ -252,10 +252,13 @@ export default function EntryEditor({
   }, [editingRow]);
 
   // ----- Sheet open/close helpers -----
+  // #178: reuse an existing empty/untitled row instead of stacking a new blank
+  // one each time "add ingredient" is tapped.
   const openSheetForAdd = useCallback(() => {
-    setEditingRow(null);
+    const existingEmpty = rows.find(r => !r.name.trim());
+    setEditingRow(existingEmpty ?? null);
     setSheetOpen(true);
-  }, []);
+  }, [rows]);
 
   const openSheetForEdit = useCallback((row: EditorRow) => {
     setEditingRow(row);
@@ -299,6 +302,13 @@ export default function EntryEditor({
   async function handleSave() {
     if (!canSave) return;
     setSaveError(null);
+
+    // #174: pre-validate client-side so a blank ingredient name surfaces as a
+    // clear message instead of a raw "Request failed with status code 400".
+    if (rows.some(r => !r.name.trim())) {
+      setSaveError('Every ingredient needs a name');
+      return;
+    }
 
     const ingredients: IngredientInput[] = rows.map(r => ({
       name: r.name,

--- a/client/src/features/nutrition/MealBuilder.tsx
+++ b/client/src/features/nutrition/MealBuilder.tsx
@@ -340,6 +340,12 @@ export default function MealBuilder({ open, kind, initialDraft, prefillRows, onC
       setSaveError('Please enter a name.');
       return;
     }
+    // #174: pre-validate client-side so a blank ingredient name surfaces as a
+    // clear message instead of a raw "Request failed with status code 400".
+    if (kind === 'meal' && rows.some(r => !r.name.trim())) {
+      setSaveError('Every ingredient needs a name');
+      return;
+    }
     setSaveError(null);
 
     // Proposal mode: hand payload back to caller; no DB write here.
@@ -425,10 +431,13 @@ export default function MealBuilder({ open, kind, initialDraft, prefillRows, onC
   const [sheetOpen, setSheetOpen] = useState(false);
   const [editingRow, setEditingRow] = useState<BuilderRow | null>(null);
 
+  // #178: reuse an existing empty/untitled row instead of stacking a new blank
+  // one each time "add ingredient" is tapped.
   const openSheetForAdd = useCallback(() => {
-    setEditingRow(null);
+    const existingEmpty = rows.find(r => !r.name.trim());
+    setEditingRow(existingEmpty ?? null);
     setSheetOpen(true);
-  }, []);
+  }, [rows]);
 
   const openSheetForEdit = useCallback((row: BuilderRow) => {
     setEditingRow(row);


### PR DESCRIPTION
## Summary
- Issue #178: `openSheetForAdd` in EntryEditor.tsx and MealBuilder.tsx now reuses an existing empty/untitled ingredient row (if one exists) instead of always appending a new blank row, preventing stacked "Untitled ingredient" rows when tapping "add ingredient" repeatedly.
- Issue #174: `handleSave` in both files now pre-validates client-side — if any ingredient row has a blank name, it sets the existing inline save-error state to "Every ingredient needs a name" and returns early, instead of sending the request and surfacing a raw "Request failed with status code 400" from the server.

Both fixes mirror the existing `handleExpandMeal` "find existing empty row" pattern already in both files, and reuse the existing inline error display (`saveError` state + `styles.errorMsg`). No server routes, axios interceptor, or zod schemas were touched — validation is entirely client-side.

Closes #178
Closes #174

## Test plan
- [x] `npx tsc --noEmit` in `client/` — passes with no errors
- [x] `npm run build` in `client/` — succeeds
- [ ] Manual: tap "add ingredient" twice without filling the first row — second tap should reopen the same row, not add a new one
- [ ] Manual: leave an ingredient name blank and save — should show "Every ingredient needs a name" instead of a raw 400 error