### PR TITLE
Add notes section to each variation

### DIFF
--- a/client/src/components/Icons.jsx
+++ b/client/src/components/Icons.jsx
@@ -13,6 +13,7 @@ import {
   Hash,
   BarChart3,
   Dumbbell as DumbbellIcon,
+  NotebookPen,
 } from 'lucide-react';
 
 export function Calender({ className }) {
@@ -49,4 +50,8 @@ export function Chart({ className }) {
 
 export function Dumbbell({ className, ...props }) {
   return <DumbbellIcon className={className} {...props} size={16} />;
+}
+
+export function Notes({ className }) {
+  return <NotebookPen className={className} size={16} />;
 }

--- a/client/src/components/VariationNotesModal.jsx
+++ b/client/src/components/VariationNotesModal.jsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import Modal from './Modal.jsx';
+import styles from '../styles/VariationNotesModal.module.scss';
+
+/**
+ * VariationNotesModal — free-text notes editor for a variation.
+ * Mirrors the shape of WeightGraphModal: same Modal wrapper, same
+ * header-with-title-and-close pattern. Autosaves on blur, no Save button.
+ *
+ * Props:
+ *   variation {object}   — must have .id and .label
+ *   notes     {string}   — current notes value (may be empty/null)
+ *   onSave    {fn}       — async (notes: string) => void, called on blur when changed
+ *   onClose   {fn}       — called to close the modal
+ */
+function VariationNotesModal({ variation, notes, onSave, onClose }) {
+  const [value, setValue] = useState(notes ?? '');
+
+  function handleBlur() {
+    const trimmed = value;
+    if (trimmed === (notes ?? '')) return;
+    onSave(trimmed);
+  }
+
+  return (
+    <Modal
+      open={true}
+      onOpenChange={(isOpen) => { if (!isOpen) onClose(); }}
+      title={variation.label || 'Variation'}
+      showTitle={false}
+      contentClassName={styles.modalContent}
+    >
+      <div className={styles.modal}>
+        <div className={styles.header}>
+          <span className={styles.title}>{variation.label || 'Variation'}</span>
+          <button className={styles.close} onClick={onClose} aria-label="Close">✕</button>
+        </div>
+
+        <textarea
+          className={styles.textarea}
+          value={value}
+          onChange={e => setValue(e.target.value)}
+          onBlur={handleBlur}
+          placeholder="Bar weight, machine settings, form cues..."
+          maxLength={2000}
+          autoFocus
+        />
+      </div>
+    </Modal>
+  );
+}
+
+export default VariationNotesModal;

--- a/client/src/components/VariationNotesModal.jsx
+++ b/client/src/components/VariationNotesModal.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import Modal from './Modal.jsx';
 import styles from '../styles/VariationNotesModal.module.scss';
 
@@ -7,25 +7,51 @@ import styles from '../styles/VariationNotesModal.module.scss';
  * Mirrors the shape of WeightGraphModal: same Modal wrapper, same
  * header-with-title-and-close pattern. Autosaves on blur, no Save button.
  *
+ * Radix Dialog closes on Escape and overlay click without ever blurring the
+ * textarea (no mousedown moves focus first), so `onBlur` alone misses those
+ * paths and would silently discard the edit. Every close path — blur, the
+ * close button, overlay click, and Escape — funnels through `flush()`,
+ * which reads the latest typed value from a ref (avoiding stale closures)
+ * and no-ops if it already matches what was last saved (avoiding duplicate
+ * PATCHes when e.g. blur fires immediately before a close handler).
+ *
  * Props:
  *   variation {object}   — must have .id and .label
  *   notes     {string}   — current notes value (may be empty/null)
- *   onSave    {fn}       — async (notes: string) => void, called on blur when changed
+ *   onSave    {fn}       — async (notes: string) => void, called when the value changed
  *   onClose   {fn}       — called to close the modal
  */
 function VariationNotesModal({ variation, notes, onSave, onClose }) {
-  const [value, setValue] = useState(notes ?? '');
+  const initial = notes ?? '';
+  const [value, setValue] = useState(initial);
+  const valueRef = useRef(initial);
+  const savedRef = useRef(initial);
 
-  function handleBlur() {
-    const trimmed = value;
-    if (trimmed === (notes ?? '')) return;
-    onSave(trimmed);
+  function handleChange(e) {
+    const next = e.target.value;
+    setValue(next);
+    valueRef.current = next;
+  }
+
+  function flush() {
+    const current = valueRef.current;
+    if (current === savedRef.current) return;
+    // Update synchronously, before the (async) save resolves, so a second
+    // close signal (e.g. blur followed by the close button's own handler)
+    // sees it as already-saved and no-ops instead of firing a second PATCH.
+    savedRef.current = current;
+    onSave(current);
+  }
+
+  function handleClose() {
+    flush();
+    onClose();
   }
 
   return (
     <Modal
       open={true}
-      onOpenChange={(isOpen) => { if (!isOpen) onClose(); }}
+      onOpenChange={(isOpen) => { if (!isOpen) handleClose(); }}
       title={variation.label || 'Variation'}
       showTitle={false}
       contentClassName={styles.modalContent}
@@ -33,14 +59,14 @@ function VariationNotesModal({ variation, notes, onSave, onClose }) {
       <div className={styles.modal}>
         <div className={styles.header}>
           <span className={styles.title}>{variation.label || 'Variation'}</span>
-          <button className={styles.close} onClick={onClose} aria-label="Close">✕</button>
+          <button className={styles.close} onClick={handleClose} aria-label="Close">✕</button>
         </div>
 
         <textarea
           className={styles.textarea}
           value={value}
-          onChange={e => setValue(e.target.value)}
-          onBlur={handleBlur}
+          onChange={handleChange}
+          onBlur={flush}
           placeholder="Bar weight, machine settings, form cues..."
           maxLength={2000}
           autoFocus

--- a/client/src/components/variation/ThinVariation.jsx
+++ b/client/src/components/variation/ThinVariation.jsx
@@ -1,10 +1,10 @@
 import Editable from "../Editable";
 import styles from "../../styles/Variation.module.scss";
 import mobileStyles from "../../styles/ThinVariation.module.scss";
-import { Dumbbell, Number, Delete, Chart } from "../Icons";
+import { Dumbbell, Number, Delete, Chart, Notes } from "../Icons";
 import DateInput from "../DateInput";
 
-function ThinVariation({ variation, details, handleLabelEdit, handleDetailEdit, handleRemove, showRemove, removeAllowed, onGraphOpen }) {
+function ThinVariation({ variation, details, handleLabelEdit, handleDetailEdit, handleRemove, showRemove, removeAllowed, onGraphOpen, onNotesOpen, hasNotes }) {
   return (
     <div className={mobileStyles.variation}>
       <section>
@@ -23,6 +23,14 @@ function ThinVariation({ variation, details, handleLabelEdit, handleDetailEdit, 
 
         {/* graph + remove grouped for consistent right-alignment */}
         <div className={mobileStyles.rightGroup}>
+          <button
+            className={`${styles.notesBtn} ${hasNotes ? styles.notesBtnActive : ''}`}
+            onClick={onNotesOpen}
+            aria-label="Notes"
+          >
+            <Notes className={styles.icon} />
+          </button>
+
           <button className={styles.graphBtn} onClick={onGraphOpen}>
             <Chart className={styles.icon} />
           </button>

--- a/client/src/components/variation/Variation.jsx
+++ b/client/src/components/variation/Variation.jsx
@@ -6,6 +6,7 @@ import ThinVariation from './ThinVariation.jsx';
 import WideVariation from './WideVariation.jsx';
 import ConfirmModal from '../ConfirmModal.jsx';
 import WeightGraphModal from '../WeightGraphModal.jsx';
+import VariationNotesModal from '../VariationNotesModal.jsx';
 
 function Variation({ variation, setVariations, removeAllowed }) {
   const { isMobile } = useIsMobile();
@@ -13,6 +14,7 @@ function Variation({ variation, setVariations, removeAllowed }) {
   const [showRemove, setShowRemove] = useState(isMobile);
   const [showConfirm, setShowConfirm] = useState(false);
   const [showGraph, setShowGraph] = useState(false);
+  const [showNotes, setShowNotes] = useState(false);
   const { withAuth } = useAuth();
 
   useEffect(() => {
@@ -92,7 +94,22 @@ function Variation({ variation, setVariations, removeAllowed }) {
     ))
   }
 
-  const props = { variation, details, handleLabelEdit, handleDetailEdit, handleRemove: handleRemoveClick, showRemove, setShowRemove, removeAllowed, onGraphOpen: () => setShowGraph(true) }
+  async function handleNotesEdit(change) {
+    // Note edits don't bump `date` — date reflects when the lift was last
+    // updated, and a note edit isn't a PR update.
+    setVariations(prevVariations => (
+      prevVariations.map(v => (
+        v.id === variation.id
+          ? { ...v, notes: change }
+          : v
+      ))
+    ));
+    await withAuth(() => (
+      clientApi.patch(`/variations/${variation.id}`, { notes: change })
+    ))
+  }
+
+  const props = { variation, details, handleLabelEdit, handleDetailEdit, handleRemove: handleRemoveClick, showRemove, setShowRemove, removeAllowed, onGraphOpen: () => setShowGraph(true), onNotesOpen: () => setShowNotes(true), hasNotes: !!(variation.notes && variation.notes.trim()) }
   return (
     <>
       {showConfirm && (
@@ -106,6 +123,14 @@ function Variation({ variation, setVariations, removeAllowed }) {
         <WeightGraphModal
           variation={variation}
           onClose={() => setShowGraph(false)}
+        />
+      )}
+      {showNotes && (
+        <VariationNotesModal
+          variation={variation}
+          notes={variation.notes}
+          onSave={handleNotesEdit}
+          onClose={() => setShowNotes(false)}
         />
       )}
       {isMobile

--- a/client/src/components/variation/WideVariation.jsx
+++ b/client/src/components/variation/WideVariation.jsx
@@ -1,9 +1,9 @@
 import Editable from "../Editable";
 import styles from "../../styles/Variation.module.scss";
-import { Dumbbell, Number, Delete, Chart } from "../Icons";
+import { Dumbbell, Number, Delete, Chart, Notes } from "../Icons";
 import DateInput from "../DateInput";
 
-function WideVariation({ variation, details, handleLabelEdit, handleDetailEdit, handleRemove, showRemove, setShowRemove, removeAllowed, onGraphOpen }) {
+function WideVariation({ variation, details, handleLabelEdit, handleDetailEdit, handleRemove, showRemove, setShowRemove, removeAllowed, onGraphOpen, onNotesOpen, hasNotes }) {
   const hoverProps = {
     onMouseEnter: () => setShowRemove(true),
     onMouseLeave: () => setShowRemove(false)
@@ -51,6 +51,14 @@ function WideVariation({ variation, details, handleLabelEdit, handleDetailEdit, 
 
       {/* graph + remove grouped for right-alignment */}
       <div className={styles.rightGroup} {...hoverProps}>
+        <button
+          className={`${styles.notesBtn} ${hasNotes ? styles.notesBtnActive : ''}`}
+          onClick={onNotesOpen}
+          aria-label="Notes"
+        >
+          <Notes className={styles.icon} />
+        </button>
+
         <button className={styles.graphBtn} onClick={onGraphOpen}>
           <Chart className={styles.icon} />
         </button>

--- a/client/src/styles/Variation.module.scss
+++ b/client/src/styles/Variation.module.scss
@@ -117,6 +117,35 @@
   }
 }
 
+.notesBtn {
+  display: flex;
+  width: 40px;
+  height: 40px;
+  align-items: center;
+  justify-content: center;
+  background-color: transparent;
+  border: none;
+  border-radius: 100px;
+  cursor: pointer;
+  color: $primary;
+  opacity: 0.55;
+
+  &:hover {
+    background-color: $primary-translucent;
+    opacity: 0.85;
+  }
+
+  .icon {
+    padding-right: 0px;
+  }
+}
+
+// Subtle visual hint that notes already exist for this variation.
+.notesBtnActive {
+  opacity: 1;
+  background-color: $primary-translucent;
+}
+
 .rightGroup {
   display: flex;
   align-items: center;

--- a/client/src/styles/VariationNotesModal.module.scss
+++ b/client/src/styles/VariationNotesModal.module.scss
@@ -1,0 +1,88 @@
+@import "variables";
+
+// Sizing override applied to Radix Dialog.Content for this panel.
+// Passed as contentClassName={styles.modalContent} from VariationNotesModal.jsx.
+.modalContent {
+  max-width: 480px;
+}
+
+// Panel inner wrapper
+.modal {
+  padding: 28px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+
+  @media (max-width: $mobile-width) {
+    padding: 20px 16px;
+  }
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.title {
+  color: $text;
+  font-family: $sarabun;
+  font-size: 20px;
+  font-weight: 400;
+  letter-spacing: $sarabun-spacing;
+  font-style: italic;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.close {
+  background: transparent;
+  border: none;
+  color: $text;
+  font-size: 18px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 8px;
+  line-height: 1;
+  flex-shrink: 0;
+  // Tappable on mobile
+  min-width: 44px;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    background-color: $primary-translucent;
+  }
+}
+
+.textarea {
+  width: 100%;
+  min-height: 160px;
+  resize: vertical;
+  box-sizing: border-box;
+  background-color: $surface;
+  border: 1px solid $surface-border;
+  border-radius: $border-radius;
+  color: $text;
+  font-family: $sarabun;
+  letter-spacing: $sarabun-spacing;
+  padding: 12px 14px;
+  // font-size is intentionally left unset below 885px so the global
+  // `max(16px, 1em) !important` rule in index.css (anti-iOS-zoom) wins.
+  font-size: 15px;
+  line-height: 1.5;
+
+  &:focus {
+    outline: none;
+    border-color: $primary-border;
+  }
+
+  &::placeholder {
+    color: $text;
+    opacity: 0.45;
+  }
+}

--- a/migrations/016_variation_notes.sql
+++ b/migrations/016_variation_notes.sql
@@ -1,0 +1,1 @@
+ALTER TABLE variations ADD COLUMN notes TEXT NULL;

--- a/routes/variations.ts
+++ b/routes/variations.ts
@@ -108,7 +108,7 @@ router.get('/movements', async (req, res): Promise<any> => {
         }
 
         [rows] = await pool.query<RowDataPacket[]>(`
-            SELECT movement_id, variation_id as id, label, weight, reps, date
+            SELECT movement_id, variation_id as id, label, weight, reps, date, notes
             FROM variations
             WHERE movement_id IN (?)
         `, [ids])
@@ -149,7 +149,7 @@ router.get('/movement/:movementId', async (req, res): Promise<any> => {
 
     try {
         [data] = await pool.query<RowDataPacket[]>(`
-            SELECT variation_id as id, label, weight, reps, date
+            SELECT variation_id as id, label, weight, reps, date, notes
             FROM variations
             WHERE movement_id = ?
         `, [movementId])
@@ -173,7 +173,7 @@ router.get('/variation/:variationId', async (req, res): Promise<any> => {
     let data: RowDataPacket;
     try {
         [[data]] = await pool.query<RowDataPacket[]>(`
-            SELECT v.variation_id as id, v.label, v.weight, v.reps, v.date
+            SELECT v.variation_id as id, v.label, v.weight, v.reps, v.date, v.notes
             FROM variations v
             JOIN movements m ON m.movement_id = v.movement_id
             JOIN sections s ON s.section_id = m.section_id
@@ -228,7 +228,7 @@ router.patch('/:variationId', async (req, res): Promise<any> => {
     const variationId: string = req.params.variationId;
     if (!validateId(variationId, res)) return;
 
-    const allowedFields = ['label', 'weight', 'reps', 'date'];
+    const allowedFields = ['label', 'weight', 'reps', 'date', 'notes'];
     const invalidFields = Object.keys(req.body).filter(key => !allowedFields.includes(key));
     if (invalidFields.length > 0) {
         return res.status(400).json({

--- a/utils/validation.ts
+++ b/utils/validation.ts
@@ -69,7 +69,7 @@ function validateVariation(body: any, res?: Response) {
         return false;
     }
     
-    const { label, weight, reps, date } = body;
+    const { label, weight, reps, date, notes } = body;
     if (label !== undefined && !validateLabel(label, res)) {
         return false;
     }
@@ -85,6 +85,14 @@ function validateVariation(body: any, res?: Response) {
     }
     if (date !== undefined && !isValidISO(date)) {
         message += "Date field must be a ISO 8601 formatted date string\n";
+        valid = false;
+    }
+    if (notes !== undefined && notes !== null && typeof notes !== 'string') {
+        message += "Notes must be a string\n";
+        valid = false;
+    }
+    if (typeof notes === 'string' && notes.length > 2000) {
+        message += "Notes must not exceed 2000 characters\n";
         valid = false;
     }
     if (!valid) res?.status(400).json({ message });


### PR DESCRIPTION
## Summary
- Adds a `notes` TEXT column to `variations` (migration 016).
- `routes/variations.ts`: `notes` is now readable via all three GET paths (batched `/movements`, `/movement/:movementId`, `/variation/:variationId`) and writable via PATCH (`allowedFields`). POST is left unchanged — new variations start with empty notes.
- `utils/validation.ts`: `validateVariation` now validates `notes` (string, `null` to clear, max 2000 chars).
- Client: a new "Notes" button sits next to the graph button on every variation (mobile `ThinVariation` and desktop `WideVariation`), always visible. It opens `VariationNotesModal`, styled and structured after `WeightGraphModal` (same `Modal` wrapper, header/close pattern). The textarea autosaves on blur (no Save button), shows a placeholder ("Bar weight, machine settings, form cues...") when empty, and skips the PATCH if the text is unchanged. The button gets a subtle accented/filled state when notes exist.
- A notes-only edit intentionally does **not** bump the variation's `date` and does **not** write a `variation_history` row (verified — the history block is still gated on `'weight' in req.body || 'reps' in req.body`).

## Test plan
- [x] `npm run build` (tsc) passes
- [x] `cd client && npm run build` (vite) passes
- [x] Ran the app locally (docker-compose MySQL + migration 016 applied by hand + built server), logged in as `dev@dev.com`
- [x] Verified via curl: PATCH with `{ notes }` updates notes without touching `date` and without adding a `variation_history` row; validation rejects non-string/>2000-char notes; `null` clears notes
- [x] Verified in-browser (Playwright): notes button appears on every variation in both mobile and desktop layouts, modal opens, text autosaves on blur, persists across close/reopen and a full page reload, empty state shows placeholder, active button state reflects presence of notes
- [x] Checked no horizontal overflow at 320px viewport width with realistic labels
- [x] Cleaned up test data (section/movement/variations) and ran `docker compose down`

Closes #207