### PR TITLE
Feedback modal: persist draft, add UI category, add tool/tab select

### DIFF
--- a/client/src/features/nutrition/FeedbackModal.tsx
+++ b/client/src/features/nutrition/FeedbackModal.tsx
@@ -1,14 +1,24 @@
 /**
  * FeedbackModal — item #1.
  * A small Radix Dialog + react-hook-form that lets users send feedback.
- * Category: bug / idea / other. Message: textarea.
+ * Category: bug / idea / UI / other. Tool: which tab the feedback concerns
+ * (defaults to the tab the user is currently on). Message: textarea.
  * On submit: calls submitFeedback() from api.ts.
  * Shows a brief thank-you state, then auto-closes after 2s.
+ *
+ * #218: the modal is mounted globally (Header.jsx) and stays mounted across
+ * open/close, so a Cancel/backdrop/Esc close must NOT clear the in-progress
+ * draft — react-hook-form's `reset()` is only called after a *successful*
+ * submit. The draft is plain React state (via react-hook-form's internal
+ * state), so it survives close/reopen within the page session but starts
+ * clean on a full reload — no localStorage involved, per product decision.
  */
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { useSearchParams } from 'react-router-dom';
 import Modal from '../../components/Modal.jsx';
 import { submitFeedback } from './api';
+import { TABS, TAB_LABELS, DEFAULT_ORDER, VALID_TABS } from '../../config/tabs';
 import styles from './FeedbackModal.module.scss';
 
 interface FeedbackModalProps {
@@ -16,10 +26,15 @@ interface FeedbackModalProps {
   onClose: () => void;
 }
 
-type FeedbackCategory = 'bug' | 'idea' | 'other';
+type FeedbackCategory = 'bug' | 'idea' | 'ui' | 'other';
+
+// #215: "which tab/tool" the feedback is about — the four app tabs plus a
+// catch-all for feedback that isn't tied to a specific tab.
+const OTHER_TOOL = 'other';
 
 interface FeedbackForm {
   category: FeedbackCategory;
+  tool: string;
   message: string;
 }
 
@@ -27,17 +42,42 @@ export default function FeedbackModal({ open, onClose }: FeedbackModalProps) {
   const [submitted, setSubmitted] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
+  // #215: default the "tool" field to the tab the user is currently on —
+  // read the same way NavDrawer.jsx does (URL `tab` search param, falling
+  // back to Workouts). Imported from the shared config, not duplicated.
+  const [searchParams] = useSearchParams();
+  const tabParam = searchParams.get('tab');
+  const currentTab = VALID_TABS.has(tabParam) ? tabParam : TABS.WORKOUTS;
+
   const {
     register,
     handleSubmit,
     reset,
+    setValue,
+    getValues,
     formState: { errors, isSubmitting },
   } = useForm<FeedbackForm>({
-    defaultValues: { category: 'idea', message: '' },
+    defaultValues: { category: 'idea', tool: currentTab, message: '' },
   });
 
+  // Since this modal stays mounted app-wide (see header comment), the user
+  // can navigate tabs while it's closed. Keep "tool" following the active
+  // tab in that case — but only while it still holds the last tab we
+  // defaulted it to. Once the user picks a tool themselves, their choice
+  // (part of the draft #218 preserves) is left alone.
+  const lastDefaultTool = useRef(currentTab);
+  useEffect(() => {
+    if (getValues('tool') === lastDefaultTool.current) {
+      setValue('tool', currentTab);
+    }
+    lastDefaultTool.current = currentTab;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentTab]);
+
+  // #218: close (Cancel / backdrop / Esc) leaves the draft untouched — only
+  // the transient success/error UI state is reset. `reset()` is reserved for
+  // the post-submit path below.
   function handleClose() {
-    reset();
     setSubmitted(false);
     setSubmitError(null);
     onClose();
@@ -46,10 +86,11 @@ export default function FeedbackModal({ open, onClose }: FeedbackModalProps) {
   async function onSubmit(data: FeedbackForm) {
     setSubmitError(null);
     try {
-      await submitFeedback({ category: data.category, message: data.message });
+      await submitFeedback({ category: data.category, tool: data.tool, message: data.message });
       setSubmitted(true);
-      // Auto-close after 2s
+      // Auto-close after 2s, clearing the draft since submission succeeded
       setTimeout(() => {
+        reset({ category: 'idea', tool: currentTab, message: '' });
         handleClose();
       }, 2000);
     } catch (err: unknown) {
@@ -89,7 +130,27 @@ export default function FeedbackModal({ open, onClose }: FeedbackModalProps) {
               >
                 <option value="bug">Bug report</option>
                 <option value="idea">Feature idea</option>
+                <option value="ui">UI</option>
                 <option value="other">Other</option>
+              </select>
+            </div>
+
+            {/* #215: Tool/tab select — required, defaults to the current tab */}
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="fb-tool">
+                Tool
+              </label>
+              <select
+                id="fb-tool"
+                className={styles.select}
+                {...register('tool', { required: true })}
+              >
+                {DEFAULT_ORDER.map((tab) => (
+                  <option key={tab} value={tab}>
+                    {TAB_LABELS[tab]}
+                  </option>
+                ))}
+                <option value={OTHER_TOOL}>Other / N/A</option>
               </select>
             </div>
 

--- a/client/src/features/nutrition/api.ts
+++ b/client/src/features/nutrition/api.ts
@@ -260,7 +260,8 @@ export async function saveResolution(
 // GITHUB_TOKEN is configured, else stores in a feedback table. App-level, not
 // nutrition-scoped, but lives here since the feedback UI ships with this batch.
 export async function submitFeedback(input: {
-  category?: 'bug' | 'idea' | 'other';
+  category?: 'bug' | 'idea' | 'ui' | 'other';
+  tool?: string;
   message: string;
 }): Promise<void> {
   await clientApi.post('/feedback', input);

--- a/migrations/017_feedback_tool.sql
+++ b/migrations/017_feedback_tool.sql
@@ -1,0 +1,4 @@
+-- #215: track which tab/tool the feedback is about.
+-- migrate.js tolerates duplicate-column error 1060 so re-runs are safe.
+
+ALTER TABLE feedback ADD COLUMN tool VARCHAR(32) NULL AFTER category;

--- a/routes/feedback.ts
+++ b/routes/feedback.ts
@@ -9,7 +9,10 @@ const router = Router();
 router.use(authenticateToken);
 
 const feedbackSchema = z.object({
-  category: z.enum(['bug', 'idea', 'other']).optional(),
+  category: z.enum(['bug', 'idea', 'ui', 'other']).optional(),
+  // #215: which tab/tool the feedback concerns. Free-form-ish but constrained
+  // to the client's known values (the four tabs, or 'other').
+  tool: z.string().min(1).max(32).optional(),
   message: z.string().min(1).max(4000),
 });
 
@@ -32,10 +35,12 @@ async function createGithubIssue(
     const repo = getGithubRepo();
     const excerpt = body.message.slice(0, 60).replace(/\n/g, ' ');
     const categoryLabel = body.category ?? 'other';
-    const title = `[${categoryLabel}] ${excerpt}${body.message.length > 60 ? '...' : ''}`;
+    const tool = body.tool ?? 'other';
+    const title = `[${categoryLabel}][${tool}] ${excerpt}${body.message.length > 60 ? '...' : ''}`;
 
     const issueBody =
       `**Category:** ${categoryLabel}\n` +
+      `**Tool:** ${tool}\n` +
       `**Submitted by:** ${submitterEmail}\n\n` +
       `---\n\n${body.message}`;
 
@@ -70,13 +75,13 @@ router.post('/', async (req, res): Promise<any> => {
       .json({ message: parsed.error.issues[0]?.message ?? 'Invalid request body' });
   }
 
-  const { category, message } = parsed.data;
+  const { category, tool, message } = parsed.data;
 
   // Always insert into the DB (record + fallback)
   try {
     await pool.query<ResultSetHeader>(
-      `INSERT INTO feedback (user_uuid, category, message) VALUES (UUID_TO_BIN(?), ?, ?)`,
-      [uuid, category ?? null, message],
+      `INSERT INTO feedback (user_uuid, category, tool, message) VALUES (UUID_TO_BIN(?), ?, ?, ?)`,
+      [uuid, category ?? null, tool ?? null, message],
     );
   } catch (err) {
     console.error('[feedback] DB insert failed:', err);


### PR DESCRIPTION
## Summary
- Persist the feedback draft across Cancel/backdrop/Esc close-and-reopen within the same page session (plain React state via react-hook-form — no localStorage). A full page reload still starts clean. The draft is cleared only after a successful submit.
- Add a "UI" option to the feedback category dropdown; server zod enum and client `submitFeedback()` signature widened to accept `'ui'`.
- Add a required "Tool" dropdown (the four app tabs + "Other / N/A"), defaulting to the tab the user is currently on (read from the URL `tab` param the same way `NavDrawer.jsx` does, importing from `client/src/config/tabs.js`). Surfaces on the created GitHub issue as a `[category][tool]` title prefix and a `**Tool:**` body line, and persists to a new nullable `tool VARCHAR(32)` column via `migrations/017_feedback_tool.sql`.

Closes #214
Closes #215
Closes #218

## Test plan
- [x] `npm run build` (root tsc) passes
- [x] `cd client && npm run build` (vite) passes
- [x] Manual browser verification against a local docker/vite/express dev stack: category select includes UI, tool select includes the 4 tabs + Other/N/A and defaults to the URL's `tab` param, Cancel-then-reopen preserves the typed draft (category/tool/message), successful submit shows the thank-you state, auto-closes after 2s, clears the draft, and persists the row (`category`, `tool`, `message`) to MySQL. No console errors observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)