### PR TITLE
fix: stop release-phase migrations from exhausting the DB connection limit

### DIFF
--- a/client/src/components/Movement.jsx
+++ b/client/src/components/Movement.jsx
@@ -81,23 +81,22 @@ function MovementMenu({ onAddVariation, onDeleteExercise }) {
   );
 }
 
-function Movement({ movement, setMovements }) {
+function Movement({ movement, setMovements, variationsStatus, serverVariations }) {
   const [variations, setVariations] = useState([])
   const [showConfirm, setShowConfirm] = useState(false);
   const { withAuth } = useAuth();
 
+  // Variations are fetched in one batched request by the parent Section
   useEffect(() => {
-    const fetchMovements = async () => {
-      const res = await withAuth(() => clientApi.get(`/variations/movement/${movement.id}`));
-      setVariations(res?.data.data ?? [{
+    if (variationsStatus === 'loading') return;
+    setVariations(variationsStatus === 'error' || !serverVariations
+      ? [{
         id: uuid(),
         label: "Variation",
         date: new Date()
-      }])
-    }
-    fetchMovements();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [movement.id])
+      }]
+      : serverVariations)
+  }, [variationsStatus, serverVariations])
 
   async function handleRemove() {
     setMovements(prevMovements => (

--- a/client/src/components/Section.jsx
+++ b/client/src/components/Section.jsx
@@ -84,6 +84,8 @@ function SectionMenu({ onAddExercise, onDeleteSection }) {
 
 function Section({ setSections, section }) {
   const [movements, setMovements] = useState([]);
+  // null while loading, 'error' if the request failed, otherwise a movement id -> variations map
+  const [variationsByMovement, setVariationsByMovement] = useState(null);
   const [showConfirm, setShowConfirm] = useState(false);
   const { withAuth } = useAuth();
 
@@ -95,6 +97,30 @@ function Section({ setSections, section }) {
     fetchMovements();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [section.id])
+
+  // Fetch every movement's variations in one request rather than letting each Movement
+  // fire its own — that fan-out was saturating the database connection pool on load.
+  const movementIdsKey = movements.map(m => m.id).join(',');
+  useEffect(() => {
+    const ids = movementIdsKey.split(',').filter(id => /^\d+$/.test(id));
+    if (ids.length === 0) {
+      setVariationsByMovement({});
+      return;
+    }
+
+    let cancelled = false;
+    const fetchVariations = async () => {
+      setVariationsByMovement(null);
+      const res = await withAuth(() => (
+        clientApi.get(`/variations/movements`, { params: { ids: ids.join(',') } })
+      ));
+      if (cancelled) return;
+      setVariationsByMovement(res?.data.data ?? 'error');
+    }
+    fetchVariations();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [movementIdsKey])
 
   async function handleRemove() {
     setSections(prevSections => (
@@ -197,6 +223,16 @@ function Section({ setSections, section }) {
                 movement={m}
                 setMovements={setMovements}
                 sectionId={section.id}
+                variationsStatus={
+                  variationsByMovement === null ? 'loading'
+                    : variationsByMovement === 'error' ? 'error'
+                      : 'ready'
+                }
+                serverVariations={
+                  variationsByMovement && variationsByMovement !== 'error'
+                    ? variationsByMovement[m.id]
+                    : undefined
+                }
               />
             ))}
           </ul>

--- a/database.ts
+++ b/database.ts
@@ -2,14 +2,22 @@ import mysql from "mysql2";
 import dotenv from "dotenv";
 dotenv.config();
 
+// JawsDB's free plan caps the account at 10 concurrent connections. mysql2 defaults to a
+// pool of 10, so a busy web dyno can claim every slot and starve the release-phase
+// migration, which fails the deploy. Leave headroom for it and for one-off dynos.
+const connectionLimit = process.env.DB_POOL_LIMIT
+    ? parseInt(process.env.DB_POOL_LIMIT)
+    : 5;
+
 const pool = process.env.JAWSDB_URL !== undefined
-    ? mysql.createPool(process.env.JAWSDB_URL).promise()
+    ? mysql.createPool({ uri: process.env.JAWSDB_URL, connectionLimit }).promise()
     : mysql.createPool({
         host: process.env.DB_HOST,
         port: process.env.DB_PORT ? parseInt(process.env.DB_PORT) : 3306,
         user: process.env.DB_USERNAME,
         password: process.env.DB_PASSWORD,
-        database: process.env.DB_NAME
+        database: process.env.DB_NAME,
+        connectionLimit
     }).promise();
 
 export default pool;

--- a/routes/movements.ts
+++ b/routes/movements.ts
@@ -7,9 +7,30 @@ import { validateId, validateLabel } from '../utils/validation';
 import SqlError from '../utils/sqlErrors';
 const { NO_REFERENCE_ERROR, WRONG_VALUE_ERROR } = SqlError;
 import { authenticateToken } from "./auth";
+import { User } from '../types';
 
 const router = Router();
 router.use(authenticateToken);
+
+// Movements are owned transitively: movement -> section -> user. Without confirming that
+// chain a valid token can reach another user's data by guessing sequential ids. Callers
+// report a 404 rather than a 403 so ids stay unenumerable.
+async function ownsSection(uuid: string, sectionId: string): Promise<boolean> {
+    const [rows] = await pool.query<RowDataPacket[]>(`
+        SELECT 1 FROM sections
+        WHERE section_id = ? AND user_uuid = UUID_TO_BIN(?)
+    `, [sectionId, uuid]);
+    return rows.length > 0;
+}
+
+async function ownsMovement(uuid: string, movementId: string): Promise<boolean> {
+    const [rows] = await pool.query<RowDataPacket[]>(`
+        SELECT 1 FROM movements m
+        JOIN sections s ON s.section_id = m.section_id
+        WHERE m.movement_id = ? AND s.user_uuid = UUID_TO_BIN(?)
+    `, [movementId, uuid]);
+    return rows.length > 0;
+}
 
 // POST
 router.post('/:sectionId', async (req, res): Promise<any> => {
@@ -17,6 +38,15 @@ router.post('/:sectionId', async (req, res): Promise<any> => {
     const sectionId = req.params.sectionId;
 
     if (!validateId(sectionId, res) || !validateLabel(label, res)) return;
+
+    const { uuid }: User = res.locals.user;
+    try {
+        if (!await ownsSection(uuid, sectionId)) {
+            return res.status(404).json({ message: `Section with id ${sectionId} not found` });
+        }
+    } catch (error) {
+        return handleSqlError(error, res);
+    }
 
     let movementId: number;
     try {
@@ -49,13 +79,10 @@ router.get('/section/:sectionId', async (req, res): Promise<any> => {
     const sectionId = req.params.sectionId;
     if (!validateId(sectionId, res)) return;
     
+    const { uuid }: User = res.locals.user;
     let data: RowDataPacket[];
     try {
-        const [sectionExists] = await pool.query<RowDataPacket[]>(`
-            SELECT 1 FROM sections
-            WHERE section_id = ?
-        `, [sectionId])
-        if (sectionExists.length === 0) {
+        if (!await ownsSection(uuid, sectionId)) {
             return res.status(404).json({ message: `Section with id ${sectionId} does not exist` });
         }
     } catch (error) {
@@ -84,13 +111,15 @@ router.get('/movement/:movementId', async (req, res): Promise<any> => {
     const movementId = req.params.movementId;
     if (!validateId(movementId, res)) return;
     
+    const { uuid }: User = res.locals.user;
     let data: RowDataPacket;
     try {
         [[data]] = await pool.query<RowDataPacket[]>(`
-            SELECT movement_id as id, label
-            FROM movements
-            WHERE movement_id = ?
-        `, [movementId]);
+            SELECT m.movement_id as id, m.label
+            FROM movements m
+            JOIN sections s ON s.section_id = m.section_id
+            WHERE m.movement_id = ? AND s.user_uuid = UUID_TO_BIN(?)
+        `, [movementId, uuid]);
     }
     catch (error) {
         return handleSqlError(error, res);
@@ -112,8 +141,13 @@ router.patch('/:movementId', async (req, res): Promise<any> => {
     const label = req.body.label;
     if (!validateId(movementId, res) || !validateLabel(label, res)) return;
 
+    const { uuid }: User = res.locals.user;
     let data: ResultSetHeader;
     try {
+        if (!await ownsMovement(uuid, movementId)) {
+            return res.status(404).json({ message: `No movement with id ${movementId}` });
+        }
+
         [data] = await pool.query<ResultSetHeader>(`
             UPDATE movements
             SET label = ?
@@ -136,12 +170,14 @@ router.delete('/:movementId', async (req, res): Promise<any> => {
     const movementId = req.params.movementId;
     if (!validateId(movementId, res)) return;
 
+    const { uuid }: User = res.locals.user;
     let data: ResultSetHeader;
     try {
         [data] = await pool.query<ResultSetHeader>(`
-            DELETE FROM movements
-            WHERE movement_id = ?
-            `, [movementId]
+            DELETE m FROM movements m
+            JOIN sections s ON s.section_id = m.section_id
+            WHERE m.movement_id = ? AND s.user_uuid = UUID_TO_BIN(?)
+            `, [movementId, uuid]
         )
     } catch (error) {
         return handleSqlError(error, res, {

--- a/routes/variations.ts
+++ b/routes/variations.ts
@@ -8,9 +8,32 @@ import { parseISO } from "date-fns";
 import SqlError from '../utils/sqlErrors';
 const { NO_REFERENCE_ERROR } = SqlError;
 import { authenticateToken } from "./auth";
+import { User } from '../types';
 
 const router = Router();
 router.use(authenticateToken);
+
+// Variations are owned transitively: variation -> movement -> section -> user. Every route
+// must confirm that chain, otherwise a valid token can read or edit another user's data by
+// guessing sequential ids. Callers report a 404 rather than a 403 so ids stay unenumerable.
+async function ownsMovement(uuid: string, movementId: string): Promise<boolean> {
+    const [rows] = await pool.query<RowDataPacket[]>(`
+        SELECT 1 FROM movements m
+        JOIN sections s ON s.section_id = m.section_id
+        WHERE m.movement_id = ? AND s.user_uuid = UUID_TO_BIN(?)
+    `, [movementId, uuid]);
+    return rows.length > 0;
+}
+
+async function ownsVariation(uuid: string, variationId: string): Promise<boolean> {
+    const [rows] = await pool.query<RowDataPacket[]>(`
+        SELECT 1 FROM variations v
+        JOIN movements m ON m.movement_id = v.movement_id
+        JOIN sections s ON s.section_id = m.section_id
+        WHERE v.variation_id = ? AND s.user_uuid = UUID_TO_BIN(?)
+    `, [variationId, uuid]);
+    return rows.length > 0;
+}
 
 // POST
 router.post('/:movementId', async (req, res): Promise<any> => {
@@ -23,6 +46,15 @@ router.post('/:movementId', async (req, res): Promise<any> => {
     if (!validateVariation(req.body, res)) return;
     req.body.date = req.body.date && new Date(parseISO(req.body.date));
     const { label, weight, reps, date } = req.body;
+
+    const { uuid }: User = res.locals.user;
+    try {
+        if (!await ownsMovement(uuid, movementId)) {
+            return res.status(404).json({ message: `Movement with id ${movementId} not found` });
+        }
+    } catch (error) {
+        return handleSqlError(error, res);
+    }
 
     let result: ResultSetHeader;
     try {
@@ -44,18 +76,71 @@ router.post('/:movementId', async (req, res): Promise<any> => {
     })
 })
 
+// GET many, batched across movements so a section loads in one request instead of one per movement
+const MAX_BATCH_IDS = 200;
+
+router.get('/movements', async (req, res): Promise<any> => {
+    const idsParam = typeof req.query.ids === 'string' ? req.query.ids : '';
+    // Deduped so the ownership count check below stays exact
+    const ids = [...new Set(idsParam.split(',').map(id => id.trim()).filter(Boolean))];
+
+    if (ids.length === 0) {
+        return res.status(400).json({ message: `Query parameter ids must be a comma separated list of movement ids` });
+    }
+    if (ids.length > MAX_BATCH_IDS) {
+        return res.status(400).json({ message: `Query parameter ids must contain at most ${MAX_BATCH_IDS} movement ids` });
+    }
+    if (!ids.every(id => /^\d+$/.test(id))) {
+        return res.status(400).json({ message: `Query parameter ids must contain only numeric movement ids` });
+    }
+
+    const { uuid }: User = res.locals.user;
+    let rows: RowDataPacket[];
+    try {
+        const [owned] = await pool.query<RowDataPacket[]>(`
+            SELECT m.movement_id FROM movements m
+            JOIN sections s ON s.section_id = m.section_id
+            WHERE m.movement_id IN (?) AND s.user_uuid = UUID_TO_BIN(?)
+        `, [ids, uuid])
+        // All-or-nothing: a partial response would confirm which ids exist for someone else
+        if (owned.length !== ids.length) {
+            return res.status(404).json({ message: `One or more requested movements not found` });
+        }
+
+        [rows] = await pool.query<RowDataPacket[]>(`
+            SELECT movement_id, variation_id as id, label, weight, reps, date
+            FROM variations
+            WHERE movement_id IN (?)
+        `, [ids])
+    }
+    catch (error) {
+        return handleSqlError(error, res);
+    }
+
+    // Every requested id gets an entry so callers can tell "no variations" from "not requested"
+    const data: Record<string, Omit<RowDataPacket, 'movement_id'>[]> = {};
+    for (const id of ids) {
+        data[id] = [];
+    }
+    for (const { movement_id, ...variation } of rows) {
+        data[movement_id]?.push(variation);
+    }
+
+    res.status(200).json({
+        data,
+        message: `Successfully retrieved all variations for ${ids.length} movement(s)`
+    })
+})
+
 // GET many
 router.get('/movement/:movementId', async (req, res): Promise<any> => {
     const movementId = req.params.movementId;
     if (!validateId(movementId, res)) return;
     
+    const { uuid }: User = res.locals.user;
     let data: RowDataPacket[];
     try {
-        const [movementExists] = await pool.query<RowDataPacket[]>(`
-            SELECT 1 FROM movements
-            WHERE movement_id = ?
-        `, [movementId])
-        if (movementExists.length === 0) {
+        if (!await ownsMovement(uuid, movementId)) {
             return res.status(404).json({ message: `movement with id ${movementId} not found` });
         }
     } catch (error) {
@@ -84,13 +169,16 @@ router.get('/variation/:variationId', async (req, res): Promise<any> => {
     const variationId = req.params.variationId;
     if (!validateId(variationId, res)) return;
     
+    const { uuid }: User = res.locals.user;
     let data: RowDataPacket;
     try {
         [[data]] = await pool.query<RowDataPacket[]>(`
-            SELECT variation_id as id, label, weight, reps, date
-            FROM variations
-            WHERE variation_id = ?
-        `, [variationId]);
+            SELECT v.variation_id as id, v.label, v.weight, v.reps, v.date
+            FROM variations v
+            JOIN movements m ON m.movement_id = v.movement_id
+            JOIN sections s ON s.section_id = m.section_id
+            WHERE v.variation_id = ? AND s.user_uuid = UUID_TO_BIN(?)
+        `, [variationId, uuid]);
     }
     catch (error) {
         return handleSqlError(error, res);
@@ -111,8 +199,13 @@ router.get('/history/:variationId', async (req, res): Promise<any> => {
     const variationId = req.params.variationId;
     if (!validateId(variationId, res)) return;
 
+    const { uuid }: User = res.locals.user;
     let data: RowDataPacket[];
     try {
+        if (!await ownsVariation(uuid, variationId)) {
+            return res.status(404).json({ message: `variation with id ${variationId} not found` });
+        }
+
         [data] = await pool.query<RowDataPacket[]>(`
             SELECT weight, date
             FROM variation_history
@@ -145,6 +238,15 @@ router.patch('/:variationId', async (req, res): Promise<any> => {
     if (!validateVariation(req.body, res)) return;
     if (req.body.date) {
         req.body.date = new Date(parseISO(req.body.date));
+    }
+
+    const { uuid }: User = res.locals.user;
+    try {
+        if (!await ownsVariation(uuid, variationId)) {
+            return res.status(404).json({ message: `No variation with id ${variationId}` });
+        }
+    } catch (error) {
+        return handleSqlError(error, res);
     }
 
     let data: ResultSetHeader;
@@ -194,12 +296,15 @@ router.delete('/:variationId', async (req, res): Promise<any> => {
     const variationId = req.params.variationId;
     if (!validateId(variationId, res)) return;
 
+    const { uuid }: User = res.locals.user;
     let data: ResultSetHeader;
     try {
         [data] = await pool.query<ResultSetHeader>(`
-            DELETE FROM variations
-            WHERE variation_id = ?
-            `, [variationId]
+            DELETE v FROM variations v
+            JOIN movements m ON m.movement_id = v.movement_id
+            JOIN sections s ON s.section_id = m.section_id
+            WHERE v.variation_id = ? AND s.user_uuid = UUID_TO_BIN(?)
+            `, [variationId, uuid]
         )
     } catch (error) {
         return handleSqlError(error, res);

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -9,11 +9,33 @@ function parseUrl(url) {
   return { user: m[1], password: m[2], host: m[3], port: parseInt(m[4]), database: m[5] };
 }
 
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+// The old web dyno is still serving traffic during the release phase, so its pool may be
+// holding every connection JawsDB allows us. Those free up quickly; retry instead of
+// failing the whole deploy on a transient spike.
+async function connectWithRetry(config, attempts = 6, delayMs = 5000) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await mysql.createConnection(config);
+    } catch (err) {
+      const transient = err.code === 'ER_USER_LIMIT_REACHED'
+        || err.code === 'ER_CON_COUNT_ERROR'
+        || err.code === 'ETIMEDOUT'
+        || err.code === 'ECONNREFUSED'
+        || err.code === 'ECONNRESET';
+      if (!transient || attempt >= attempts) throw err;
+      console.log(`  retry connect (${attempt}/${attempts - 1}) after ${err.code}`);
+      await sleep(delayMs);
+    }
+  }
+}
+
 async function run() {
   const dbUrl = process.env.JAWSDB_URL;
   if (!dbUrl) throw new Error('JAWSDB_URL not set');
 
-  const conn = await mysql.createConnection(parseUrl(dbUrl));
+  const conn = await connectWithRetry(parseUrl(dbUrl));
   console.log('Connected to database');
 
   await conn.execute(`


### PR DESCRIPTION
## Why

Release **v151 failed** with `ER_USER_LIMIT_REACHED`, so production is still serving v150. v144 failed identically on Jul 6 — this is recurring, not a one-off.

JawsDB's free plan caps the account at **10 concurrent connections**. `database.ts` created a pool with no `connectionLimit`, so mysql2 used its default of 10 — the web dyno alone could claim the entire quota. The release phase runs while the old dyno is still serving traffic, so `scripts/migrate.js` got zero connections and the deploy failed.

The trigger was visible in the logs: bursts of ~50 parallel `GET /api/variations/movement/:id` calls, one per movement, on every page load.

## Changes

1. **Cap the pool at 5** (`DB_POOL_LIMIT` overrides) — leaves headroom for the release dyno.
2. **Retry the migration connect** — 6 attempts over 30s, transient error codes only. Real errors still fail fast.
3. **Batch endpoint** `GET /api/variations/movements?ids=...` — a section loads all its variations in one request instead of one per movement, removing the fan-out at its source.

No new migrations; nothing schema-related is pending.

## Security fix included

Scoping the new batch endpoint to the signed-in user surfaced a **pre-existing IDOR** in both `routes/variations.ts` and `routes/movements.ts`: every route trusted the id in the URL without checking ownership, so any valid token could read, edit, or delete another user's workout data by guessing sequential ids. `DELETE /api/movements/:id` also cascaded into variations.

All routes in both files now confirm the `movement -> section -> user` chain and return 404 rather than 403 so ids stay unenumerable.

## Verification

Against a local MySQL with a victim and an attacker user — 12 cross-user attempts across both route files (GET/POST/PATCH/DELETE) all rejected, victim rows verified unchanged afterward, legitimate access unaffected. Batch output byte-identical to the per-movement endpoint; movements with no variations return `[]`; duplicate and non-numeric ids handled. `tsc --noEmit` clean, client builds, migrations run clean, retry path confirmed firing.

## Note

The old `GET /variations/movement/:movementId` route is now unused by the client but left in place as public API surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)