### PR TITLE
Fix macro scaling breaking permanently when grams field is emptied

### DIFF
--- a/client/src/features/nutrition/IngredientSheet.tsx
+++ b/client/src/features/nutrition/IngredientSheet.tsx
@@ -120,6 +120,22 @@ function IngredientForm({ row, onChange, onExpandMeal, onOpenBarcode }: Ingredie
   const [searchQuery, setSearchQuery] = useState('');
   const [showSearch, setShowSearch] = useState(false);
 
+  // #219 — while the user is mid-edit clearing the grams/quantity field, the
+  // input must visibly go empty WITHOUT ever committing quantity/grams: 0 (or
+  // NaN) into `row`. Committing a 0 there would make scaleRowMacros scale
+  // every macro to 0 and, once macros are 0, there's no baseline left to
+  // derive from on the next keystroke — the "1.5g protein stays 1.5g, then
+  // becomes 3g" scaling described in #219 would be gone for good. So instead:
+  // empty/zero/invalid input is tracked purely as local display text here,
+  // `row` (and therefore the macro fields, which read straight off `row`)
+  // stays frozen at its last real values, however long the field sits empty.
+  // Cleared automatically whenever `row` changes for a reason other than this
+  // field's own commits (new row loaded, food/barcode selected, unit changed).
+  const [frozenQuantityText, setFrozenQuantityText] = useState<string | null>(null);
+  useEffect(() => {
+    setFrozenQuantityText(null);
+  }, [row.rowKey, row.quantity, row.unitLabel]);
+
   // ---- Async portion fetching for USDA foods ----
   useEffect(() => {
     if (row.source !== 'usda' || !row.source_ref) return;
@@ -220,13 +236,28 @@ function IngredientForm({ row, onChange, onExpandMeal, onOpenBarcode }: Ingredie
   // per100g snapshot (hand-typed macros, or a snapshot lost via
   // handleNameChange). scaleRowMacros derives a baseline from the row's
   // current macros ÷ current grams in that case, so this always scales.
+  //
+  // #219 — an empty (or genuinely zero/invalid) grams field is deliberately
+  // NOT committed to `row` at all: `parseFloat('') || 0` used to coerce empty
+  // straight to 0 and write it through, which zeroed every macro and wiped
+  // out the baseline scaleRowMacros needs for the *next* edit (see the block
+  // comment on scaleRowMacros). Instead, freeze — track the raw text locally
+  // so the field still visibly reads empty, but leave quantity/grams/macros
+  // untouched until a real positive number is typed, however long that takes.
   function handleQuantityChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const quantity = parseFloat(e.target.value) || 0;
-    const effectiveGrams = quantity * row.unitGrams;
-    onChange({ ...row, quantity, grams: effectiveGrams, ...scaleRowMacros(row, effectiveGrams) });
+    const raw = e.target.value;
+    const parsed = parseFloat(raw);
+    if (raw.trim() === '' || Number.isNaN(parsed) || parsed <= 0) {
+      setFrozenQuantityText(raw);
+      return;
+    }
+    setFrozenQuantityText(null);
+    const effectiveGrams = parsed * row.unitGrams;
+    onChange({ ...row, quantity: parsed, grams: effectiveGrams, ...scaleRowMacros(row, effectiveGrams) });
   }
 
   function handleUnitChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    setFrozenQuantityText(null);
     const label = e.target.value;
     const selected = row.portions.find(p => p.label === label) ?? GRAMS_UNIT;
     const effectiveGrams = row.quantity * selected.grams;
@@ -293,7 +324,7 @@ function IngredientForm({ row, onChange, onExpandMeal, onOpenBarcode }: Ingredie
             type="number"
             min="0"
             step="0.1"
-            value={row.quantity === 0 ? '' : row.quantity}
+            value={frozenQuantityText !== null ? frozenQuantityText : (row.quantity === 0 ? '' : row.quantity)}
             onChange={handleQuantityChange}
             aria-label="Quantity"
           />

--- a/client/src/features/nutrition/ingredientMath.ts
+++ b/client/src/features/nutrition/ingredientMath.ts
@@ -98,6 +98,22 @@ export function recomputeMacros(
 // Because the baseline is derived fresh from current state every time (never
 // cached), a manual macro edit (handleMacroChange) automatically becomes the
 // new baseline for the next scale — no separate re-baseline step needed.
+//
+// #219 — that "derive fresh from current state" design has one hazard: if a
+// caller ever commits a row with `grams: 0` (e.g. the grams input was
+// transiently emptied mid-edit and naively coerced via `parseFloat(x) || 0`),
+// the row's own macros AND grams collapse to 0 in the same update, and the
+// baseline this function would derive next time is gone for good — there is
+// nothing left to scale from. The fix lives on the caller side: IngredientSheet
+// (handleQuantityChange) never writes an empty/zero-parsed grams value into
+// row state while the user is mid-edit — it freezes the input's own display
+// text locally and leaves the row (grams + macros) untouched, so the last
+// real (grams, macros) pair the row holds keeps serving as the baseline for
+// as long as the field sits empty, however long that is. The two guards below
+// are defense-in-depth for any other caller (e.g. applyNewPortions) that asks
+// to scale to/from a non-positive grams value: freeze instead of dividing by
+// (or scaling to) zero, so a stray 0 can never silently zero out — and lose —
+// a manual baseline.
 // ---------------------------------------------------------------------------
 export function scaleRowMacros(
   row: EditorRow,
@@ -106,9 +122,11 @@ export function scaleRowMacros(
   if (row.per100g) {
     return recomputeMacros(row.per100g, newGrams);
   }
-  // Guard divide-by-zero: with no prior grams to derive a rate from, there's
-  // no valid baseline — leave macros as-is rather than producing NaN/Infinity.
-  if (!row.grams) {
+  // Guard divide-by-zero (no prior grams to derive a rate from) and guard
+  // scaling TO a non-positive target (#219 — would zero out, and thereby
+  // destroy, the manual baseline). Either way, there's nothing sound to
+  // compute — leave macros as-is rather than producing NaN/Infinity/0.
+  if (!row.grams || newGrams <= 0) {
     return {
       calories: row.calories,
       protein_g: row.protein_g,


### PR DESCRIPTION
Closes #219

## Problem
Clearing the grams/quantity field to empty (intending to type a new value) permanently destroyed macro scaling for hand-typed ingredient rows (rows with no `per100g` snapshot).

Root cause: `handleQuantityChange` used `parseFloat(e.target.value) || 0`, which coerced an empty input straight to `0` and committed it into row state. `scaleRowMacros` then scaled every macro to `0` (factor `0 / oldGrams`), and once the macros were `0`, there was nothing left for the next scale to derive a baseline from — the divide-by-zero guard just returned the zeroed macros forever.

## Fix
- **`IngredientSheet.tsx`** — `handleQuantityChange` now treats an empty/zero/invalid grams field as a freeze: the raw input text is tracked in local state purely so the field visibly displays empty, but `row` (grams + macros) is left completely untouched until a real positive number is typed. The macro inputs read straight off `row`, so they stay frozen at their last real values for however long the field sits empty. The frozen text is cleared whenever the row changes for a reason other than this field's own commits (new row loaded, food/barcode selected, unit changed).
- **`ingredientMath.ts`** — `scaleRowMacros`'s existing divide-by-zero guard now also guards against scaling *to* a non-positive `newGrams` (not just an invalid denominator), as defense-in-depth for other callers (e.g. `applyNewPortions`) so a stray `0` can never silently zero out a manual baseline. Updated the `#185` comment block to document this hazard and how it's avoided.

Per100g-backed rows (which always rescale from the snapshot) and the `#185` "manual edit becomes the new baseline" behavior are both unaffected.

## Numeric trace (reporter's exact repro)
Simulated the logic standalone to confirm:
```
start: grams=100, quantity=100, protein_g=15
type 10   -> protein 1.5   (expect 1.5)  PASS
clear     -> row unchanged, protein still 1.5           PASS
(5 more clears, still frozen at 1.5)                     PASS
type 20   -> protein 3     (expect 3, scaled from 10g/1.5g baseline)  PASS
clear again, type 5 -> protein 0.75 (scaled from 20g/3g baseline)     PASS
```

No unit test runner is configured for the client (`client/package.json` test script is a placeholder: `"Tests not configured for Vite yet"`), so this was verified via the standalone trace above plus `tsc`/`vite build`.

## Test plan
- [x] `npm run build` (root `tsc`) passes
- [x] `cd client && npm run build` (vite) passes
- [x] Numeric trace of the exact reporter repro (100g/15g → 10g → empty → 20g ⇒ 3g protein), plus repeated clear/retype cycles
- [ ] Manual verification in the running app (grams field empties, protein freezes at 1.5, then rescales to 3 on retyping 20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)