### PR TITLE
fix: persist proposal accept/deny resolutions server-side

### DIFF
--- a/client/src/features/nutrition/NutritionChat.tsx
+++ b/client/src/features/nutrition/NutritionChat.tsx
@@ -36,8 +36,8 @@ import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport, isToolUIPart, getToolName } from 'ai';
 import type { FileUIPart, UIMessage, ToolUIPart, DynamicToolUIPart } from 'ai';
 import ReactMarkdown from 'react-markdown';
-import { useCreateEntry, useCreateCustomFood, fetchTranscript, clearTranscript, lookupBarcode } from './api';
-import type { StoredChatMessage } from './api';
+import { useCreateEntry, useCreateCustomFood, fetchTranscript, clearTranscript, lookupBarcode, fetchResolutions, saveResolution } from './api';
+import type { StoredChatMessage, ProposalResolution } from './api';
 import EntryEditor from './EntryEditor';
 import MealBuilder from './MealBuilder';
 import BarcodeScanner from './BarcodeScanner';
@@ -1046,6 +1046,43 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
     });
   }, [deniedProposals, confirmedProposals, deniedCustomFoodProposals, confirmedCustomFoodProposals, selectedDate]);
 
+  // #186: merge server-persisted resolutions into the local collections.
+  // localStorage above is an OPTIMISTIC fast path (so an accepted proposal
+  // never flashes back to "pending" before a server round-trip lands) — but
+  // it's per-device and can go stale/missing, which is exactly what let a
+  // resolved proposal come back as actionable. The server is the durable
+  // source of truth, so on conflict its rows win: they're merged in AFTER the
+  // existing Set/Map contents (Map spread order means a later same-key entry
+  // overwrites; Set membership is a no-op either way).
+  const applyServerResolutions = useCallback((rows: ProposalResolution[]) => {
+    if (rows.length === 0) return;
+    const deniedEntry = rows.filter(r => r.kind === 'entry' && r.status === 'denied').map(r => r.toolCallId);
+    const confirmedEntry: [string, string][] = rows
+      .filter(r => r.kind === 'entry' && r.status === 'confirmed')
+      .map(r => [r.toolCallId, r.displayName ?? '']);
+    const deniedFood = rows.filter(r => r.kind === 'custom_food' && r.status === 'denied').map(r => r.toolCallId);
+    const confirmedFood: [string, string][] = rows
+      .filter(r => r.kind === 'custom_food' && r.status === 'confirmed')
+      .map(r => [r.toolCallId, r.displayName ?? '']);
+
+    if (deniedEntry.length) setDeniedProposals(prev => new Set([...prev, ...deniedEntry]));
+    if (confirmedEntry.length) setConfirmedProposals(prev => new Map([...prev, ...confirmedEntry]));
+    if (deniedFood.length) setDeniedCustomFoodProposals(prev => new Set([...prev, ...deniedFood]));
+    if (confirmedFood.length) setConfirmedCustomFoodProposals(prev => new Map([...prev, ...confirmedFood]));
+  }, []);
+
+  // Fetch resolutions for `date` from the server and merge them in — a no-op
+  // (via applyServerResolutions' early return) when the server has nothing.
+  // Best-effort: a failed read must never break the chat.
+  const refreshResolutionsFromServer = useCallback((date: string) => {
+    fetchResolutions(date)
+      .then(rows => {
+        if (date !== loadedDateRef.current) return; // day changed while in flight — stale
+        applyServerResolutions(rows);
+      })
+      .catch(() => {});
+  }, [applyServerResolutions]);
+
   // Keep a ref to the latest messages so the (stable) refetch callback can compare
   // the incoming DB transcript against what's currently loaded without re-creating
   // itself on every message change.
@@ -1133,8 +1170,11 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
   }, []);
 
   // On mount: load transcript from DB, then evaluate the dangling condition.
+  // #186: also pull server-side resolutions so an accepted/denied proposal
+  // from another device (or a cleared local cache) renders resolved on load.
   useEffect(() => {
     fetchAndApplyTranscript(selectedDate).then(applied => evaluateDangling(selectedDate, applied));
+    refreshResolutionsFromServer(selectedDate);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -1159,8 +1199,10 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
       resolutionsDateRef.current = selectedDate;
       fetchAndApplyTranscript(selectedDate, cached)
         .then(applied => evaluateDangling(selectedDate, applied));
+      // #186: server resolutions win over whatever the local cache had for this day.
+      refreshResolutionsFromServer(selectedDate);
     }
-  }, [selectedDate, setMessages, fetchAndApplyTranscript, evaluateDangling]);
+  }, [selectedDate, setMessages, fetchAndApplyTranscript, evaluateDangling, refreshResolutionsFromServer]);
 
   // #15: On window focus / visibilitychange — refetch transcript so runs that
   // completed server-side while the tab was backgrounded show up. Also (re)start
@@ -1170,6 +1212,8 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
       if (document.visibilityState === 'visible') {
         fetchAndApplyTranscript(selectedDate)
           .then(applied => evaluateDangling(selectedDate, applied));
+        // #186: pick up resolutions written from another device/tab while backgrounded.
+        refreshResolutionsFromServer(selectedDate);
       }
     }
     document.addEventListener('visibilitychange', handleVisibilityChange);
@@ -1178,7 +1222,7 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
       document.removeEventListener('visibilitychange', handleVisibilityChange);
       window.removeEventListener('focus', handleVisibilityChange);
     };
-  }, [selectedDate, fetchAndApplyTranscript, evaluateDangling]);
+  }, [selectedDate, fetchAndApplyTranscript, evaluateDangling, refreshResolutionsFromServer]);
 
   // The poll loop. Exactly one interval at a time; keyed on pollingActive +
   // selectedDate. React tears down the previous interval (cleanup) before
@@ -1509,14 +1553,20 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
   const handleProposalDeny = useCallback((partKey: string) => {
     setDeniedProposals(prev => new Set([...prev, partKey]));
     setPendingDenialCount(prev => prev + 1);
-  }, []);
+    // #186: write through to the server so this resolution survives a reload/
+    // device switch. localStorage (via the persist effect above) is the
+    // optimistic fast path; this call is best-effort and never blocks the UI.
+    saveResolution(selectedDate, partKey, 'entry', 'denied', null).catch(() => {});
+  }, [selectedDate]);
 
   const handleProposalConfirmWithTracking = useCallback(async (input: EntryInput, partKey: string) => {
     await createEntry.mutateAsync(input);
     // #71: store the entry name so the confirmed message can display it
     const entryName = (input as unknown as { name?: string }).name ?? '';
     setConfirmedProposals(prev => new Map([...prev, [partKey, entryName]]));
-  }, [createEntry]);
+    // #186: server write-through (best-effort, see handleProposalDeny above)
+    saveResolution(selectedDate, partKey, 'entry', 'confirmed', entryName).catch(() => {});
+  }, [createEntry, selectedDate]);
 
   // ---- Custom food proposal handlers ----
   // Already mark-only (no auto-send) — also feeds the same denial-note queue
@@ -1524,12 +1574,16 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
   const handleCustomFoodDeny = useCallback((partKey: string) => {
     setDeniedCustomFoodProposals(prev => new Set([...prev, partKey]));
     setPendingDenialCount(prev => prev + 1);
-  }, []);
+    // #186: server write-through (best-effort, see handleProposalDeny above)
+    saveResolution(selectedDate, partKey, 'custom_food', 'denied', null).catch(() => {});
+  }, [selectedDate]);
 
   const handleCustomFoodConfirm = useCallback(async (payload: CustomFoodInput, partKey: string) => {
     const saved = await createCustomFood.mutateAsync(payload);
     setConfirmedCustomFoodProposals(prev => new Map([...prev, [partKey, saved.name]]));
-  }, [createCustomFood]);
+    // #186: server write-through (best-effort, see handleProposalDeny above)
+    saveResolution(selectedDate, partKey, 'custom_food', 'confirmed', saved.name).catch(() => {});
+  }, [createCustomFood, selectedDate]);
 
   // ---- #7/#70: Clear chat — guarded by ConfirmModal ----
   const executeClearChat = useCallback(async () => {

--- a/client/src/features/nutrition/api.ts
+++ b/client/src/features/nutrition/api.ts
@@ -242,6 +242,36 @@ export async function clearTranscript(date: string): Promise<void> {
   await clientApi.delete('/nutrition/chat/transcript', { params: { date } });
 }
 
+// ---- Proposal resolutions (#186) ----
+// Server-side persistence for propose_entry / propose_custom_food accept/deny
+// state, so a re-fetched transcript doesn't render an already-resolved
+// proposal as pending again. localStorage remains the fast optimistic path in
+// NutritionChat.tsx; these calls are the source-of-truth writes/reads.
+export type ProposalResolution = {
+  toolCallId: string;
+  kind: 'entry' | 'custom_food';
+  status: 'confirmed' | 'denied';
+  displayName: string | null;
+};
+
+/** Load all resolved proposals for a local day. */
+export async function fetchResolutions(date: string): Promise<ProposalResolution[]> {
+  const res = await clientApi.get('/nutrition/chat/resolutions', { params: { date } });
+  const rows = (res.data.data ?? []) as { tool_call_id: string; kind: 'entry' | 'custom_food'; status: 'confirmed' | 'denied'; display_name: string | null }[];
+  return rows.map(r => ({ toolCallId: r.tool_call_id, kind: r.kind, status: r.status, displayName: r.display_name }));
+}
+
+/** Record a single proposal's resolution. */
+export async function saveResolution(
+  date: string,
+  toolCallId: string,
+  kind: 'entry' | 'custom_food',
+  status: 'confirmed' | 'denied',
+  displayName: string | null = null,
+): Promise<void> {
+  await clientApi.post('/nutrition/chat/resolutions', { date, toolCallId, kind, status, displayName });
+}
+
 // ---- App feedback (#1) — POST creates a GitHub issue server-side when a
 // GITHUB_TOKEN is configured, else stores in a feedback table. App-level, not
 // nutrition-scoped, but lives here since the feedback UI ships with this batch.

--- a/migrations/015_proposal_resolutions.sql
+++ b/migrations/015_proposal_resolutions.sql
@@ -1,0 +1,21 @@
+-- Proposal resolution persistence for the nutrition chat (#186).
+-- Accept/deny state for propose_entry / propose_custom_food cards was only
+-- kept in localStorage, so an accepted proposal came back as "pending" after
+-- a reload or on a different device (the DB transcript is source of truth
+-- for messages, but nothing recorded whether a proposal had been resolved).
+-- Stores one row per user + date + toolCallId. UNIQUE key makes an upsert-style
+-- write idempotent (a re-confirm/re-deny of the same toolCallId overwrites).
+-- migrate.js tolerates 1050/1060 so re-runs are safe.
+
+CREATE TABLE IF NOT EXISTS proposal_resolutions (
+  id           INT AUTO_INCREMENT PRIMARY KEY,
+  user_uuid    BINARY(16)     NOT NULL,
+  date         DATE           NOT NULL,
+  tool_call_id VARCHAR(64)    NOT NULL,
+  kind         ENUM('entry','custom_food') NOT NULL,
+  status       ENUM('confirmed','denied') NOT NULL,
+  display_name VARCHAR(255)   NULL COMMENT 'entry/food name recorded at confirm time, for "Logged: <name>"',
+  created_at   DATETIME       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE KEY uniq_user_date_toolcall (user_uuid, date, tool_call_id),
+  KEY idx_user_date (user_uuid, date)
+);

--- a/routes/nutrition.ts
+++ b/routes/nutrition.ts
@@ -4,7 +4,7 @@ import { authenticateToken } from './auth';
 import { validateId } from '../utils/validation';
 import handleSqlError from '../utils/handleSqlError';
 import { User } from '../types';
-import { entryInputSchema, goalsSchema, customFoodInputSchema } from '../schemas/nutrition';
+import { entryInputSchema, goalsSchema, customFoodInputSchema, proposalResolutionInputSchema } from '../schemas/nutrition';
 import * as store from '../services/nutrition/store';
 import { searchAllFoodsWithPortions, lookupBarcode, getPortions } from '../services/nutrition/providers';
 import { streamNutritionChat } from '../services/nutrition/agent';
@@ -14,6 +14,9 @@ import {
   appendMessage,
   markInterrupted,
   clearTranscript,
+  getResolutions,
+  saveResolution,
+  clearResolutions,
 } from '../services/nutrition/transcripts';
 
 const router = Router();
@@ -349,6 +352,44 @@ router.delete('/chat/transcript', async (req, res): Promise<any> => {
 
   try {
     await clearTranscript(uuid, date);
+    // #186: clearing the chat must also drop that day's resolutions, mirroring
+    // executeClearChat's dropResolutionsForDate on the client — otherwise a
+    // stale resolution row could reattach to a toolCallId that gets reused.
+    await clearResolutions(uuid, date);
+    return res.status(204).send();
+  } catch (error) {
+    return handleSqlError(error, res);
+  }
+});
+
+// GET /chat/resolutions?date=YYYY-MM-DD — proposal accept/deny state for a day (#186)
+router.get('/chat/resolutions', async (req, res): Promise<any> => {
+  const { uuid }: User = res.locals.user;
+  const date = (req.query.date ?? '') as string;
+
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return res.status(400).json({ message: 'date query param must be in YYYY-MM-DD format' });
+  }
+
+  try {
+    const data = await getResolutions(uuid, date);
+    return res.status(200).json({ data, message: `Found ${data.length} resolution(s)` });
+  } catch (error) {
+    return handleSqlError(error, res);
+  }
+});
+
+// POST /chat/resolutions — record a proposal's accept/deny state (#186)
+router.post('/chat/resolutions', async (req, res): Promise<any> => {
+  const { uuid }: User = res.locals.user;
+  const parsed = proposalResolutionInputSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ message: parsed.error.issues[0]?.message ?? 'Invalid request body' });
+  }
+
+  try {
+    const { date, toolCallId, kind, status, displayName } = parsed.data;
+    await saveResolution(uuid, date, toolCallId, kind, status, displayName ?? null);
     return res.status(204).send();
   } catch (error) {
     return handleSqlError(error, res);

--- a/schemas/nutrition.ts
+++ b/schemas/nutrition.ts
@@ -198,6 +198,19 @@ export const customFoodRowSchema = z.object({
 });
 export type CustomFoodRow = z.infer<typeof customFoodRowSchema>;
 
+// ---- Proposal resolutions (#186) ----
+// Server-side record of accept/deny state for propose_entry / propose_custom_food
+// cards, so a refetched transcript doesn't re-render an already-resolved proposal
+// as actionable. Keyed by toolCallId (see NutritionChat.tsx's ProposalResolutions).
+export const proposalResolutionInputSchema = z.object({
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  toolCallId: z.string().min(1).max(64),
+  kind: z.enum(['entry', 'custom_food']),
+  status: z.enum(['confirmed', 'denied']),
+  displayName: z.string().max(255).nullable().optional(),
+});
+export type ProposalResolutionInput = z.infer<typeof proposalResolutionInputSchema>;
+
 // ---- DB row / response shapes returned to the client ----
 export interface IngredientRow extends IngredientInput {
   id: number;

--- a/services/nutrition/transcripts.ts
+++ b/services/nutrition/transcripts.ts
@@ -103,3 +103,93 @@ export async function clearTranscript(
     return 0;
   }
 }
+
+// ---------------------------------------------------------------------------
+// Proposal resolutions (#186) — server-side record of accept/deny state for
+// propose_entry / propose_custom_food cards, keyed by (user_uuid, date,
+// tool_call_id). This is what makes an accepted proposal stay "Logged: <name>"
+// after the transcript is refetched from the DB (previously only localStorage
+// remembered this, so it was lost across devices / cleared storage / reload
+// races).
+// ---------------------------------------------------------------------------
+
+/** A stored proposal resolution row as returned to the client. */
+export interface ProposalResolutionRow {
+  tool_call_id: string;
+  kind: 'entry' | 'custom_food';
+  status: 'confirmed' | 'denied';
+  display_name: string | null;
+}
+
+/**
+ * Fetch all proposal resolutions for a user+date.
+ * Returns an empty array on any error — callers must not let this break the chat.
+ */
+export async function getResolutions(
+  userUuid: string,
+  date: string,
+): Promise<ProposalResolutionRow[]> {
+  try {
+    const [rows] = await pool.query<RowDataPacket[]>(
+      `SELECT tool_call_id, kind, status, display_name
+       FROM proposal_resolutions
+       WHERE user_uuid = UUID_TO_BIN(?) AND date = ?`,
+      [userUuid, date],
+    );
+    return rows.map((row) => ({
+      tool_call_id: row.tool_call_id as string,
+      kind: row.kind as 'entry' | 'custom_food',
+      status: row.status as 'confirmed' | 'denied',
+      display_name: (row.display_name as string | null) ?? null,
+    }));
+  } catch (err) {
+    console.error('[transcripts] getResolutions failed:', err);
+    return [];
+  }
+}
+
+/**
+ * Record (or overwrite) a proposal's resolution. Upsert on the
+ * (user_uuid, date, tool_call_id) unique key so a duplicate write for the
+ * same toolCallId is idempotent. Best-effort — swallows errors so a failed
+ * write never breaks the chat UI.
+ */
+export async function saveResolution(
+  userUuid: string,
+  date: string,
+  toolCallId: string,
+  kind: 'entry' | 'custom_food',
+  status: 'confirmed' | 'denied',
+  displayName: string | null,
+): Promise<void> {
+  try {
+    await pool.query(
+      `INSERT INTO proposal_resolutions (user_uuid, date, tool_call_id, kind, status, display_name)
+       VALUES (UUID_TO_BIN(?), ?, ?, ?, ?, ?)
+       ON DUPLICATE KEY UPDATE kind = VALUES(kind), status = VALUES(status), display_name = VALUES(display_name)`,
+      [userUuid, date, toolCallId, kind, status, displayName],
+    );
+  } catch (err) {
+    console.error('[transcripts] saveResolution failed:', err);
+  }
+}
+
+/**
+ * Delete all proposal resolutions for a user+date. Mirrors clearTranscript —
+ * called from the same DELETE /chat/transcript route so a cleared chat doesn't
+ * leave orphaned resolution rows that could reattach to a future toolCallId
+ * collision (astronomically unlikely, but keeps the table tidy).
+ */
+export async function clearResolutions(
+  userUuid: string,
+  date: string,
+): Promise<void> {
+  try {
+    await pool.query(
+      `DELETE FROM proposal_resolutions WHERE user_uuid = UUID_TO_BIN(?) AND date = ?`,
+      [userUuid, date],
+    );
+  } catch (err) {
+    console.error('[transcripts] clearResolutions failed:', err);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `proposal_resolutions` table (migration `015_proposal_resolutions.sql`) storing, per user + date + `toolCallId`: the resolution kind (`entry` | `custom_food`), status (`confirmed` | `denied`), and the display name recorded at confirm time.
- Adds `getResolutions` / `saveResolution` / `clearResolutions` to `services/nutrition/transcripts.ts`, all best-effort (never throw into the caller).
- Adds `GET /nutrition/chat/resolutions` and `POST /nutrition/chat/resolutions` routes, validated with a new `proposalResolutionInputSchema` in `schemas/nutrition.ts`. `DELETE /nutrition/chat/transcript` now also calls `clearResolutions` so a cleared chat doesn't leave orphaned rows.
- Client (`client/src/features/nutrition/api.ts`): adds `fetchResolutions` / `saveResolution`.
- Client (`NutritionChat.tsx`): keeps localStorage as the optimistic fast path (so a just-accepted proposal never flashes back to "pending"), but merges in server resolutions — which win on conflict — on mount, on day change, and on visibility-change transcript refetch. The four confirm/deny handlers now write through to the server via `.catch(() => {})` (matching the existing best-effort style).

Closes #186

## Test plan
- [x] `npm run build` (backend `tsc`) passes
- [x] `cd client && npx tsc --noEmit` passes
- [x] `cd client && npm run build` (vite) passes
- [x] Applied migration `015_proposal_resolutions.sql` against local Docker MySQL (port 3307) via `scripts/migrate.js` — applies cleanly, is idempotent on re-run (`skip` on second pass), and matches the naive `;`-splitter (verified no stray semicolons in comments after fixing one).
- [x] Verified the exact SQL used by `saveResolution`/`getResolutions`/`clearResolutions` directly against the DB: insert, upsert-overwrite (`ON DUPLICATE KEY UPDATE`), select, and delete all behave as expected.
- [ ] Not verified in the running app UI (no browser/Playwright pass against the live chat flow) — logic was verified at the SQL layer and via type-checking only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)