### PR TITLE
Fix serif graph labels + add est. 1RM tracking to variation graphs

### DIFF
--- a/client/src/components/WeightGraphModal.jsx
+++ b/client/src/components/WeightGraphModal.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import { format } from 'date-fns';
@@ -6,31 +7,107 @@ import { useUser } from '../context/UserProvider.jsx';
 import Modal from './Modal.jsx';
 import styles from '../styles/WeightGraphModal.module.scss';
 
+// Single global flag shared by every variation graph — not per-variation.
+// Switching one graph to "Weight" switches all of them.
+const METRIC_STORAGE_KEY = 'variationGraphMetric';
+const METRIC_EST_1RM = 'est1rm';
+const METRIC_WEIGHT = 'weight';
+
+function readStoredMetric() {
+  try {
+    const stored = localStorage.getItem(METRIC_STORAGE_KEY);
+    if (stored === METRIC_EST_1RM || stored === METRIC_WEIGHT) return stored;
+  } catch (_) {
+    // localStorage can throw (e.g. Safari private mode); fall back to default.
+  }
+  return METRIC_EST_1RM;
+}
+
+function writeStoredMetric(metric) {
+  try {
+    localStorage.setItem(METRIC_STORAGE_KEY, metric);
+  } catch (_) {
+    // Best-effort; nothing to do if storage is unavailable.
+  }
+}
+
+// Epley formula. When reps is null/undefined/0 we have no rep data for that
+// point (pre-existing history rows never recorded reps), so the est. 1RM is
+// just the weight itself rather than an extrapolation.
+function estimate1RM(weight, reps) {
+  if (weight == null) return null;
+  if (!reps) return Math.round(weight);
+  return Math.round(weight * (1 + reps / 30));
+}
+
+function GraphTooltip({ active, payload, isEst1RM }) {
+  if (!active || !payload || payload.length === 0) return null;
+  const point = payload[0].payload;
+  const contentStyle = {
+    backgroundColor: '#282B28',
+    border: '1px solid #575757',
+    borderRadius: '8px',
+    color: '#EBEDE9',
+    fontFamily: 'Sarabun, sans-serif',
+    padding: '8px 12px',
+    fontSize: '13px',
+  };
+
+  if (!isEst1RM) {
+    return (
+      <div style={contentStyle}>
+        <div>{`${point.value} lbs`}</div>
+        <div style={{ opacity: 0.7 }}>Weight</div>
+      </div>
+    );
+  }
+
+  const setLabel = point.reps ? `${point.weight} lbs × ${point.reps}` : `${point.weight} lbs`;
+  return (
+    <div style={contentStyle}>
+      <div>{`${point.value} lbs (est. 1RM)`}</div>
+      <div style={{ opacity: 0.7 }}>{setLabel}</div>
+    </div>
+  );
+}
+
 /**
- * WeightGraphModal — weight-over-time chart for a variation.
+ * WeightGraphModal — weight / estimated-1RM-over-time chart for a variation.
  *
  * Props (unchanged):
  *   variation {object} — must have .id and .label
  *   onClose   {fn}     — called to close the modal
- *
- * Data logic: unchanged (React Query useQuery).
  */
 function WeightGraphModal({ variation, onClose }) {
   const { user } = useUser();
+  const [metric, setMetric] = useState(readStoredMetric);
 
-  // ── React Query data logic (untouched) ──────────────────────────────────────
   const { data: history = [], isLoading: loading } = useQuery({
     queryKey: ['variationHistory', variation.id],
     queryFn: async () => {
       const res = await clientApi.get(`/variations/history/${variation.id}`);
       return res.data.data.map(entry => ({
         weight: entry.weight,
+        reps: entry.reps,
         date: format(new Date(entry.date), 'MMM d'),
         rawDate: new Date(entry.date).getTime()
       }));
     },
     enabled: !!user,
   });
+
+  function handleMetricChange(next) {
+    setMetric(next);
+    writeStoredMetric(next);
+  }
+
+  const isEst1RM = metric === METRIC_EST_1RM;
+  const chartData = isEst1RM
+    ? history.map(entry => ({
+        ...entry,
+        value: estimate1RM(entry.weight, entry.reps),
+      }))
+    : history.map(entry => ({ ...entry, value: entry.weight }));
 
   return (
     <Modal
@@ -46,6 +123,27 @@ function WeightGraphModal({ variation, onClose }) {
           <button className={styles.close} onClick={onClose} aria-label="Close">✕</button>
         </div>
 
+        <div className={styles.toggle} role="tablist" aria-label="Graph metric">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={isEst1RM}
+            className={`${styles.toggleOption} ${isEst1RM ? styles.toggleOptionActive : ''}`}
+            onClick={() => handleMetricChange(METRIC_EST_1RM)}
+          >
+            Est. 1RM
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={!isEst1RM}
+            className={`${styles.toggleOption} ${!isEst1RM ? styles.toggleOptionActive : ''}`}
+            onClick={() => handleMetricChange(METRIC_WEIGHT)}
+          >
+            Weight
+          </button>
+        </div>
+
         {loading ? (
           <p className={styles.empty}>Loading…</p>
         ) : history.length < 2 ? (
@@ -57,7 +155,7 @@ function WeightGraphModal({ variation, onClose }) {
         ) : (
           <div className={styles.chartWrap}>
             <ResponsiveContainer width="100%" height={260}>
-              <LineChart data={history} margin={{ top: 10, right: 16, left: 0, bottom: 0 }}>
+              <LineChart data={chartData} margin={{ top: 10, right: 16, left: 0, bottom: 0 }}>
                 <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.08)" />
                 <XAxis
                   dataKey="date"
@@ -72,19 +170,10 @@ function WeightGraphModal({ variation, onClose }) {
                   width={48}
                   tickFormatter={v => `${v}`}
                 />
-                <Tooltip
-                  contentStyle={{
-                    backgroundColor: '#282B28',
-                    border: '1px solid #575757',
-                    borderRadius: '8px',
-                    color: '#EBEDE9',
-                    fontFamily: 'Sarabun, sans-serif',
-                  }}
-                  formatter={(value) => [`${value} lbs`, 'Weight']}
-                />
+                <Tooltip content={<GraphTooltip isEst1RM={isEst1RM} />} />
                 <Line
                   type="monotone"
-                  dataKey="weight"
+                  dataKey="value"
                   stroke="#70EB70"
                   strokeWidth={2}
                   dot={{ fill: '#70EB70', r: 4 }}

--- a/client/src/styles/WeightGraphModal.module.scss
+++ b/client/src/styles/WeightGraphModal.module.scss
@@ -59,8 +59,69 @@
   }
 }
 
+.toggle {
+  display: flex;
+  align-self: flex-start;
+  background-color: $surface;
+  border: 1px solid $surface-border;
+  border-radius: $border-radius;
+  padding: 3px;
+  gap: 3px;
+
+  @media (max-width: $mobile-width) {
+    align-self: stretch;
+  }
+}
+
+.toggleOption {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: $text;
+  font-family: $sarabun;
+  font-size: 13px;
+  letter-spacing: $sarabun-spacing;
+  border-radius: calc(#{$border-radius} - 4px);
+  padding: 8px 14px;
+  // Tappable on mobile
+  min-height: 36px;
+  opacity: 0.65;
+  transition: background-color 0.15s ease, color 0.15s ease, opacity 0.15s ease;
+
+  @media (max-width: $mobile-width) {
+    flex: 1;
+  }
+
+  &:hover {
+    opacity: 0.9;
+  }
+}
+
+.toggleOptionActive {
+  background-color: $primary-translucent;
+  color: $primary;
+  opacity: 1;
+
+  &:hover {
+    opacity: 1;
+  }
+}
+
 .chartWrap {
   position: relative;
+
+  // recharts writes fontFamily as an SVG presentation attribute on <text>
+  // nodes; the global `* { font: inherit }` rule in index.css beats that
+  // attribute, so it must be re-asserted here as a real stylesheet rule.
+  :global(text) {
+    font-family: $sarabun;
+  }
+}
+
+// Tooltip content is portaled outside .chartWrap by recharts, so it needs
+// its own global rule rather than relying on the wrapper above.
+:global(.recharts-tooltip-wrapper) {
+  font-family: $sarabun;
 }
 
 .yLabel {

--- a/routes/variations.ts
+++ b/routes/variations.ts
@@ -207,7 +207,7 @@ router.get('/history/:variationId', async (req, res): Promise<any> => {
         }
 
         [data] = await pool.query<RowDataPacket[]>(`
-            SELECT weight, date
+            SELECT weight, reps, date
             FROM variation_history
             WHERE variation_id = ?
             ORDER BY date ASC
@@ -265,22 +265,34 @@ router.patch('/:variationId', async (req, res): Promise<any> => {
         return res.status(404).json({ message: `No variation with id ${variationId}` });
     }
 
-    if ('weight' in req.body && req.body.weight != null) {
+    if ('weight' in req.body || 'reps' in req.body) {
         const historyDate = req.body.date ?? new Date();
         try {
             await withTransaction(async (conn) => {
+                const [[current]] = await conn.query<RowDataPacket[]>(`
+                    SELECT weight, reps FROM variations
+                    WHERE variation_id = ?
+                `, [variationId]);
+                if (!current || current.weight == null) {
+                    // A history point needs a weight to be plottable.
+                    return;
+                }
+
                 const [latestHistory] = await conn.query<RowDataPacket[]>(`
-                    SELECT weight FROM variation_history
+                    SELECT weight, reps FROM variation_history
                     WHERE variation_id = ?
                     ORDER BY date DESC, history_id DESC
                     LIMIT 1
                 `, [variationId]);
-                const latestWeight = latestHistory.length > 0 ? latestHistory[0].weight : null;
-                if (latestWeight === null || latestWeight !== req.body.weight) {
+                const latest = latestHistory.length > 0 ? latestHistory[0] : null;
+                const repsEqual = (latest?.reps ?? null) === (current.reps ?? null);
+                const weightEqual = latest !== null && latest.weight === current.weight;
+                const unchanged = latest !== null && weightEqual && repsEqual;
+                if (!unchanged) {
                     await conn.query<ResultSetHeader>(`
-                        INSERT INTO variation_history (variation_id, weight, date)
-                        VALUES (?, ?, ?)
-                    `, [variationId, req.body.weight, historyDate]);
+                        INSERT INTO variation_history (variation_id, weight, reps, date)
+                        VALUES (?, ?, ?, ?)
+                    `, [variationId, current.weight, current.reps ?? null, historyDate]);
                 }
             });
         } catch (_) {


### PR DESCRIPTION
## Summary
- **#209** — Recharts writes `fontFamily` as an SVG presentation attribute on axis `<text>` nodes, which the global `* { font: inherit }` rule in `index.css` beats. Added a scoped rule in `WeightGraphModal.module.scss` targeting descendant `text` (and `.recharts-tooltip-wrapper`) to re-assert Sarabun. Verified in-browser: axis tick labels now compute to `Sarabun, sans-serif`. The `BodyWeightTracker` chart was checked too — its `LineChart` already carries an inline `style={{ fontFamily: ... }}`, which beats the stylesheet rule, and it renders correctly already, so `BodyWeightTracker.module.scss` was left untouched.
- **#208** — Reps were never actually recorded in `variation_history`. Fixed three bugs in `routes/variations.ts`: the `GET /history/:variationId` query now selects `reps`; the history `INSERT` now writes `reps`; and the logging gate now fires on a weight-only *or* reps-only edit (previously a reps-only edit like 185×5 → 185×8 wrote no history row at all). The dedupe check now re-reads the variation's current `(weight, reps)` pair and compares it against the latest history row, treating `NULL` vs `NULL` as equal.
- Added an `Est. 1RM` / `Weight` segmented toggle to `WeightGraphModal.jsx`, defaulting to Est. 1RM (Epley formula, rounded; falls back to plain weight when reps is null/0). Toggle state is one global `localStorage` flag (`variationGraphMetric`) shared by every variation graph, wrapped in try/catch. Tooltip shows a computed est. 1RM row plus the underlying set (e.g. `169 lbs (est. 1RM)` / `145 lbs × 5`); Weight mode reproduces the original chart/tooltip exactly.

## Test plan
- [x] `npm run build` (tsc) — passes
- [x] `cd client && npm run build` (vite) — passes
- [x] Ran the full app locally (docker-compose MySQL + nodemon + vite) and drove it with Playwright:
  - Confirmed axis text `getComputedStyle(...).fontFamily` is `Sarabun, sans-serif` on the variation graph and on the body-weight tracker chart
  - PATCHed a variation weight-only, then reps-only, then both — confirmed via `GET /history/:id` that a reps-only change now produces a new history row with the updated reps
  - Opened the graph modal: Est. 1RM tooltip showed `169 lbs (est. 1RM)` / `145 lbs × 5` for a 145×5 point (145 × (1 + 5/30) = 169.2 → 169), toggled to Weight and confirmed it reproduced the old raw-weight chart/tooltip
  - Confirmed the toggle choice is global: switching one variation's graph to Weight and opening a different variation's graph also showed Weight
  - Checked the toggle at 320px width — full-width segmented control, no overflow

Closes #209
Closes #208