### PR TITLE
Fix multi-barcode-scan override, barcode grounding memory, and preview serif font

### DIFF
--- a/client/src/features/nutrition/BarcodeAttachmentCard.tsx
+++ b/client/src/features/nutrition/BarcodeAttachmentCard.tsx
@@ -65,14 +65,14 @@ export default function BarcodeAttachmentCard({ open, data, onClose }: BarcodeAt
                 }}
               />
             ) : data.imageRedacted ? (
-              <p style={{ fontSize: 12, fontStyle: 'italic', opacity: 0.6, margin: '0 0 12px' }}>
+              <p className={styles.rowHint} style={{ fontStyle: 'italic', marginBottom: 12 }}>
                 Photo no longer available
               </p>
             ) : null}
 
             <div className={styles.nameRow}>
               <div className={styles.nameInputWrap}>
-                <p style={{ fontWeight: 600, margin: 0 }}>{row.name}</p>
+                <p className={styles.readOnlyName}>{row.name}</p>
               </div>
             </div>
 

--- a/client/src/features/nutrition/IngredientSheet.module.scss
+++ b/client/src/features/nutrition/IngredientSheet.module.scss
@@ -171,6 +171,17 @@
   }
 }
 
+// Read-only product name text (BarcodeAttachmentCard) — same typography as
+// .input but for a static <p>, not an editable field.
+.readOnlyName {
+  margin: 0;
+  color: $text;
+  font-family: $sarabun;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: $sarabun-spacing;
+}
+
 // Smaller numeric inputs
 .inputSmall {
   background-color: transparent;

--- a/client/src/features/nutrition/NutritionChat.tsx
+++ b/client/src/features/nutrition/NutritionChat.tsx
@@ -126,8 +126,13 @@ interface PendingPhoto {
 // barcode. `imageDataUrl` is the still-frame screenshot (UI-only thumbnail +
 // tap preview); `product` is the structured Open Food Facts data that gets
 // fed to the agent as a pre-fetched tool-result (see services/nutrition/agent.ts).
+// `id` is a client-generated key (like PendingPhoto's `previewUrl`) so MULTIPLE
+// scans can be pending at once — see #213: this used to be a single object,
+// which meant a second scan silently overwrote the first. It's now a LIST,
+// following the exact same append/remove-by-key pattern as pendingPhotos.
 // ---------------------------------------------------------------------------
 interface PendingBarcode {
+  id: string;
   code: string;
   imageDataUrl?: string;
   product: BarcodeAttachmentData['product'];
@@ -1315,7 +1320,9 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
   const [pendingPhotos, setPendingPhotos] = useState<PendingPhoto[]>([]);
   const [photoError, setPhotoError] = useState<string | null>(null);
   const [barcodeOpen, setBarcodeOpen] = useState(false);
-  const [pendingBarcode, setPendingBarcode] = useState<PendingBarcode | null>(null);
+  // #213: LIST of pending scans (mirrors pendingPhotos), not a single object —
+  // a single-object slot meant a second scan silently overwrote the first.
+  const [pendingBarcodes, setPendingBarcodes] = useState<PendingBarcode[]>([]);
   const [barcodeNotice, setBarcodeNotice] = useState<string | null>(null);
   // Tap-to-preview: holds whichever barcode attachment (pending in composer, or
   // already sent in the transcript) the user tapped. null = no card open.
@@ -1448,7 +1455,9 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
         );
         return;
       }
-      setPendingBarcode({ code, imageDataUrl, product });
+      // #213: APPEND rather than replace, so a second (third, ...) scan adds
+      // another chip instead of overwriting the previous one.
+      setPendingBarcodes(prev => [...prev, { id: crypto.randomUUID(), code, imageDataUrl, product }]);
     } catch {
       setBarcodeNotice(
         `Barcode lookup failed. Describe the item in the chat, or take a photo of the nutrition label instead.`,
@@ -1458,12 +1467,12 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
     }
   }, []);
 
-  const removePendingBarcode = useCallback(() => {
-    setPendingBarcode(null);
+  const removePendingBarcode = useCallback((id: string) => {
+    setPendingBarcodes(prev => prev.filter(b => b.id !== id));
   }, []);
 
   // ---- Send ----
-  const canSend = (text.trim().length > 0 || pendingPhotos.length > 0 || pendingBarcode !== null) && !isStreaming;
+  const canSend = (text.trim().length > 0 || pendingPhotos.length > 0 || pendingBarcodes.length > 0) && !isStreaming;
 
   // Denial tracking: deny no longer auto-sends a message (see
   // handleProposalDeny/handleCustomFoodDeny below). Instead the agent learns
@@ -1496,33 +1505,37 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
     if (deniedProposalCount > 0) setPendingDenialCount(0);
 
     // A barcode-only send (no typed text) still needs SOME text content: the
-    // structured product data travels as a `data-barcodeAttachment` part, which
-    // convertToModelMessages drops from the user turn by design (it's UI-only —
-    // the model instead receives it as a pre-fetched tool-result, see agent.ts).
-    // Without this fallback the user turn could end up with empty content.
-    if (pendingBarcode && !msgText) {
-      msgText = `Log this scanned product: ${pendingBarcode.product.name}`;
+    // structured product data travels as one `data-barcodeAttachment` part PER
+    // scan, which convertToModelMessages drops from the user turn by design
+    // (it's UI-only — the model instead receives it as a pre-fetched
+    // tool-result, see agent.ts). Without this fallback the user turn could
+    // end up with empty content. #213: lists every scanned product, not just
+    // the first, when there's more than one pending.
+    if (pendingBarcodes.length > 0 && !msgText) {
+      const names = pendingBarcodes.map(b => b.product.name).join(', ');
+      msgText = pendingBarcodes.length === 1
+        ? `Log this scanned product: ${names}`
+        : `Log these scanned products: ${names}`;
     }
 
-    const barcodePart = pendingBarcode
-      ? [{
-          type: 'data-barcodeAttachment' as const,
-          data: {
-            code: pendingBarcode.code,
-            imageDataUrl: pendingBarcode.imageDataUrl ?? null,
-            product: pendingBarcode.product,
-          } satisfies BarcodeAttachmentData,
-        }]
-      : [];
+    // #213: one data-barcodeAttachment part per pending scan (was a single part).
+    const barcodeParts = pendingBarcodes.map(b => ({
+      type: 'data-barcodeAttachment' as const,
+      data: {
+        code: b.code,
+        imageDataUrl: b.imageDataUrl ?? null,
+        product: b.product,
+      } satisfies BarcodeAttachmentData,
+    }));
 
     pendingPhotos.forEach(p => URL.revokeObjectURL(p.previewUrl));
     setText('');
     setPendingPhotos([]);
-    setPendingBarcode(null);
+    setPendingBarcodes([]);
 
     const parts = [
       ...files,
-      ...barcodePart,
+      ...barcodeParts,
       ...(msgText ? [{ type: 'text' as const, text: msgText }] : []),
     ];
 
@@ -1530,7 +1543,7 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
       { parts } as Parameters<typeof sendMessage>[0],
       { body: { selectedDate, deniedProposalCount } },
     );
-  }, [canSend, text, pendingPhotos, pendingBarcode, pendingDenialCount, selectedDate, sendMessage]);
+  }, [canSend, text, pendingPhotos, pendingBarcodes, pendingDenialCount, selectedDate, sendMessage]);
 
   // #14: Stop button calls useChat stop()
   const handleStop = useCallback(() => {
@@ -1832,8 +1845,8 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
           <div ref={messagesEndRef} />
         </div>
 
-        {/* Photo thumbnails + pending barcode attachment chip */}
-        {(pendingPhotos.length > 0 || pendingBarcode) && (
+        {/* Photo thumbnails + pending barcode attachment chips */}
+        {(pendingPhotos.length > 0 || pendingBarcodes.length > 0) && (
           <div className={styles.thumbnails}>
             {pendingPhotos.map(p => (
               <div key={p.previewUrl} className={styles.thumbnailWrap}>
@@ -1850,21 +1863,28 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
               </div>
             ))}
 
-            {/* #barcode-attachment: scanned-product chip — tap to preview, X to remove */}
-            {pendingBarcode && (
-              <div className={styles.thumbnailWrap}>
+            {/* #barcode-attachment (#213): one chip PER pending scan — tap to
+                preview, X to remove just that one. Each chip gets its own
+                index-qualified aria-label so multiple scans (even of the same
+                product) remain distinguishable to assistive tech. */}
+            {pendingBarcodes.map((b, i) => (
+              <div key={b.id} className={styles.thumbnailWrap}>
                 <button
                   type="button"
                   className={styles.barcodeThumbBtn}
                   onClick={() => setBarcodePreview({
-                    code: pendingBarcode.code,
-                    imageDataUrl: pendingBarcode.imageDataUrl ?? null,
-                    product: pendingBarcode.product,
+                    code: b.code,
+                    imageDataUrl: b.imageDataUrl ?? null,
+                    product: b.product,
                   })}
-                  aria-label={`View scanned product: ${pendingBarcode.product.name}`}
+                  aria-label={
+                    pendingBarcodes.length > 1
+                      ? `View scanned product ${i + 1} of ${pendingBarcodes.length}: ${b.product.name}`
+                      : `View scanned product: ${b.product.name}`
+                  }
                 >
-                  {pendingBarcode.imageDataUrl ? (
-                    <img src={pendingBarcode.imageDataUrl} alt="Scanned product" className={styles.thumbnail} />
+                  {b.imageDataUrl ? (
+                    <img src={b.imageDataUrl} alt="Scanned product" className={styles.thumbnail} />
                   ) : (
                     <span className={styles.thumbnail} style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                       <ScanBarcode size={16} aria-hidden="true" style={{ display: 'block' }} />
@@ -1875,13 +1895,17 @@ export default function NutritionChat({ open, onClose, selectedDate }: Nutrition
                 <button
                   type="button"
                   className={styles.thumbnailRemove}
-                  onClick={removePendingBarcode}
-                  aria-label="Remove scanned product"
+                  onClick={() => removePendingBarcode(b.id)}
+                  aria-label={
+                    pendingBarcodes.length > 1
+                      ? `Remove scanned product ${i + 1} of ${pendingBarcodes.length}: ${b.product.name}`
+                      : 'Remove scanned product'
+                  }
                 >
                   ✕
                 </button>
               </div>
-            )}
+            ))}
           </div>
         )}
 

--- a/services/nutrition/agent.ts
+++ b/services/nutrition/agent.ts
@@ -30,7 +30,7 @@ export interface NutritionChatOptions {
 }
 
 /**
- * Task C — barcode-attachment grounding.
+ * Task C / #216 — barcode-attachment grounding.
  *
  * The client attaches a scanned barcode as a `data-barcodeAttachment` UI
  * message part (see client/src/features/nutrition/NutritionChat.tsx). Data
@@ -43,6 +43,15 @@ export interface NutritionChatOptions {
  * (a FoodSearchResult-shaped product: name/source/source_ref/per100g/
  * serving_grams), so the model treats it as already-retrieved grounding for a
  * `lookup_barcode` call it never actually makes (that tool no longer exists).
+ *
+ * #216 fix: EVERY user message's barcode attachment(s) are replayed, not just
+ * the most recent message's. Previously only the last message was inspected,
+ * so a barcode was grounded ONLY on the turn it was scanned — asking about it
+ * a turn later got "0 barcode scans" because the model genuinely had no
+ * barcode data past that turn. The parts always persisted server-side
+ * (routes/nutrition.ts stores each message's full parts array), so the fix is
+ * purely about *replaying* them all, not about storing anything new. Accepted
+ * tradeoff: extra input tokens per turn, proportional to scans-in-conversation.
  */
 interface BarcodeAttachmentProduct {
   name: string;
@@ -53,57 +62,71 @@ interface BarcodeAttachmentProduct {
   portions?: unknown;
 }
 
-/** Find a `data-barcodeAttachment` part on the LAST message, if it's a user turn. */
+/**
+ * Find every `data-barcodeAttachment` part on a single message, if it's a user
+ * turn. #213 made multiple scans possible per message, so this `.filter`s
+ * (rather than `.find`s) every matching part.
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function findBarcodeAttachment(messages: any[]): { code: string; product: BarcodeAttachmentProduct } | null {
-  const last = messages[messages.length - 1];
-  if (!last || last.role !== 'user' || !Array.isArray(last.parts)) return null;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const part = last.parts.find((p: any) => p?.type === 'data-barcodeAttachment');
-  const data = part?.data;
-  if (!data?.code || !data?.product) return null;
-  return { code: data.code, product: data.product };
+function findBarcodeAttachments(message: any): { code: string; product: BarcodeAttachmentProduct }[] {
+  if (!message || message.role !== 'user' || !Array.isArray(message.parts)) return [];
+  return message.parts
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .filter((p: any) => p?.type === 'data-barcodeAttachment')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .map((p: any) => p?.data)
+    .filter((data: unknown): data is { code: string; product: BarcodeAttachmentProduct } => {
+      const d = data as { code?: unknown; product?: unknown } | null | undefined;
+      return !!d?.code && !!d?.product;
+    });
 }
 
 /**
- * Build the synthetic assistant tool-call + tool message pair that replays the
- * scanned product as a `lookup_barcode` tool-result. Appended to the END of
- * `modelMessages` — safe because when the LAST raw client message is a 'user'
- * message, `convertToModelMessages` always appends its converted form as the
- * final entry in the returned array (one user message → exactly one pushed
- * ModelMessage), so these synthetic messages land immediately after it.
+ * Build the synthetic assistant tool-call + tool message pairs that replay a
+ * message's scanned product(s) as `lookup_barcode` tool-results. Each
+ * attachment gets its own pair with a distinct `toolCallId` — `messageKey`
+ * (the source message's index/id) plus the attachment's position within that
+ * message guarantees uniqueness across the whole conversation, even when the
+ * same barcode is scanned more than once (a plain `Date.now()` id, as used
+ * previously, could collide when several attachments are processed within the
+ * same millisecond).
  */
 function buildBarcodeToolResultMessages(
-  attachment: { code: string; product: BarcodeAttachmentProduct },
+  attachments: { code: string; product: BarcodeAttachmentProduct }[],
+  messageKey: string,
 ): ModelMessage[] {
-  const toolCallId = `barcode-scan-${attachment.code}-${Date.now()}`;
-  return [
-    {
-      role: 'assistant',
-      content: [
-        {
-          type: 'tool-call',
-          toolCallId,
-          toolName: 'lookup_barcode',
-          input: { code: attachment.code },
-        },
-      ],
-    },
-    {
-      role: 'tool',
-      content: [
-        {
-          type: 'tool-result',
-          toolCallId,
-          toolName: 'lookup_barcode',
-          // JSON round-trip: strips the object down to plain JSON so it satisfies
-          // ToolResultOutput's `value: JSONValue` (mirrors the pattern used by the
-          // search_food_history tools above for the same reason).
-          output: { type: 'json', value: JSON.parse(JSON.stringify(attachment.product)) },
-        },
-      ],
-    },
-  ];
+  const result: ModelMessage[] = [];
+  attachments.forEach((attachment, i) => {
+    const toolCallId = `barcode-scan-${messageKey}-${i}-${attachment.code}`;
+    result.push(
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId,
+            toolName: 'lookup_barcode',
+            input: { code: attachment.code },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId,
+            toolName: 'lookup_barcode',
+            // JSON round-trip: strips the object down to plain JSON so it satisfies
+            // ToolResultOutput's `value: JSONValue` (mirrors the pattern used by the
+            // search_food_history tools above for the same reason).
+            output: { type: 'json', value: JSON.parse(JSON.stringify(attachment.product)) },
+          },
+        ],
+      },
+    );
+  });
+  return result;
 }
 
 /** Build a compact text summary of recent entries for the system prompt context block. */
@@ -250,13 +273,34 @@ ${summariseEntries(recent)}
     ? `\n\nIMPORTANT: The user just DENIED your ${(deniedProposalCount ?? 0) > 1 ? 'previous proposals' : 'previous proposal'} (the propose_entry/propose_custom_food card${(deniedProposalCount ?? 0) > 1 ? 's' : ''} above). Do not simply re-send the same proposal — reconsider your approach based on their latest message, and adjust the food, portion, or macros accordingly before proposing again.`
     : '');
 
-  const modelMessages = await convertToModelMessages(messages);
+  // #216: convert message-by-message (instead of the whole array at once) so
+  // each user message's barcode attachment(s) can be replayed as synthetic
+  // `lookup_barcode` tool-result pairs immediately after THAT message's
+  // converted form — not dumped at the end of the whole conversation. The old
+  // "push at the end" approach only ever replayed the LAST message's barcode,
+  // because it relied on the last raw client message always being the one
+  // 'user' turn that converts to the final ModelMessage in the array; that
+  // assumption breaks for any earlier message, so a barcode scanned on turn 1
+  // was invisible to the model by turn 2.
+  //
+  // convertToModelMessages processes each UIMessage independently (no state is
+  // carried between messages — see the `for (const message of messages)` loop
+  // in the 'ai' package's implementation), so converting one message at a time
+  // and concatenating produces the exact same ModelMessage[] as converting the
+  // whole array in one call; it just lets us interleave the synthetic pairs at
+  // the right position.
+  const modelMessages: ModelMessage[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
+    modelMessages.push(...(await convertToModelMessages([message])));
 
-  // Task C: replay a scanned-barcode attachment on the current turn as a
-  // pre-fetched `lookup_barcode` tool-result (see buildBarcodeToolResultMessages).
-  const barcodeAttachment = findBarcodeAttachment(messages);
-  if (barcodeAttachment) {
-    modelMessages.push(...buildBarcodeToolResultMessages(barcodeAttachment));
+    const barcodeAttachments = findBarcodeAttachments(message);
+    if (barcodeAttachments.length > 0) {
+      // `i` (the message's position in the conversation) keys the synthetic
+      // toolCallIds so they stay unique even if the exact same barcode is
+      // scanned again in a later message.
+      modelMessages.push(...buildBarcodeToolResultMessages(barcodeAttachments, String(i)));
+    }
   }
 
   const result = streamText({


### PR DESCRIPTION
## Summary
- Fixes the composer's `pendingBarcode` single-slot state overwriting prior scans — it's now a list, mirroring the existing `pendingPhotos` pattern, with one removable chip and one `data-barcodeAttachment` part sent per scan.
- Fixes barcode grounding only ever surviving one turn — the agent now replays every user message's barcode attachment(s) as synthetic `lookup_barcode` tool-results, interleaved at the correct position in the conversation, instead of only inspecting the last message.
- Fixes the scanned-product preview title (and the "photo no longer available" caption) rendering in the browser's default serif font instead of the site-wide Sarabun font, by giving them real CSS classes instead of bare inline styles.

Closes #213
Closes #216
Closes #217

## Details

**#213** — `client/src/features/nutrition/NutritionChat.tsx`: `pendingBarcode: PendingBarcode | null` → `pendingBarcodes: PendingBarcode[]`. `handleBarcodeDetected` appends instead of replacing; `removePendingBarcode` now removes by id; `canSend`/`handleSend`/dep arrays updated; the composer renders one chip per pending scan with index-qualified `aria-label`s so multiple scans (even of the same product) stay distinguishable to assistive tech; the send path emits one `data-barcodeAttachment` part per scan and lists every scanned product name in the synthesized fallback text.

**#216** — `services/nutrition/agent.ts`: replaced the single `convertToModelMessages(messages)` call + "push synthetic pair at the end" trick (which only worked because the last raw client message happens to convert to exactly one appended `ModelMessage`) with a per-message conversion loop that interleaves each user message's barcode tool-result pair(s) immediately after that message's converted form. `findBarcodeAttachment` → `findBarcodeAttachments` (`.find` → `.filter`, handling #213's multiple-attachments-per-message case). Synthetic `toolCallId`s are now keyed by message index + attachment position instead of `Date.now()`, so they stay unique even for rapid/duplicate scans. Updated the load-bearing comment blocks to describe the new mechanism.

**#217** — Added one new `.readOnlyName` class to `client/src/features/nutrition/IngredientSheet.module.scss` (font-family/color/size/letter-spacing matching `.input`) and applied it to the product-name `<p>` in `BarcodeAttachmentCard.tsx` instead of a bare inline `style`. Also fixed the "Photo no longer available" caption, which had the same unclassed-serif problem, by reusing the existing `.rowHint` class. No global `body { font-family }` rule added (previously rejected).

## Test plan
- [x] `npm run build` (root `tsc`) passes
- [x] `cd client && npm run build` (vite) passes
- [ ] Live-chat verification of #216 (grounding persisting across turns) — **not verified at runtime**, see note below

## Notes / gaps
The #216 fix is AI-model-dependent: it changes what context the model receives, but whether `gpt-5.5` actually answers "how many barcode scans did you see" correctly afterward needs a live chat session to confirm — I could not run that in this environment. The mechanism itself (interleaving synthetic tool-result pairs per-message instead of only for the last message) is verified by code inspection and matches how `convertToModelMessages` processes messages (confirmed by reading the `ai` package's source), but end-to-end model behavior is unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)