### PR TITLE
Fix duplicate untitled ingredient blocking Save + default new foods to Snack

### DIFF
--- a/client/src/features/nutrition/EntryEditor.tsx
+++ b/client/src/features/nutrition/EntryEditor.tsx
@@ -147,7 +147,8 @@ export default function EntryEditor({
   // ----- Meal selector -----
   const [meal, setMeal] = useState<Meal>(() => {
     if (mode.kind === 'manual-edit') return mode.entry.meal;
-    if (mode.kind === 'manual-add') return mode.defaultMeal ?? 'breakfast';
+    // #200: default new manually-created foods to Snack / Other instead of Breakfast.
+    if (mode.kind === 'manual-add') return mode.defaultMeal ?? 'snack';
     return mode.proposal.meal;
   });
 
@@ -218,7 +219,8 @@ export default function EntryEditor({
         })),
       );
     } else if (mode.kind === 'manual-add') {
-      setMeal(mode.defaultMeal ?? 'breakfast');
+      // #200: default new manually-created foods to Snack / Other instead of Breakfast.
+      setMeal(mode.defaultMeal ?? 'snack');
       setEntryName('');
       setRows([emptyRow()]);
     } else if (mode.kind === 'proposal') {

--- a/client/src/features/nutrition/IngredientSheet.tsx
+++ b/client/src/features/nutrition/IngredientSheet.tsx
@@ -196,7 +196,9 @@ function IngredientForm({ row, onChange, onExpandMeal, onOpenBarcode }: Ingredie
             onExpandMeal(expandedRows);
           })
           .catch(() => {
-            onChange(rowFromFood(food, immediatePortions(food)));
+            // #199: preserve the row's identity so this replaces the row being
+            // edited instead of appending a duplicate untitled row.
+            onChange(rowFromFood(food, immediatePortions(food), row.rowKey));
           });
         return;
       }
@@ -209,7 +211,9 @@ function IngredientForm({ row, onChange, onExpandMeal, onOpenBarcode }: Ingredie
     const portions = cached
       ? buildPortionListFromFetched(food, cached)
       : immediatePortions(food);
-    onChange(rowFromFood(food, portions));
+    // #199: preserve the row's identity so this replaces the row being edited
+    // instead of appending a duplicate untitled row.
+    onChange(rowFromFood(food, portions, row.rowKey));
   }
 
   // #185 — quantity/unit changes must scale macros even when the row has no
@@ -443,7 +447,10 @@ export default function IngredientSheet({
         setBarcodeError(`Barcode ${code} not found in database.`);
         return;
       }
-      setRow(rowFromFood(food));
+      // #199: preserve the row's identity (functional update to avoid taking
+      // a `row` dependency) so this replaces the row being edited instead of
+      // appending a duplicate untitled row.
+      setRow(prev => rowFromFood(food, undefined, prev.rowKey));
     } catch {
       setBarcodeError('Failed to look up barcode. Try again.');
     }

--- a/client/src/features/nutrition/ingredientMath.ts
+++ b/client/src/features/nutrition/ingredientMath.ts
@@ -151,8 +151,17 @@ export function immediatePortions(food: FoodSearchResult): FoodPortion[] {
 /** Convert a FoodSearchResult into an EditorRow.
  *  Picks quantity=1 + first available portion if the food has a serving_grams,
  *  otherwise defaults to quantity=100, unit=g (same behaviour as before).
+ *
+ *  #199: pass `existingRowKey` when this call is filling in an already-open
+ *  row (food-search selection or barcode scan on an editing row) so the
+ *  result replaces that row instead of minting a new one. Omit it only when
+ *  genuinely creating a brand-new row.
  */
-export function rowFromFood(food: FoodSearchResult, existingPortions?: FoodPortion[]): EditorRow {
+export function rowFromFood(
+  food: FoodSearchResult,
+  existingPortions?: FoodPortion[],
+  existingRowKey?: number,
+): EditorRow {
   const portions = existingPortions ?? immediatePortions(food);
 
   // Default: use first non-gram portion if available, else grams.
@@ -170,7 +179,7 @@ export function rowFromFood(food: FoodSearchResult, existingPortions?: FoodPorti
   const effectiveGrams = quantity * selectedUnit.grams;
 
   return {
-    rowKey: nextKey(),
+    rowKey: existingRowKey ?? nextKey(),
     name: food.name,
     grams: effectiveGrams,
     quantity,


### PR DESCRIPTION
## Summary

Two nutrition-tab fixes, landed as separate commits.

### #200 — Default new manually-created foods to Snack / Other
`EntryEditor.tsx`'s `manual-add` mode fell back to `'breakfast'` in two places (initial `useState<Meal>` and the mode-reset `useEffect`) whenever no `defaultMeal` was supplied. `NutritionTracker`'s "Add food" entry point doesn't pass one, so every manually-added food defaulted to Breakfast. Changed both fallbacks to `'snack'` (`MEAL_LABELS.snack` is already `"Snack / Other"`). Non-manual modes (`manual-edit`, `proposal`) are untouched and keep whatever meal they already carry.

### #199 — Phantom "untitled" ingredient blocks Save
Root cause: `rowFromFood()` in `ingredientMath.ts` always minted a brand-new `rowKey` via `nextKey()`. When a user filled in the pre-loaded blank ingredient row by selecting a food from search, or by scanning a barcode, the row handed back carried a *different* `rowKey` than the blank row it came from. The parent's `handleSheetDone` (both `EntryEditor.tsx` and `MealBuilder.tsx`) matches on `rowKey` to decide replace-vs-append; the mismatch made it `findIndex` miss and append, leaving the original blank row orphaned. `handleSave`'s pre-validate check (`rows.some(r => !r.name.trim())`) then fired "every ingredient needs a name".

Fix at the root: `rowFromFood()` now accepts an optional `existingRowKey` and reuses it instead of always minting a new one. Updated both call sites in `IngredientSheet.tsx` that re-key a row while editing:
- `handleSelectFood` (food-search selection, including the custom-meal-expand-failure fallback) — now passes the current `row.rowKey`.
- `handleBarcodeDetected` (barcode scan) — now uses a functional `setRow` update to grab `prev.rowKey` without adding a dependency.

The genuine "add a new ingredient" path is unaffected: it still starts from `emptyRow()`, which mints a fresh key via the same `nextKey()` counter, so key uniqueness is preserved and a real new row still hits the `findIndex`-miss → append path correctly.

`MealBuilder.tsx` needed no direct changes — it shares the same `IngredientSheet` component and already used the identical replace-by-rowKey logic in its own `handleSheetDone`, so it's fixed transitively.

**Decision on defensive fallback**: did not add an append-fallback safety net in `handleSheetDone`. The bug was an identity bug at the source; papering over a `findIndex` miss with a silent fallback would just re-hide a future instance of the same class of bug rather than surface it. Chose to fix the actual cause instead.

## #199 repro trace (verified by reading the code path)
1. Add food → `rows = [emptyRow()]` with `rowKey = K1`.
2. Click the pre-loaded untitled ingredient → `openSheetForAdd` finds the existing empty row, `editingRow = {rowKey: K1, ...}`, sheet opens with `row` state seeded from `editRow` (`rowKey = K1`).
3. Load in name/macros via search select → `handleSelectFood` now calls `onChange(rowFromFood(food, portions, row.rowKey))` where `row.rowKey === K1`, so the returned row keeps `rowKey = K1`.
4. Click Done → `handleSheetDone(row)` with `row.rowKey === K1`; `prev.findIndex(r => r.rowKey === K1)` now finds index 0 and replaces it in place — **no new row is appended**.
5. (was: a second untitled row appeared here — now it doesn't.)
6. Click Save → `rows` has exactly one row, fully named.
7. No error — `rows.some(r => !r.name.trim())` is false.
8. No manual deletion needed.

Same trace applies to the barcode-scan entry point (`handleBarcodeDetected`) and to `MealBuilder`'s equivalent flow.

## Verification
- `npx tsc --noEmit -p client/tsconfig.json` — clean.
- `cd client && npm run build` — succeeds (only pre-existing Sass `@import` deprecation warnings, unrelated).
- Traced both #199 entry points (food search, barcode scan) and both consumers (`EntryEditor`, `MealBuilder`) by reading the code; did not have a running app/browser available in this session to click through it live.

## Gaps
- Did not manually drive the app in a browser to click through the repro steps — verification for #199 is a full code-path trace rather than an interactive run.

Closes #199
Closes #200