### PR TITLE
fix: scale ingredient macros on quantity/unit change (#185)

### DIFF
--- a/client/src/features/nutrition/IngredientSheet.tsx
+++ b/client/src/features/nutrition/IngredientSheet.tsx
@@ -39,7 +39,7 @@ import {
   nextKey,
   emptyRow,
   round2,
-  recomputeMacros,
+  scaleRowMacros,
   immediatePortions,
   rowFromFood,
   buildPortionListFromFetched,
@@ -212,33 +212,34 @@ function IngredientForm({ row, onChange, onExpandMeal, onOpenBarcode }: Ingredie
     onChange(rowFromFood(food, portions));
   }
 
+  // #185 — quantity/unit changes must scale macros even when the row has no
+  // per100g snapshot (hand-typed macros, or a snapshot lost via
+  // handleNameChange). scaleRowMacros derives a baseline from the row's
+  // current macros ÷ current grams in that case, so this always scales.
   function handleQuantityChange(e: React.ChangeEvent<HTMLInputElement>) {
     const quantity = parseFloat(e.target.value) || 0;
     const effectiveGrams = quantity * row.unitGrams;
-    if (row.per100g) {
-      onChange({ ...row, quantity, grams: effectiveGrams, ...recomputeMacros(row.per100g, effectiveGrams) });
-    } else {
-      onChange({ ...row, quantity, grams: effectiveGrams });
-    }
+    onChange({ ...row, quantity, grams: effectiveGrams, ...scaleRowMacros(row, effectiveGrams) });
   }
 
   function handleUnitChange(e: React.ChangeEvent<HTMLSelectElement>) {
     const label = e.target.value;
     const selected = row.portions.find(p => p.label === label) ?? GRAMS_UNIT;
     const effectiveGrams = row.quantity * selected.grams;
-    if (row.per100g) {
-      onChange({
-        ...row,
-        unitLabel: selected.label,
-        unitGrams: selected.grams,
-        grams: effectiveGrams,
-        ...recomputeMacros(row.per100g, effectiveGrams),
-      });
-    } else {
-      onChange({ ...row, unitLabel: selected.label, unitGrams: selected.grams, grams: effectiveGrams });
-    }
+    onChange({
+      ...row,
+      unitLabel: selected.label,
+      unitGrams: selected.grams,
+      grams: effectiveGrams,
+      ...scaleRowMacros(row, effectiveGrams),
+    });
   }
 
+  // Only reachable when macrosReadOnly is false (row.per100g === null): the
+  // user is hand-entering a macro value. No separate "re-baseline" step is
+  // needed — scaleRowMacros (#185) always derives its baseline from the row's
+  // CURRENT macros/grams, so this edit automatically becomes the reference
+  // for the next quantity/unit change.
   function handleMacroChange(
     field: 'calories' | 'protein_g' | 'carbs_g' | 'fat_g',
     value: string,

--- a/client/src/features/nutrition/ingredientMath.ts
+++ b/client/src/features/nutrition/ingredientMath.ts
@@ -83,6 +83,54 @@ export function recomputeMacros(
   };
 }
 
+// ---------------------------------------------------------------------------
+// #185 — Changing serving amount should scale macros correctly even if they
+// were manually entered.
+//
+// Previously, quantity/unit changes only recomputed macros `if (row.per100g)`.
+// Rows with no per100g snapshot (hand-typed macros, or a per100g snapshot lost
+// via handleNameChange after editing an auto-filled name) silently froze their
+// macros on any qty/unit change.
+//
+// `scaleRowMacros` unifies both cases: when a per100g snapshot exists, scale
+// from it (unchanged behaviour). When it doesn't, derive an implicit "per100g"
+// baseline from the row's CURRENT macros ÷ CURRENT grams and scale from that.
+// Because the baseline is derived fresh from current state every time (never
+// cached), a manual macro edit (handleMacroChange) automatically becomes the
+// new baseline for the next scale — no separate re-baseline step needed.
+// ---------------------------------------------------------------------------
+export function scaleRowMacros(
+  row: EditorRow,
+  newGrams: number,
+): Pick<EditorRow, 'calories' | 'protein_g' | 'carbs_g' | 'fat_g' | 'fiber_g' | 'sugar_g' | 'sodium_mg'> {
+  if (row.per100g) {
+    return recomputeMacros(row.per100g, newGrams);
+  }
+  // Guard divide-by-zero: with no prior grams to derive a rate from, there's
+  // no valid baseline — leave macros as-is rather than producing NaN/Infinity.
+  if (!row.grams) {
+    return {
+      calories: row.calories,
+      protein_g: row.protein_g,
+      carbs_g: row.carbs_g,
+      fat_g: row.fat_g,
+      fiber_g: row.fiber_g,
+      sugar_g: row.sugar_g,
+      sodium_mg: row.sodium_mg,
+    };
+  }
+  const factor = newGrams / row.grams;
+  return {
+    calories: round2(row.calories * factor),
+    protein_g: round2(row.protein_g * factor),
+    carbs_g: round2(row.carbs_g * factor),
+    fat_g: round2(row.fat_g * factor),
+    fiber_g: row.fiber_g != null ? round2(row.fiber_g * factor) : null,
+    sugar_g: row.sugar_g != null ? round2(row.sugar_g * factor) : null,
+    sodium_mg: row.sodium_mg != null ? round2(row.sodium_mg * factor) : null,
+  };
+}
+
 /**
  * Build the initial portions list visible immediately when a food is selected.
  * For custom foods the portions are already provided on the result.
@@ -164,7 +212,8 @@ export function applyNewPortions(row: EditorRow, newPortions: FoodPortion[]): Ed
   const preferred = newPortions.length > 1 ? newPortions[1] : GRAMS_UNIT;
   const quantity = row.unitLabel === 'g' ? 1 : row.quantity;
   const effectiveGrams = quantity * preferred.grams;
-  const macros = row.per100g ? recomputeMacros(row.per100g, effectiveGrams) : {};
+  // #185 — scale even without a per100g snapshot (see scaleRowMacros).
+  const macros = scaleRowMacros(row, effectiveGrams);
   return {
     ...row,
     portions: newPortions,


### PR DESCRIPTION
Closes #185

## Root cause (found by reproducing the failure with the actual project logic before fixing)

`handleQuantityChange`/`handleUnitChange`/`applyNewPortions` in `IngredientSheet.tsx` / `ingredientMath.ts` only recomputed macros `if (row.per100g)`. Confirmed the backend barcode route (`routes/nutrition.ts` → `services/nutrition/providers.ts:lookupBarcode`) always populates `per100g.calories/protein_g/carbs_g/fat_g` on a 200 response — so the barcode lookup itself is not the bug (no backend fix needed, per scope in this task).

The actual triggers for the reported "macros don't change at all" symptom:

1. **`handleNameChange` nulls `row.per100g` on every keystroke.** After scanning a barcode, editing the auto-filled product name (e.g. trimming a verbose OFF brand name) silently kills live recompute — quantity/unit changes made afterward freeze the macros at whatever grams they were at when the name was touched. Reproduced with a standalone script exercising the real `ingredientMath.ts` functions.
2. **Fully hand-typed rows never had a `per100g` snapshot to begin with**, so quantity/unit changes never scaled their macros — this is the "even if manually entered" half of the issue title. Also reproduced directly.

## Fix

Added `scaleRowMacros(row, newGrams)` in `ingredientMath.ts`:
- If `row.per100g` is set, scale from it (unchanged behavior).
- Otherwise, derive an implicit per-100g-equivalent baseline from the row's **current** macros ÷ **current** grams, and scale from that. Guards divide-by-zero when `row.grams === 0` (returns macros unchanged rather than NaN/Infinity).
- Because the baseline is recomputed fresh from current state on every call (never cached), a manual macro edit via `handleMacroChange` automatically becomes the new baseline for the next quantity/unit change — no separate re-baseline step required.

Wired into `handleQuantityChange`, `handleUnitChange` (IngredientSheet.tsx), and `applyNewPortions` (ingredientMath.ts, used by the USDA portions-fetch effect). `macrosReadOnly = row.per100g !== null` is untouched, so macro inputs stay read-only exactly when a live snapshot exists.

## Scope

Only touched `IngredientSheet.tsx` and `ingredientMath.ts` (add-ingredient workflow). Did not touch `MealBuilder.tsx`, `EntryEditor.tsx`, `NutritionChat.tsx`, or any backend file, per the issue's scope.

## Verification
- `npx tsc --noEmit` — clean
- `npm run build` — succeeds
- Reproduced the bug and verified the fix by exercising the actual (esbuild-compiled) `ingredientMath.ts` functions with 4 scenarios: barcode-scan-then-name-edit-then-qty-change (bug reproduced pre-fix, now scales correctly), hand-typed-macros-then-qty-change (bug reproduced pre-fix, now scales correctly), grams=0 guard (no NaN/Infinity), and the original per100g-present path (unchanged, still correct).
- Did not get a full browser/Playwright run against local dev in this pass (no live app instance was running); recommend a quick manual smoke test of the barcode-scan → edit-name → change-quantity flow before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)