### PR TITLE
Remove Recently used row and Ask AI button from nutrition tab

### DIFF
--- a/client/src/features/nutrition/NutritionTracker.module.scss
+++ b/client/src/features/nutrition/NutritionTracker.module.scss
@@ -97,30 +97,6 @@
   }
 }
 
-.aiBtn {
-  flex: 0 1 auto;
-  min-height: 48px;
-  padding: 10px 18px;
-  background-color: rgba($primary, 0.08);
-  color: $primary;
-  border: 2px solid rgba($primary-border, 0.6);
-  border-radius: $border-radius;
-  font-family: $sarabun;
-  font-size: 15px;
-  font-weight: 600;
-  letter-spacing: $sarabun-spacing;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-
-  &:active {
-    background-color: $primary-translucent;
-    border-color: $primary-border;
-  }
-}
-
-
 .settingsBtn {
   min-width: 48px;
   min-height: 48px;
@@ -440,69 +416,4 @@
   color: rgba($text, 0.5);
   letter-spacing: $sarabun-spacing;
   padding: 8px 0;
-}
-
-// ---- Recently used custom foods ----
-.recentRow {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.recentLabel {
-  font-family: $sarabun;
-  font-size: 13px;
-  font-weight: 700;
-  letter-spacing: 1.5px;
-  color: rgba($text, 0.45);
-  text-transform: uppercase;
-}
-
-.recentItems {
-  display: flex;
-  gap: 8px;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  padding-bottom: 4px;
-}
-
-.recentItem {
-  flex-shrink: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  padding: 8px 12px;
-  background-color: $surface;
-  border: 1px solid rgba($surface-border, 0.6);
-  border-radius: 10px;
-  cursor: pointer;
-  text-align: left;
-  min-height: 52px;
-  min-width: 110px;
-  max-width: 160px;
-
-  &:active {
-    background-color: rgba($primary, 0.1);
-    border-color: rgba($primary-border, 0.5);
-  }
-}
-
-.recentName {
-  font-family: $sarabun;
-  font-size: 14px;
-  font-weight: 600;
-  color: $text;
-  letter-spacing: $sarabun-spacing;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-  word-break: break-word;
-}
-
-.recentMeta {
-  font-family: $sarabun;
-  font-size: 11px;
-  color: rgba($text, 0.45);
-  letter-spacing: $sarabun-spacing;
 }

--- a/client/src/features/nutrition/NutritionTracker.tsx
+++ b/client/src/features/nutrition/NutritionTracker.tsx
@@ -1,12 +1,12 @@
 import { useState, useRef, useEffect } from 'react';
-import { useDay, useGoals, useDeleteEntry, useCreateEntry, useRecentCustomFoods, getCustomFood } from './api';
+import { useDay, useGoals, useDeleteEntry } from './api';
 import EntryEditor from './EntryEditor';
 import NutritionGoalsModal from './NutritionGoalsModal';
 import NutritionChat from './NutritionChat';
 import MyFoodsSheet from './MyFoodsSheet';
 import MealBuilder from './MealBuilder';
 import ConfirmModal from '../../components/ConfirmModal.jsx';
-import type { EntryEditorMode, EntryRow, Meal, IngredientInput } from './types';
+import type { EntryEditorMode, EntryRow, Meal } from './types';
 import { MEALS, MEAL_LABELS } from './types';
 import styles from './NutritionTracker.module.scss';
 import { MoreVertical, ChevronLeft, ChevronRight, Target, BookMarked } from 'lucide-react';
@@ -142,80 +142,6 @@ function EntryMenu({ entry, onEdit, onDelete, onSaveAsMeal }: EntryMenuProps) {
           </button>
         </div>
       )}
-    </div>
-  );
-}
-
-// ---- Recently used custom foods row ----
-
-interface RecentlyUsedRowProps {
-  selectedDate: string;
-  defaultMeal?: Meal;
-}
-
-function RecentlyUsedRow({ selectedDate, defaultMeal }: RecentlyUsedRowProps) {
-  const { data: recent = [] } = useRecentCustomFoods(4);
-  const createEntry = useCreateEntry(selectedDate);
-
-  async function handleQuickReLog(food: { name: string; source: string; source_ref: string; per100g: any; portions?: any[] | null }) {
-    try {
-      const id = parseInt(food.source_ref, 10);
-      if (isNaN(id)) return;
-      const customFood = await getCustomFood(id);
-
-      let grams = customFood.total_grams;
-      if (customFood.servings.length > 0) {
-        grams = customFood.servings[0].grams;
-      }
-
-      const scaleFactor = grams / (customFood.total_grams || 1);
-      const ingredients: IngredientInput[] = customFood.ingredients.map(ing => ({
-        name: ing.name,
-        grams: Math.round(ing.grams * scaleFactor * 10) / 10,
-        source: 'custom' as const,
-        source_ref: ing.source_ref ?? null,
-        calories: Math.round(ing.calories * scaleFactor * 100) / 100,
-        protein_g: Math.round(ing.protein_g * scaleFactor * 100) / 100,
-        carbs_g: Math.round(ing.carbs_g * scaleFactor * 100) / 100,
-        fat_g: Math.round(ing.fat_g * scaleFactor * 100) / 100,
-        fiber_g: ing.fiber_g != null ? Math.round(ing.fiber_g * scaleFactor * 100) / 100 : null,
-        sugar_g: ing.sugar_g != null ? Math.round(ing.sugar_g * scaleFactor * 100) / 100 : null,
-        sodium_mg: ing.sodium_mg != null ? Math.round(ing.sodium_mg * scaleFactor * 100) / 100 : null,
-      }));
-
-      await createEntry.mutateAsync({
-        localDate: selectedDate,
-        meal: defaultMeal ?? 'breakfast',
-        name: food.name,
-        source: 'custom',
-        ingredients,
-        from_custom_food_id: id,
-      });
-    } catch {
-      // Silently ignore
-    }
-  }
-
-  if (recent.length === 0) return null;
-
-  return (
-    <div className={styles.recentRow}>
-      <span className={styles.recentLabel}>Recently used</span>
-      <div className={styles.recentItems}>
-        {recent.map(food => (
-          <button
-            key={food.source_ref}
-            type="button"
-            className={styles.recentItem}
-            onClick={() => handleQuickReLog(food)}
-            aria-label={`Quick re-log ${food.name}`}
-            title={`Quick re-log: ${food.name}`}
-          >
-            <span className={styles.recentName}>{food.name}</span>
-            <span className={styles.recentMeta}>{Math.round(food.per100g.calories)} kcal/100g</span>
-          </button>
-        ))}
-      </div>
     </div>
   );
 }
@@ -359,15 +285,6 @@ export default function NutritionTracker() {
           + Add food
         </button>
 
-        <button
-          className={styles.aiBtn}
-          onClick={() => setChatOpen(true)}
-          aria-label="Ask AI"
-          title="AI-powered food logging"
-        >
-          Ask AI
-        </button>
-
         {/* Goals button — #73: bullseye/target icon instead of sun-like glyph */}
         <button
           className={styles.settingsBtn}
@@ -493,9 +410,6 @@ export default function NutritionTracker() {
           ))}
         </div>
       ))}
-
-      {/* Recently used custom foods row */}
-      <RecentlyUsedRow selectedDate={selectedDate} defaultMeal={editorMode.kind === 'manual-add' ? (editorMode as any).defaultMeal : undefined} />
 
       {/* EntryEditor (always mounted, controlled by open) */}
       <EntryEditor

--- a/client/src/features/nutrition/api.ts
+++ b/client/src/features/nutrition/api.ts
@@ -19,7 +19,6 @@ export const nutritionKeys = {
   goals: ['nutrition', 'goals'] as const,
   customFoods: (status?: 'draft' | 'saved') =>
     status ? ['nutrition', 'customFoods', status] as const : ['nutrition', 'customFoods'] as const,
-  recentCustomFoods: ['nutrition', 'recentCustomFoods'] as const,
 };
 
 export function useDay(date: string) {
@@ -147,18 +146,6 @@ export function useCustomFoods(status?: 'draft' | 'saved') {
   });
 }
 
-export function useRecentCustomFoods(limit = 5) {
-  return useQuery<FoodSearchResult[]>({
-    queryKey: nutritionKeys.recentCustomFoods,
-    queryFn: async () => {
-      const res = await clientApi.get('/nutrition/custom-foods/recent', {
-        params: { limit },
-      });
-      return res.data.data;
-    },
-  });
-}
-
 export async function getCustomFood(id: number): Promise<CustomFoodRow> {
   const res = await clientApi.get(`/nutrition/custom-foods/${id}`);
   return res.data.data;
@@ -173,7 +160,6 @@ export function useCreateCustomFood() {
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['nutrition', 'customFoods'] });
-      qc.invalidateQueries({ queryKey: nutritionKeys.recentCustomFoods });
     },
   });
 }
@@ -187,7 +173,6 @@ export function useUpdateCustomFood() {
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['nutrition', 'customFoods'] });
-      qc.invalidateQueries({ queryKey: nutritionKeys.recentCustomFoods });
     },
   });
 }
@@ -200,7 +185,6 @@ export function useDeleteCustomFood() {
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['nutrition', 'customFoods'] });
-      qc.invalidateQueries({ queryKey: nutritionKeys.recentCustomFoods });
     },
   });
 }


### PR DESCRIPTION
## Summary
- Removes the "Recently used" custom-foods row from the nutrition tab (client-side only — server endpoint and store function are untouched).
- Removes the "Ask AI" button from the nutrition tab actions row. The chat itself stays mounted and reachable via its own floating action button and drag-handle peek inside `NutritionChat.tsx`.

## Changes
- `client/src/features/nutrition/NutritionTracker.tsx`: deleted `RecentlyUsedRow`/`RecentlyUsedRowProps`, its render site, the `Ask AI` button, and now-unused imports (`useRecentCustomFoods`, `useCreateEntry`, `getCustomFood`, `IngredientInput`).
- `client/src/features/nutrition/NutritionTracker.module.scss`: deleted `.aiBtn` and the `.recentRow`/`.recentLabel`/`.recentItems`/`.recentItem`/`.recentName`/`.recentMeta` block.
- `client/src/features/nutrition/api.ts`: deleted `useRecentCustomFoods` and the `recentCustomFoods` query key, plus its `invalidateQueries` calls in `useCreateCustomFood`/`useUpdateCustomFood`/`useDeleteCustomFood`.

Closes #194
Closes #191

## Test plan
- [x] `cd client && npx tsc --noEmit` passes clean
- [x] `cd client && npm run build` succeeds
- [x] Grepped `client/src` for `RecentlyUsedRow`, `useRecentCustomFoods`, `recentCustomFoods`, `aiBtn`, `.recentRow` — no lingering references