### PR TITLE
fix: prevent sign in/out buttons from wrapping on mobile

### DIFF
--- a/client/src/styles/Header.module.scss
+++ b/client/src/styles/Header.module.scss
@@ -33,6 +33,22 @@
     align-items: flex-end;
     // Let logo shrink if header is tight; headerRight gets its space
     flex: 1;
+    // #192: allow the logo to shrink below its content width so the
+    // auth buttons never get squeezed into wrapping; truncate instead.
+    min-width: 0;
+    overflow: hidden;
+
+    .title {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+
+  // #192: tighten header padding on mobile — the 2.5rem side padding is a
+  // big part of what squeezes the auth pills into wrapping on narrow screens.
+  @media (max-width: $mobile-width) {
+    padding: 1.25rem 1rem;
   }
 }
 
@@ -70,6 +86,9 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  // #192: never let this cluster get flex-shrunk below its content width —
+  // the logo (flex: 1, min-width: 0) should yield space instead.
+  flex-shrink: 0;
 }
 
 // #60: Feedback icon button in the header
@@ -110,6 +129,9 @@
   display: flex;
   align-items: baseline;
   gap: 10px;
+  // #192: keep the pill cluster at its natural width — never shrink it,
+  // the buttons wrapping their text is worse than the logo truncating.
+  flex-shrink: 0;
   font: {
     family: $sarabun;
     size: 18px;
@@ -121,6 +143,9 @@
     text-decoration: none;
     padding: 8px 15px;
     border-radius: 20px;
+    // #192: "Sign Up" / "Sign In" / "Logout" must stay on one line
+    white-space: nowrap;
+    flex-shrink: 0;
   }
 
   .transparentButton {
@@ -138,6 +163,18 @@
     transition: ease 0.2s;
     &:hover {
       background-color: $button-hover;
+    }
+  }
+
+  // #192: on mobile, shrink the pills' font/padding/gap so both buttons
+  // fit without squeezing — keeps ~40px effective tap height, matching
+  // the hamburger/feedback icon buttons.
+  @media (max-width: $mobile-width) {
+    gap: 6px;
+    font-size: 15px;
+
+    span, a, a:visited {
+      padding: 9px 12px;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Fixes mobile squashing of the Sign Up / Sign In (and Logout) header pill buttons, which were wrapping their text onto two lines on narrow viewports.
- `.headerRight` and `.authLinks` now get `flex-shrink: 0` so they never get squeezed below their content width; the pill labels get `white-space: nowrap`.
- `.logo` now yields space instead (`min-width: 0`, with `text-overflow: ellipsis` truncation as a safety net) rather than the auth buttons wrapping.
- Added a `@media (max-width: $mobile-width)` block (the file previously had none) that tightens `.header` horizontal padding and trims the auth pill font-size/padding/gap on mobile, while keeping the pill's rendered height around ~37-38px (comparable to the existing 40px hamburger/feedback icon buttons).

## Verification
- `cd client && npx tsc --noEmit` — clean.
- `cd client && npm run build` — succeeds.
- Verified at runtime with Playwright (`vite dev` + browser automation), measuring actual rendered button geometry rather than eyeballing:
  - At 375px viewport (logged out, tightest case): "Sign Up" 73.6x37.5px, "Sign In" 68.2x37.5px — both single-line, `scrollWidth` matches the visible width (no overflow/wrap). Header height 56px.
  - At 320px viewport (iPhone SE): identical button dimensions, still no wrap.
  - At 1280px (desktop): buttons render at 39px height using the original (untightened) padding/font-size — no regression.
  - Logged-in state: `AccountMenu` renders only a fixed 38x38px icon button in `.headerRight` (no text pill), so it was never subject to the wrap issue; the CSS fix to `.authLinks span, a` also covers `Logout.jsx`'s `transparentButton` span defensively if it's ever rendered inside `.authLinks` again (it's currently unused/unimported elsewhere in the app).

Closes #192

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] Playwright runtime check at 320px/375px/1280px widths, logged-out state
- [x] Code-inspection check of logged-in state (icon-only button, not affected)
