### PR TITLE
Fix notes icon opacity and est. 1RM chart tooltip for same-day points

### DIFF
--- a/client/src/components/WeightGraphModal.jsx
+++ b/client/src/components/WeightGraphModal.jsx
@@ -86,11 +86,16 @@ function WeightGraphModal({ variation, onClose }) {
     queryKey: ['variationHistory', variation.id],
     queryFn: async () => {
       const res = await clientApi.get(`/variations/history/${variation.id}`);
-      return res.data.data.map(entry => ({
+      return res.data.data.map((entry, index) => ({
         weight: entry.weight,
         reps: entry.reps,
         date: format(new Date(entry.date), 'MMM d'),
-        rawDate: new Date(entry.date).getTime()
+        rawDate: new Date(entry.date).getTime(),
+        // #220: row index in the (server-sorted, chronological) history array.
+        // Used as the X-axis key below since it's guaranteed unique per point,
+        // unlike the formatted `date` day-label which repeats when several
+        // history rows land on the same calendar day.
+        index,
       }));
     },
     enabled: !!user,
@@ -118,6 +123,22 @@ function WeightGraphModal({ variation, onClose }) {
   const range = dataMax - dataMin;
   const padding = range > 0 ? range * 0.15 : Math.max(dataMax * 0.1, 5);
   const yDomain = [Math.max(0, Math.floor(dataMin - padding)), Math.ceil(dataMax + padding)];
+
+  // #220: several history rows can land on the same calendar day (e.g. two
+  // weight edits in one session). Recharts treats XAxis dataKey values as a
+  // category axis by default, and every point sharing a category collapses
+  // onto one x position — hovering any of them then always resolves to the
+  // FIRST matching datum, so same-day points all reported that point's
+  // value/reps in the tooltip even though the plotted line moved correctly.
+  // Fix: key the axis on `index` (unique per row, guaranteed by construction
+  // above) instead of the formatted day string, and dedupe the *visible*
+  // ticks down to one per day (first point of the day) via tickFormatter +
+  // explicit `ticks` so the axis doesn't fill up with repeated day labels.
+  const dayTicks = chartData.reduce((ticks, point, i) => {
+    if (i === 0 || point.date !== chartData[i - 1].date) ticks.push(point.index);
+    return ticks;
+  }, []);
+  const formatDayTick = (index) => chartData[index]?.date ?? '';
 
   return (
     <Modal
@@ -168,7 +189,12 @@ function WeightGraphModal({ variation, onClose }) {
               <LineChart data={chartData} margin={{ top: 10, right: 16, left: 0, bottom: 0 }}>
                 <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.08)" />
                 <XAxis
-                  dataKey="date"
+                  dataKey="index"
+                  type="number"
+                  domain={['dataMin', 'dataMax']}
+                  allowDecimals={false}
+                  ticks={dayTicks}
+                  tickFormatter={formatDayTick}
                   tick={{ fill: '#EBEDE9', fontSize: 12, fontFamily: 'Sarabun, sans-serif' }}
                   axisLine={{ stroke: '#575757' }}
                   tickLine={false}

--- a/client/src/styles/Variation.module.scss
+++ b/client/src/styles/Variation.module.scss
@@ -128,11 +128,9 @@
   border-radius: 100px;
   cursor: pointer;
   color: $primary;
-  opacity: 0.55;
 
   &:hover {
     background-color: $primary-translucent;
-    opacity: 0.85;
   }
 
   .icon {
@@ -140,9 +138,11 @@
   }
 }
 
-// Subtle visual hint that notes already exist for this variation.
+// #212: .notesBtn used to carry its own dimmed opacity, making the notes icon
+// look darker than the adjacent .graphBtn/.delete icons even though all three
+// are the same $primary color. Base opacity is gone now, so .notesBtnActive's
+// highlighted background is the only "this variation has notes" cue.
 .notesBtnActive {
-  opacity: 1;
   background-color: $primary-translucent;
 }
 


### PR DESCRIPTION
## Summary
- Removes the dimmed opacity on `.notesBtn` in `Variation.module.scss` so the notes icon matches the graph/delete icons beside it. `.notesBtnActive`'s highlighted background remains the sole "this variation has notes" indicator.
- Fixes the est. 1RM / weight chart in `WeightGraphModal.jsx`: the X-axis was keyed on the formatted "MMM d" day string, so multiple history rows on the same calendar day collapsed onto one category and the tooltip always reported the first matching point's value for every same-day node. The axis is now keyed on each row's unique index (numeric axis), with visible tick labels deduped to one per day via `tickFormatter` so the axis still reads as human dates without repeated labels.

## Test plan
- [x] `npm run build` (root tsc) passes
- [x] `cd client && npm run build` (vite) passes
- [x] Reasoned through the reporter's exact repro (25×9 → 25×10 → 30×6 on the same day): Epley gives 33, 33, 36 respectively; with the fix each node's tooltip now reads its own value/reps (`25 lbs × 9` / `25 lbs × 10` / `30 lbs × 6`) instead of all three reporting the first point's 33
- [ ] Not verified in a running browser — no dev server was started in this environment

Closes #212
Closes #220