### PR TITLE
fix: keep timeline pulse dot next to step label (#193)

### DIFF
--- a/client/src/features/nutrition/NutritionChat.module.scss
+++ b/client/src/features/nutrition/NutritionChat.module.scss
@@ -416,7 +416,12 @@
   display: inline-flex;
   overflow: hidden;
   min-width: 0;
-  flex: 1 1 auto;
+  // #193: was `flex: 1 1 auto`, which let this viewport grow to fill the
+  // whole header row, pushing .reasoningSpinner (the next flex sibling) far
+  // right of the label with a big empty gap. Sizing to content (0 1 auto)
+  // keeps the dot right after the text — it still shrinks under min-width: 0
+  // so long labels ellipsize instead of overflowing or squeezing the dot out.
+  flex: 0 1 auto;
 }
 
 .timelineLabel {


### PR DESCRIPTION
## Summary
- `.timelineLabelViewport` in `NutritionChat.module.scss` used `flex: 1 1 auto`, letting it grow to fill the entire collapsed process-timeline header row. The pulsing dot (`.reasoningSpinner`), as the next flex sibling, was pushed to the far right edge, leaving a large empty gap between the step label and the dot.
- Changed to `flex: 0 1 auto` so the viewport sizes to its content — the dot now sits immediately after the label, separated only by the header's normal `gap: 6px`.
- `min-width: 0` is retained so long labels still shrink and ellipsize (via `.timelineLabel` / `.timelineLabelLive`'s existing `text-overflow: ellipsis`) instead of overflowing or pushing the dot off-screen.
- Added a `// #193:` comment explaining why the viewport must not grow.
- CSS-only fix; `NutritionChat.tsx` was not touched.

Closes #193

## Test plan
- [x] `cd client && npx tsc --noEmit` — passes clean
- [x] `cd client && npm run build` — succeeds
- [ ] Visual verification via Playwright/browser was not performed (not blocking per task instructions); verified by careful reading of the flex layout — `.reasoningToggle` is `display: flex; gap: 6px` with children: chevron, `.timelineLabelViewport` (now `flex: 0 1 auto`, `min-width: 0`, `overflow: hidden`), then conditionally `.reasoningSpinner`. The label's own ellipsis/nowrap/overflow-hidden styles are unchanged, and the `stepSlideUp` conveyor animation on `.timelineLabelLive` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)