### PR TITLE
Nutrition: more-options dropdown + entry card title spacing fix

### DIFF
--- a/client/src/features/nutrition/NutritionTracker.module.scss
+++ b/client/src/features/nutrition/NutritionTracker.module.scss
@@ -97,7 +97,13 @@
   }
 }
 
-.settingsBtn {
+// #202: "More options" (Goals / My Foods) dropdown trigger, in the actions row
+.actionsMenuWrapper {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.actionsDotsBtn {
   min-width: 48px;
   min-height: 48px;
   background: transparent;
@@ -116,11 +122,11 @@
   }
 }
 
-.settingsIcon {
-  display: block;
-  // #75: standardize goals/settings icon to 16px
-  width: 16px;
-  height: 16px;
+// #202: dropdown anchors under the actions-row trigger instead of a per-entry
+// row. Compound selector so this reliably wins over .entryDropdown's own
+// `top` regardless of declaration order (both are single-class specificity).
+.entryDropdown.actionsDropdown {
+  top: calc(100% + 6px);
 }
 
 // ---- Totals card ----
@@ -340,6 +346,13 @@
     background-color: rgba($primary, 0.12);
     color: $primary;
   }
+}
+
+// #202: icon shown before the label in dropdown items that use icon+text (actions menu)
+.entryDropdownItemIcon {
+  display: block;
+  flex-shrink: 0;
+  margin-right: 10px;
 }
 
 .entryDropdownItemDanger {

--- a/client/src/features/nutrition/NutritionTracker.module.scss
+++ b/client/src/features/nutrition/NutritionTracker.module.scss
@@ -249,13 +249,18 @@
   padding: 12px 14px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  // #201: 8px (not 4px) so .dotsBtn's 8px negative-margin overflow (below,
+  // see .dotsBtn) never reaches into .macroChips' tap area.
+  gap: 8px;
 }
 
 // #72: Entry top row — name on left (wraps up to 2 lines), three-dots on right
+// #201: align to the top (not centered) so the 36px dots button doesn't stretch
+// the row height and push extra space above a one-line title. The button keeps
+// its 36px tap target via negative margins on .dotsBtn instead.
 .entryTop {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 8px;
 }
 
@@ -268,6 +273,10 @@
   color: $text;
   letter-spacing: $sarabun-spacing;
   min-width: 0;
+  // #201: fixed line-height so a single line has a known, stable height (20px).
+  // .dotsBtn's negative margins below are computed against this value so the
+  // dots button never drives the row taller than the title itself.
+  line-height: 20px;
   // Allow up to 2 lines before clamping
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -277,15 +286,28 @@
 }
 
 // #72: Three-dots menu wrapper (positioned relative so dropdown anchors to it)
+// #201: display:flex so the child's negative margins (below) shrink this
+// wrapper's own box height deterministically instead of collapsing/leaking
+// into the surrounding .entryTop flex row.
 .entryMenuWrapper {
   position: relative;
   flex-shrink: 0;
+  display: flex;
 }
 
 // #72: The ⋮ trigger button
+// #201: keeps its 36x36 tap target, but negative vertical margins pull that
+// box up/down symmetrically by 8px each side so its effective height in the
+// flex layout matches .entryName's 20px single-line height (36 - 8 - 8 = 20).
+// This stops the button from stretching .entryTop taller than a one-line
+// title, which was the source of the extra space above short titles. For a
+// two-line title (40px) the button no longer matters since it's smaller than
+// the text either way. The 36px hit area itself is untouched — it just
+// overflows the row's box rather than expanding it.
 .dotsBtn {
   min-width: 36px;
   min-height: 36px;
+  margin: -8px 0;
   background: transparent;
   border: none;
   border-radius: 8px;
@@ -310,7 +332,12 @@
 // #72: Dropdown menu
 .entryDropdown {
   position: absolute;
-  top: calc(100% + 4px);
+  // #201: .dotsBtn's -8px vertical margins (above) shrink .entryMenuWrapper's
+  // own box to 20px while the button itself still visually extends 8px below
+  // it (36px box, only its top half "fits" inside the wrapper's 100%). Add
+  // that 8px back here so the dropdown still opens flush under the button's
+  // actual visible edge instead of overlapping it.
+  top: calc(100% + 4px + 8px);
   right: 0;
   background-color: $surface;
   border: 1px solid $surface-border;

--- a/client/src/features/nutrition/NutritionTracker.tsx
+++ b/client/src/features/nutrition/NutritionTracker.tsx
@@ -146,6 +146,84 @@ function EntryMenu({ entry, onEdit, onDelete, onSaveAsMeal }: EntryMenuProps) {
   );
 }
 
+// ---- Actions row "more options" menu (#202) ----
+
+interface ActionsMenuProps {
+  onGoals: () => void;
+  onMyFoods: () => void;
+}
+
+function ActionsMenu({ onGoals, onMyFoods }: ActionsMenuProps) {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const btnRef = useRef<HTMLButtonElement>(null);
+
+  // Close on outside tap/click
+  useEffect(() => {
+    if (!open) return;
+    function handleOutside(e: MouseEvent | TouchEvent) {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleOutside);
+    document.addEventListener('touchstart', handleOutside, { passive: true });
+    return () => {
+      document.removeEventListener('mousedown', handleOutside);
+      document.removeEventListener('touchstart', handleOutside);
+    };
+  }, [open]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        setOpen(false);
+        btnRef.current?.focus();
+      }
+    }
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [open]);
+
+  return (
+    <div className={styles.actionsMenuWrapper} ref={wrapperRef}>
+      <button
+        ref={btnRef}
+        className={styles.actionsDotsBtn}
+        onClick={() => setOpen(v => !v)}
+        aria-label="More options"
+        aria-haspopup="true"
+        aria-expanded={open}
+      >
+        <MoreVertical className={styles.dotsIcon} size={18} aria-hidden="true" />
+      </button>
+
+      {open && (
+        <div className={`${styles.entryDropdown} ${styles.actionsDropdown}`} role="menu">
+          <button
+            className={styles.entryDropdownItem}
+            role="menuitem"
+            onClick={() => { setOpen(false); onGoals(); }}
+          >
+            <Target className={styles.entryDropdownItemIcon} size={16} aria-hidden="true" />
+            Goals
+          </button>
+          <button
+            className={styles.entryDropdownItem}
+            role="menuitem"
+            onClick={() => { setOpen(false); onMyFoods(); }}
+          >
+            <BookMarked className={styles.entryDropdownItemIcon} size={16} aria-hidden="true" />
+            My Foods
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ---- Main component ----
 
 export default function NutritionTracker() {
@@ -285,25 +363,11 @@ export default function NutritionTracker() {
           + Add food
         </button>
 
-        {/* Goals button — #73: bullseye/target icon instead of sun-like glyph */}
-        <button
-          className={styles.settingsBtn}
-          onClick={() => setGoalsModalOpen(true)}
-          aria-label="Nutrition goals"
-          title="Set nutrition goals"
-        >
-          <Target className={styles.settingsIcon} size={16} aria-hidden="true" />
-        </button>
-
-        {/* My Foods button */}
-        <button
-          className={styles.settingsBtn}
-          onClick={() => setMyFoodsOpen(true)}
-          aria-label="My Foods"
-          title="My custom foods and meals"
-        >
-          <BookMarked className={styles.settingsIcon} size={16} aria-hidden="true" />
-        </button>
+        {/* #202: Goals + My Foods moved into a single "more options" dropdown for discoverability */}
+        <ActionsMenu
+          onGoals={() => setGoalsModalOpen(true)}
+          onMyFoods={() => setMyFoodsOpen(true)}
+        />
       </div>
 
       {/* Totals card */}


### PR DESCRIPTION
## Summary
- Closes #202
- Closes #201

**#202 — Move Goals/My Foods into a "more options" dropdown**
Replaces the Goals and My Foods icon buttons in the nutrition actions row with a single ⋮ "More options" trigger. Mirrors the existing per-entry `EntryMenu` pattern (click-outside-to-close, Escape-to-close, `aria-haspopup`/`aria-expanded`, 36px+ tap target). The dropdown items show both an icon and a text label ("Goals", "My Foods") for better discoverability.

**#201 — Equalize spacing above/below entry card titles**
Root cause: `.entryTop` used `align-items: center`, so the 36px `.dotsBtn` tap target (taller than a single line of title text) drove the row's height and centered the shorter title inside it — producing dead space above/below one-line titles that two-line titles didn't have.

Fix: `.entryTop` now aligns children to the top, `.entryName` gets a fixed `line-height` so its box height is predictable, and `.dotsBtn` gets negative vertical margins so it keeps its 36x36 hit area without stretching the row. `.entryRow`'s gap and the per-entry dropdown's anchor offset were adjusted to compensate for the button's resulting overflow, so it doesn't overlap the macro chips below and the dropdown still opens in the same visible spot.

## Test plan
- [x] `npx tsc --noEmit -p client/tsconfig.json` — clean
- [x] `cd client && npm run build` — succeeds
- [x] Reasoned through the box model by hand: for a one-line title, `.entryTop` height now equals the title's own line-height (20px), matching the two-line case (which was already driven by the title). Space above the title in both cases = the card's own 12px padding, with no additional dead space from the button.
- [ ] Not verified in an actual rendered browser (no interactive browser session available in this run) — recommend a quick visual check on a 375px viewport before merging.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>