### PR TITLE
Fix nutrition date nav overflowing the page at 320px

### DIFF
--- a/client/src/features/nutrition/NutritionTracker.module.scss
+++ b/client/src/features/nutrition/NutritionTracker.module.scss
@@ -47,6 +47,10 @@
 
 .dateInput {
   flex: 1;
+  // A date input carries an intrinsic minimum width, and a flex item's default
+  // `min-width: auto` refuses to shrink below it — which overflowed the page by
+  // a few px at 320px. Allow the field to shrink; the 44px arrows never do.
+  min-width: 0;
   min-height: 44px;
   background: transparent;
   color: $text;
@@ -68,6 +72,14 @@
   &::-webkit-calendar-picker-indicator {
     filter: invert(1) opacity(0.4);
     cursor: pointer;
+  }
+
+  // On the narrowest phones (320px) the 44px arrows + gaps leave the field too
+  // little room, and the full date clips against the picker icon. Trade some
+  // side padding — the text is centred, so this costs nothing visually.
+  @media (max-width: 360px) {
+    padding-left: 4px;
+    padding-right: 4px;
   }
 }
 


### PR DESCRIPTION
Closes #205

Pre-existing bug found while runtime-validating the #199/#200/#201/#202 batch — not caused by those changes.

## Root cause
`.dateInput` is `flex: 1`, but an `<input type=date>` carries an intrinsic minimum width, and a flex item's default `min-width: auto` refuses to shrink below it. At a 320px viewport the date row needed ~296px inside a 292px container, pushing the trailing 44px `.arrowBtn` past the viewport edge and scrolling the page horizontally by 4px.

## Fix
1. `min-width: 0` on `.dateInput` so the field can shrink instead of forcing the row wide.
2. That alone left the field with a 120px content box for ~122px of content (date text + 2px letter-spacing + the picker icon), clipping "08/05/2026" to "08/05/202". So at `max-width: 360px` the field trades its 12px side padding for 4px. The text is centred, so this is visually free.

The 44px arrow tap targets are untouched.

## Verification (measured in-browser, not eyeballed)
| viewport | page overflow | date field padding | result |
|---|---|---|---|
| 320px | none (scrollWidth 320 = clientWidth) | 4px | full date legible |
| 360px | none | 4px | full date legible |
| 375px | none | 12px (unchanged) | unchanged |
| 1024px | none | 12px (unchanged) | unchanged |

Also confirmed at 320px: the field is still 44px tall, `elementFromPoint` at its centre still resolves to the input (nothing covering it), and zero console errors. `npx tsc --noEmit -p client/tsconfig.json` clean; `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)