### PR TITLE
fix: floor mobile input font-size instead of clamping to 16px

### DIFF
--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -16,6 +16,15 @@ html {
  * #62: Prevent iOS Safari from auto-zooming on input/textarea/select focus.
  * iOS zooms whenever the focused element has font-size < 16px.
  * A single global rule on mobile is the safest fix — no per-component changes needed.
+ *
+ * #187: A flat `16px !important` also clamped inputs *down* when a component
+ * intentionally sizes its surrounding text larger than 16px (e.g. the 22px
+ * Workouts reps/weight fields), making the input visibly smaller than the
+ * adjacent text/units. `max(16px, 1em)` makes this a floor instead of a fixed
+ * value: `1em` here resolves against the input's parent's computed font-size
+ * (elements inherit their font-size via the `* { font: inherit }` rule
+ * above), so a 22px context still renders a 22px input, while anything at or
+ * below 16px is still floored up to 16px.
  * The !important is intentional: component-level font-size rules that are < 16px
  * must be overridden to guarantee no zoom on any form control.
  */
@@ -23,6 +32,6 @@ html {
   input,
   textarea,
   select {
-    font-size: 16px !important;
+    font-size: max(16px, 1em) !important;
   }
 }


### PR DESCRIPTION
## Summary
- The #62 anti-zoom rule in `client/src/styles/index.css` forced every `input`/`textarea`/`select` to exactly `16px !important` on mobile (≤885px), which visually shrank the Workouts tab's reps/weight inputs (rendered inside `.part`, which sets `font-size: 22px`) well below the adjacent " lbs"/" reps" text.
- Changed the rule to `font-size: max(16px, 1em) !important`. Since `* { font: inherit }` (line 3) makes inputs inherit their container's font-size, `1em` resolves to the input's parent's computed font-size — so a 22px context still renders a 22px input, while anything at or below 16px is still floored up to avoid iOS Safari's auto-zoom-on-focus.
- Updated the explanatory comment to describe the new `max()` semantics and reference both #62 and #187.
- No SCSS changes needed — `Variation.module.scss`'s `.part > .icon { width: 1em; height: 1em; }` (added for #124) scales off `.part`'s own font-size, which this change doesn't touch, so icon/number alignment is unaffected.

## Verification
- `cd client && npm run build` passes (SCSS compiles cleanly).
- Isolated CSS test against the actual built stylesheet (dev server in this environment was serving a different checkout, so I built and tested the compiled output directly rather than relying on it):
  - Input inside a 22px `.part`-like container: computed `font-size` goes from **16px → 22px**, now matching the adjacent 22px text.
  - Input inside a 12px container (simulating any component with small surrounding text): computed `font-size` stays **16px**, confirming the iOS anti-zoom floor from #62 is preserved.
- Spot-checked other mobile form controls (auth sign-in, body-weight tracker, habit tracker, nutrition inputs) for `font-size` under 16px on `input`/`textarea`/`select`: none exist directly on those elements below 16px in a way that would regress, since `1em` there resolves to their (already ≥16px, mostly inherited-default) parent context.

Closes #187